### PR TITLE
feat(runtime): computed, watch, batched flush + nextTick

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -169,6 +169,17 @@ export function box(c, i, v) {               // reassign-only var at reactive in
 }
 export function deepBox(c, i, v) { /* Proxy wrapping arrays/objects; markVar(c,i) on mutation */ }
 
+// --- derived values, watchers, batching (compile-time deps, no auto-tracking) ---
+export function computed(c, i, deps, fn) { /* lazy derived value at index i reading `deps`;
+                                              memoized, recomputes on next read after a dep
+                                              changes; reads inside a bind that declares i are tracked */ }
+export function watch(c, deps, cb, opts) { /* run cb after any of `deps` changes; { immediate }
+                                              also runs once now; returns stop() (scope-aware) */ }
+export function watchEffect(c, deps, fn) { /* run fn now and after any of `deps` changes; returns stop() */ }
+export function nextTick(c) { /* Promise resolved after the next flush (DOM updated) */ }
+export function batch(c, fn) { /* run fn, then flush synchronously; nested batches flush once, outermost */ }
+export function afterFlush(c, cb) { /* run cb after the next flush completes (primitive behind nextTick) */ }
+
 // --- DOM ---
 export function component(tag, attrs, HTML, setup) {
   return (props) => {

--- a/packages/lunas/src/batch.mjs
+++ b/packages/lunas/src/batch.mjs
@@ -1,0 +1,37 @@
+// batch.mjs — update coalescing and nextTick.
+// See output-design.md §4 (microtask flush) and §5.
+//
+// Coalescing is already the default: markVar schedules a single microtask
+// flush, so N synchronous writes across any number of boxes produce one DOM
+// update pass. This module exposes that guarantee to user code:
+//
+//   - nextTick(c)  — a Promise resolved AFTER the pending flush (DOM updated).
+//   - batch(c, fn) — run fn, then flush synchronously, so a group of writes is
+//                    applied before batch() returns instead of next microtask.
+
+import { flush, afterFlush } from "./core.mjs";
+
+// nextTick(c) — resolves after the next flush completes. If nothing is pending
+// the flush is still scheduled, so `await nextTick(c)` always lands after the
+// current tick's update pass. Callback ordering matches registration order, so
+// two nextTick calls resolve in the order they were made.
+export function nextTick(c) {
+  return new Promise((resolve) => afterFlush(c, resolve));
+}
+
+// batch(c, fn) — run fn (which may write many boxes) and flush synchronously
+// afterward, collapsing the whole group into one update pass that has completed
+// by the time batch() returns. Useful for handlers that must read the updated
+// DOM immediately. Nested batches (on the same context) flush only at the
+// outermost call. The microtask that markVar scheduled becomes a cheap no-op
+// (empty queue). Depth is tracked per context so batches on different contexts
+// don't suppress each other's flush.
+export function batch(c, fn) {
+  c.batchDepth = (c.batchDepth || 0) + 1;
+  try {
+    return fn();
+  } finally {
+    c.batchDepth--;
+    if (c.batchDepth === 0) flush(c);
+  }
+}

--- a/packages/lunas/src/computed.mjs
+++ b/packages/lunas/src/computed.mjs
@@ -1,0 +1,53 @@
+// computed.mjs — lazily-evaluated derived values in the adjacency model.
+// See output-design.md §4 (compile-time dependency dispatch).
+//
+// A computed is a derived reactive variable. Like every reactive variable it
+// owns an index `i`; parts that read it declare `i` in their deps just like a
+// plain box. The compiler supplies both the computed's own index and the set of
+// upstream indices it reads (its `deps` mask) — there is NO runtime Proxy
+// tracking, consistent with the rest of the runtime.
+//
+// Laziness: the compute fn runs only when the value is actually read AND an
+// upstream dep has changed since the last computation. When an upstream dep
+// changes we do not recompute eagerly; we mark the value stale and mark the
+// computed's own index dirty so downstream binds are re-queued. Those binds
+// pull the fresh value on their next run, which triggers exactly one recompute.
+
+import { bind, markVar } from "./core.mjs";
+
+// computed(c, i, deps, fn) — derived value at reactive index `i` reading the
+// upstream reactive indices in `deps`. Returns a box-shaped handle whose `.v`
+// getter yields the (memoized) result. Reading `.v` inside a bound updater
+// works because that updater declares `i` in its own deps.
+//
+// The internal bind on `deps` costs one adjacency record per upstream index; it
+// does no work beyond flipping the stale flag and re-marking `i`, so a computed
+// whose value is never read never recomputes.
+export function computed(c, i, deps, fn) {
+  let value;
+  let stale = true;
+  let primed = false; // suppress the bind's initial synchronous run
+
+  // When any upstream dep changes, invalidate and propagate to `i`'s
+  // dependents. We do not recompute here — recompute is deferred to the next
+  // read (laziness). The initial bind run is skipped: at wiring time `i` has no
+  // dependents yet, so marking it would only schedule a wasted flush.
+  bind(c, deps, () => {
+    if (!primed) {
+      primed = true;
+      return;
+    }
+    stale = true;
+    markVar(c, i);
+  });
+
+  return {
+    get v() {
+      if (stale) {
+        value = fn();
+        stale = false;
+      }
+      return value;
+    },
+  };
+}

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -11,7 +11,7 @@
 // for-diff-design.md §6).
 
 export function createContext(root) {
-  return { root, deps: [], queue: [], pending: false, scope: null };
+  return { root, deps: [], queue: [], pending: false, scope: null, post: null };
 }
 
 // bind(c, deps, fn) — register an update function that reads the reactive
@@ -44,6 +44,8 @@ export function markVar(c, i) {
 }
 
 // flush(c) — run every queued update once. Only affected parts run.
+// After the update pass, drain any post-flush callbacks registered via
+// `afterFlush` (used by nextTick): they observe the DOM already updated.
 export function flush(c) {
   c.pending = false;
   const q = c.queue;
@@ -51,6 +53,24 @@ export function flush(c) {
   for (const s of q) {
     s.q = false;
     if (s.alive) s.fn();
+  }
+  const post = c.post;
+  if (post) {
+    c.post = null;
+    for (const cb of post) cb();
+  }
+}
+
+// afterFlush(c, cb) — run `cb` once, after the next flush completes (i.e. after
+// the DOM update pass). If a flush is already pending the callback rides that
+// one; otherwise a flush is scheduled so the callback still fires this tick.
+// This is the primitive behind nextTick(); it keeps flush the single place that
+// knows when updates have landed.
+export function afterFlush(c, cb) {
+  (c.post || (c.post = [])).push(cb);
+  if (!c.pending) {
+    c.pending = true;
+    queueMicrotask(() => flush(c));
   }
 }
 

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -8,6 +8,7 @@ export {
   bind,
   markVar,
   flush,
+  afterFlush,
   unbind,
   beginScope,
   endScope,
@@ -15,6 +16,12 @@ export {
 } from "./core.mjs";
 
 export { box, deepBox, shared } from "./boxes.mjs";
+
+export { computed } from "./computed.mjs";
+
+export { watch, watchEffect } from "./watch.mjs";
+
+export { nextTick, batch } from "./batch.mjs";
 
 export {
   component,

--- a/packages/lunas/src/watch.mjs
+++ b/packages/lunas/src/watch.mjs
@@ -1,0 +1,41 @@
+// watch.mjs — user-facing watchers over the adjacency model.
+// See output-design.md §4–5.
+//
+// Watchers are just binds with a policy layer. Deps are explicit reactive
+// indices (compiler- or user-supplied), never Proxy-tracked. Both variants
+// register through `bind`, so they honor the current scope: a watcher created
+// inside beginScope/endScope is torn down by dropScope, and the returned
+// stop() unbinds it explicitly at any time.
+
+import { bind, unbind } from "./core.mjs";
+
+// watch(c, deps, cb, opts?) — run `cb` after any of `deps` changes.
+//
+// By default the first (synchronous) run performed by `bind` is suppressed, so
+// the callback fires only on subsequent changes — the usual "watch" semantics.
+// Pass { immediate: true } to also invoke it once at registration time.
+//
+// Returns a stop() that unbinds the watcher. The watcher is also collected by
+// the current scope, so dropScope tears it down automatically.
+export function watch(c, deps, cb, opts) {
+  const immediate = opts && opts.immediate;
+  let primed = false;
+  const s = bind(c, deps, () => {
+    if (!primed) {
+      primed = true;
+      if (immediate) cb();
+      return;
+    }
+    cb();
+  });
+  return () => unbind(c, s);
+}
+
+// watchEffect(c, deps, fn) — run `fn` immediately and again after any of `deps`
+// changes. This is `watch` with { immediate: true } but with the effect-style
+// name and no distinction between the initial and later runs (the effect always
+// runs on registration). Returns a stop().
+export function watchEffect(c, deps, fn) {
+  const s = bind(c, deps, fn);
+  return () => unbind(c, s);
+}

--- a/packages/lunas/test/batch.test.mjs
+++ b/packages/lunas/test/batch.test.mjs
@@ -1,0 +1,153 @@
+// batch.test.mjs — coalescing and nextTick.
+// Run: node packages/lunas/test/batch.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind, markVar } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { nextTick, batch } from "../src/batch.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("N markVar on one var -> one flush pass", async () => {
+  const c = createContext(null);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  markVar(c, 0);
+  markVar(c, 0);
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(runs, 2, "initial + exactly one flush");
+});
+
+await test("handler writing several vars -> single DOM update pass", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const b = box(c, 1, 0);
+  let paints = 0;
+  // One part reads both vars, like a template line interpolating both.
+  bind(c, [0, 1], () => {
+    paints++;
+    void a.v;
+    void b.v;
+  });
+  paints = 0;
+  // A handler mutating multiple boxes:
+  a.v = 1;
+  b.v = 2;
+  a.v = 3;
+  assert.strictEqual(paints, 0, "nothing painted synchronously");
+  await tick();
+  assert.strictEqual(paints, 1, "coalesced into a single pass");
+});
+
+await test("nextTick resolves after the pending flush (DOM updated)", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let painted = -1;
+  bind(c, [0], () => {
+    painted = a.v;
+  });
+  a.v = 42;
+  // Before the tick the paint has not happened.
+  assert.strictEqual(painted, 0);
+  await nextTick(c);
+  assert.strictEqual(painted, 42, "flush completed before nextTick resolved");
+});
+
+await test("nextTick with nothing pending still resolves this tick", async () => {
+  const c = createContext(null);
+  let resolved = false;
+  const p = nextTick(c).then(() => {
+    resolved = true;
+  });
+  assert.strictEqual(resolved, false);
+  await p;
+  assert.strictEqual(resolved, true);
+});
+
+await test("nextTick ordering: two calls resolve in order, after paint", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const order = [];
+  bind(c, [0], () => order.push("paint:" + a.v));
+  a.v = 1;
+  const p1 = nextTick(c).then(() => order.push("t1"));
+  const p2 = nextTick(c).then(() => order.push("t2"));
+  await Promise.all([p1, p2]);
+  assert.deepStrictEqual(order, ["paint:0", "paint:1", "t1", "t2"]);
+});
+
+await test("batch flushes synchronously at the outermost call", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const b = box(c, 1, 0);
+  let paints = 0;
+  bind(c, [0, 1], () => {
+    paints++;
+    void a.v;
+    void b.v;
+  });
+  paints = 0;
+  batch(c, () => {
+    a.v = 1;
+    b.v = 2;
+  });
+  assert.strictEqual(paints, 1, "applied synchronously, once, on batch exit");
+  await tick();
+  assert.strictEqual(paints, 1, "no extra microtask flush");
+});
+
+await test("nested batch flushes only at the outermost", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let paints = 0;
+  bind(c, [0], () => {
+    paints++;
+    void a.v;
+  });
+  paints = 0;
+  batch(c, () => {
+    a.v = 1;
+    batch(c, () => {
+      a.v = 2;
+    });
+    assert.strictEqual(paints, 0, "inner batch did not flush");
+  });
+  assert.strictEqual(paints, 1, "single flush at outer exit");
+});
+
+await test("batches on different contexts don't suppress each other", () => {
+  const c1 = createContext(null);
+  const c2 = createContext(null);
+  const a1 = box(c1, 0, 0);
+  const a2 = box(c2, 0, 0);
+  let p1 = 0;
+  let p2 = 0;
+  bind(c1, [0], () => {
+    p1++;
+    void a1.v;
+  });
+  bind(c2, [0], () => {
+    p2++;
+    void a2.v;
+  });
+  p1 = 0;
+  p2 = 0;
+  batch(c1, () => {
+    a1.v = 1;
+    batch(c2, () => {
+      a2.v = 1;
+    });
+    assert.strictEqual(p2, 1, "c2 flushed at its own batch exit");
+  });
+  assert.strictEqual(p1, 1, "c1 flushed at its own batch exit");
+});
+
+console.log("batch.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/computed.test.mjs
+++ b/packages/lunas/test/computed.test.mjs
@@ -1,0 +1,105 @@
+// computed.test.mjs — lazy derived values in the adjacency model.
+// Run: node packages/lunas/test/computed.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { computed } from "../src/computed.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("computed is lazy: fn does not run until read", () => {
+  const c = createContext(null);
+  const a = box(c, 0, 2);
+  let computes = 0;
+  computed(c, 1, [0], () => {
+    computes++;
+    return a.v * 10;
+  });
+  assert.strictEqual(computes, 0, "no read yet -> no compute");
+});
+
+await test("computed recomputes once on read, then memoizes", () => {
+  const c = createContext(null);
+  const a = box(c, 0, 2);
+  let computes = 0;
+  const d = computed(c, 1, [0], () => {
+    computes++;
+    return a.v * 10;
+  });
+  assert.strictEqual(d.v, 20);
+  assert.strictEqual(d.v, 20, "second read is memoized");
+  assert.strictEqual(computes, 1, "computed exactly once for two reads");
+});
+
+await test("computed recomputes only after a dep changes", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 2);
+  let computes = 0;
+  const d = computed(c, 1, [0], () => {
+    computes++;
+    return a.v + 1;
+  });
+  assert.strictEqual(d.v, 3);
+  assert.strictEqual(computes, 1);
+  a.v = 5; // dep changed -> stale, but not recomputed yet (lazy)
+  assert.strictEqual(computes, 1, "no eager recompute on write");
+  await tick();
+  assert.strictEqual(d.v, 6, "recomputes on next read after change");
+  assert.strictEqual(computes, 2);
+});
+
+await test("computed participates in adjacency: reading it in a bind tracks it", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const d = computed(c, 1, [0], () => a.v * 2);
+  const seen = [];
+  // The bind declares the computed's index (1) in its deps — exactly what the
+  // compiler emits for a part that reads a derived value.
+  bind(c, [1], () => seen.push(d.v));
+  assert.deepStrictEqual(seen, [2], "initial run pulls fresh value");
+  a.v = 4;
+  await tick();
+  assert.deepStrictEqual(seen, [2, 8], "downstream bind re-ran with new value");
+});
+
+await test("unchanged dep -> downstream bind does not re-run via computed", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const other = box(c, 2, "x");
+  const d = computed(c, 1, [0], () => a.v * 2);
+  let runs = 0;
+  bind(c, [1], () => {
+    runs++;
+    void d.v;
+  });
+  assert.strictEqual(runs, 1);
+  other.v = "y"; // unrelated var
+  await tick();
+  assert.strictEqual(runs, 1, "computed's dependents untouched");
+});
+
+await test("computed over multiple deps", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const b = box(c, 1, 2);
+  let computes = 0;
+  const sum = computed(c, 2, [0, 1], () => {
+    computes++;
+    return a.v + b.v;
+  });
+  assert.strictEqual(sum.v, 3);
+  b.v = 10;
+  await tick();
+  assert.strictEqual(sum.v, 11);
+  assert.strictEqual(computes, 2);
+});
+
+console.log("computed.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/watch.test.mjs
+++ b/packages/lunas/test/watch.test.mjs
@@ -1,0 +1,104 @@
+// watch.test.mjs — user-facing watchers.
+// Run: node packages/lunas/test/watch.test.mjs
+
+import assert from "node:assert";
+import {
+  createContext,
+  beginScope,
+  endScope,
+  dropScope,
+} from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { watch, watchEffect } from "../src/watch.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("watch fires on change, not on registration by default", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  watch(c, [0], () => runs++);
+  assert.strictEqual(runs, 0, "no immediate run");
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 1);
+});
+
+await test("watch { immediate: true } runs once at registration", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  watch(c, [0], () => runs++, { immediate: true });
+  assert.strictEqual(runs, 1, "ran immediately");
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 2, "and again on change");
+});
+
+await test("watch stop() unbinds", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  const stop = watch(c, [0], () => runs++);
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 1);
+  stop();
+  a.v = 3;
+  await tick();
+  assert.strictEqual(runs, 1, "no run after stop()");
+});
+
+await test("watch is torn down by dropScope", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  const scope = beginScope(c);
+  watch(c, [0], () => runs++);
+  endScope(c);
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 1);
+  dropScope(c, scope);
+  a.v = 3;
+  await tick();
+  assert.strictEqual(runs, 1, "scoped watcher dead after dropScope");
+});
+
+await test("watch multi-dep fires on any dep", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const b = box(c, 1, 1);
+  let runs = 0;
+  watch(c, [0, 1], () => runs++);
+  a.v = 9;
+  await tick();
+  assert.strictEqual(runs, 1);
+  b.v = 9;
+  await tick();
+  assert.strictEqual(runs, 2);
+});
+
+await test("watchEffect runs immediately and on change", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 5);
+  const seen = [];
+  const stop = watchEffect(c, [0], () => seen.push(a.v));
+  assert.deepStrictEqual(seen, [5], "effect ran on registration");
+  a.v = 6;
+  await tick();
+  assert.deepStrictEqual(seen, [5, 6]);
+  stop();
+  a.v = 7;
+  await tick();
+  assert.deepStrictEqual(seen, [5, 6], "no run after stop()");
+});
+
+console.log("watch.test.mjs: all " + passed + " tests passed");


### PR DESCRIPTION
## What

Extends the `packages/lunas` JS runtime with three reactivity features from the roadmap, all consistent with the compile-time adjacency-dispatch contract in `output-design.md` §4–5 (explicit dep masks/indices, no runtime Proxy tracking, no BigInt):

- **`computed(c, i, deps, fn)`** (`src/computed.mjs`) — lazily-evaluated, memoized derived value that owns its own reactive index. An internal `bind` on the declared upstream `deps` marks the value stale and re-marks index `i`, so parts that declare `i` in their own deps re-pull the fresh value. Recomputes only on the next read after a dep changes; a computed that's never read never computes.
- **`watch` / `watchEffect`** (`src/watch.mjs`) — user-facing watchers layered over `bind`. `watch(c, deps, cb, { immediate })` fires on change (and once now if `immediate`); `watchEffect(c, deps, fn)` runs now and on change. Both return a `stop()` and are scope-aware — `dropScope` tears them down alongside their sibling binds.
- **Batched flush + `nextTick`** (`src/batch.mjs` + a small `afterFlush` primitive added to `core.mjs`) — `markVar` already coalesces N synchronous writes into one microtask flush; `afterFlush(c, cb)` is drained at the end of `flush` (after the DOM update pass), and `nextTick(c)` resolves a Promise on it. `batch(c, fn)` runs `fn` then flushes synchronously, collapsing a multi-write handler into a single completed pass; nested batches flush once at the outermost call, tracked per-context.

All exported through `src/index.mjs`. `output-design.md` §5 updated with the new API surface.

## Why

Roadmap items rx-computed, rx-watch, rx-batch. Kept tree-shakeable (one concern per module), dependency-free ES2015+ `.mjs`, matching existing core.mjs/boxes.mjs style. No `package.json` touched.

## Test evidence

New harness-style test files (`node <file>`, node 22, no deps):
- `test/computed.test.mjs` — 6 tests (laziness, memoization, recompute-on-dep, adjacency participation, unrelated-var isolation, multi-dep).
- `test/watch.test.mjs` — 6 tests (fire-on-change, `immediate`, `stop()`, `dropScope` teardown, multi-dep, `watchEffect`).
- `test/batch.test.mjs` — 8 tests (N markVar → 1 flush, multi-write → 1 pass, nextTick after paint, nextTick with nothing pending, nextTick ordering, sync batch, nested batch, cross-context isolation).

Full runtime suite green under node v22.18.0: **51 tests pass** (20 new + 31 existing, including the `afterFlush` change to core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)