### PR TITLE
chore(runtime): npm packaging, types, tree-shaking, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,23 @@ jobs:
       # The whole front end must stay wasm-ready (browser compiler / LSP).
       - name: Build for wasm32
         run: cargo build --all --target wasm32-unknown-unknown
+
+  runtime:
+    name: runtime tests (packages/lunas)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/lunas
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run test suite
+        run: node test/run-all.mjs
+
+      - name: Tree-shaking / no-side-effects check
+        run: node test/treeshake.check.mjs

--- a/packages/lunas/LICENSE
+++ b/packages/lunas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lunas Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -1,0 +1,95 @@
+# lunas
+
+Dependency-free ES2015 runtime for [Lunas](https://github.com/lunasrun/lunas)-compiled
+components. Plain ESM, no build step, no dependencies. Compatibility floor:
+ES2015 + `Proxy` (no `BigInt`).
+
+This package is the runtime target that the Lunas compiler emits calls into —
+`bind`/`markVar`/`flush` for the reactive core, `box`/`deepBox`/`shared` for
+reactive state, DOM/event wiring helpers, and the control-flow blocks
+(`if`/`for`/child components) with a keyed LIS reconciler for `:for`.
+
+## Install
+
+```sh
+npm install lunas
+```
+
+## Usage
+
+The package is pure ESM (`"type": "module"`) and marks `"sideEffects": false`,
+so bundlers can tree-shake unused exports. Import only what you need from the
+package root, or deep-import a single module to keep your bundle minimal:
+
+```js
+import { box, bind, markVar } from "lunas";
+// or, equivalently, a deep import of just the module you need:
+import { box } from "lunas/boxes";
+```
+
+Available deep-import subpaths mirror the internal modules: `lunas/core`,
+`lunas/boxes`, `lunas/dom`, `lunas/blocks`, `lunas/for_diff`.
+
+TypeScript types are included (`types/index.d.ts`, plus one `.d.ts` per
+subpath) — no `@types` package needed.
+
+```js
+import { createContext, bind, markVar, box } from "lunas";
+
+const c = createContext(document.body);
+const count = box(c, 0, 0);
+
+bind(c, [0], () => {
+  document.title = "count: " + count.v;
+});
+
+count.v++; // marks index 0 dirty; the bind above re-runs on next microtask
+markVar(c, 0);
+```
+
+In practice this package is not meant to be hand-written against — the Lunas
+compiler generates the calls into it from `.lun` component files. See
+`crates/lunas_compiler/docs/output-design.md` and `for-diff-design.md` in the
+main repo for the calling contract.
+
+## API
+
+| Export | From | Description |
+| --- | --- | --- |
+| `createContext(root)` | `lunas/core` | Create a fresh reactive context rooted at `root`. |
+| `bind(c, deps, fn)` | `lunas/core` | Register an update fn for reactive indices `deps`; runs once immediately. |
+| `markVar(c, i)` | `lunas/core` | Mark reactive variable `i` dirty; schedules a microtask flush. |
+| `flush(c)` | `lunas/core` | Run every queued update once. |
+| `unbind(c, s)` | `lunas/core` | Permanently unregister a bind record. |
+| `beginScope(c)` | `lunas/core` | Open a collection scope for a control-flow block's inner binds. |
+| `endScope(c)` | `lunas/core` | Close the currently-open scope. |
+| `dropScope(c, scope)` | `lunas/core` | Unregister every bind collected in `scope` (recursively) and tear it down. |
+| `box(c, i, v)` | `lunas/boxes` | Reassign-only reactive cell (plain getter/setter, no Proxy). |
+| `deepBox(c, i, v)` | `lunas/boxes` | Deeply-mutated reactive cell (Proxy-wrapped nested reads/writes). |
+| `shared(v)` | `lunas/boxes` | A value shared/mutated across multiple components. |
+| `component(tag, attrs, HTML, setup)` | `lunas/dom` | Compiled-component factory: builds the root, parses static HTML, runs `setup`. |
+| `refs(root, paths)` | `lunas/dom` | Positional navigation to dynamic elements by child-index paths. |
+| `on(el, ev, fn)` | `lunas/dom` | `addEventListener` shorthand. |
+| `anchorBefore(node)` | `lunas/dom` | Create a permanent empty-text-node anchor before `node`. |
+| `anchorBeforeSplit(textNode, offset)` | `lunas/dom` | Split a text node and place an anchor between head/tail. |
+| `anchorAppend(parent)` | `lunas/dom` | Create an anchor as the last child of `parent`. |
+| `ifBlock(c, anchor, deps, cond, make)` | `lunas/blocks` | Conditional block: mounts/unmounts a branch at `anchor`. |
+| `forBlock(c, anchor, deps, items, opts)` | `lunas/blocks` | Keyed list block; reconciles via `for_diff`'s LIS algorithm. |
+| `mountChild(c, anchor, childFactory, props)` | `lunas/blocks` | Instantiate and mount a child component at `anchor`. |
+| `createForState()` | `lunas/for_diff` | Create empty reconciler state. |
+| `seedForState(state, keys, nodes, data)` | `lunas/for_diff` | Seed reconciler state from a bulk initial render. |
+| `reconcile(state, host, items, makeItem, opts)` | `lunas/for_diff` | Diff old vs. new keyed list and mutate `host` with minimal moves. |
+| `longestIncreasingSubsequence(arr)` | `lunas/for_diff` | LIS helper used internally by `reconcile`. |
+
+## Testing
+
+```sh
+npm test                    # runs every test/*.test.mjs via test/run-all.mjs
+node test/treeshake.check.mjs   # tree-shaking / no-side-effects proof
+```
+
+Requires Node.js >= 18.
+
+## License
+
+MIT

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -28,7 +28,8 @@ import { box } from "lunas/boxes";
 ```
 
 Available deep-import subpaths mirror the internal modules: `lunas/core`,
-`lunas/boxes`, `lunas/dom`, `lunas/blocks`, `lunas/for_diff`.
+`lunas/boxes`, `lunas/computed`, `lunas/watch`, `lunas/batch`, `lunas/dom`,
+`lunas/blocks`, `lunas/for_diff`.
 
 TypeScript types are included (`types/index.d.ts`, plus one `.d.ts` per
 subpath) — no `@types` package needed.
@@ -60,6 +61,7 @@ main repo for the calling contract.
 | `bind(c, deps, fn)` | `lunas/core` | Register an update fn for reactive indices `deps`; runs once immediately. |
 | `markVar(c, i)` | `lunas/core` | Mark reactive variable `i` dirty; schedules a microtask flush. |
 | `flush(c)` | `lunas/core` | Run every queued update once. |
+| `afterFlush(c, cb)` | `lunas/core` | Run `cb` once, after the next flush completes (nextTick's primitive). |
 | `unbind(c, s)` | `lunas/core` | Permanently unregister a bind record. |
 | `beginScope(c)` | `lunas/core` | Open a collection scope for a control-flow block's inner binds. |
 | `endScope(c)` | `lunas/core` | Close the currently-open scope. |
@@ -67,6 +69,11 @@ main repo for the calling contract.
 | `box(c, i, v)` | `lunas/boxes` | Reassign-only reactive cell (plain getter/setter, no Proxy). |
 | `deepBox(c, i, v)` | `lunas/boxes` | Deeply-mutated reactive cell (Proxy-wrapped nested reads/writes). |
 | `shared(v)` | `lunas/boxes` | A value shared/mutated across multiple components. |
+| `computed(c, i, deps, fn)` | `lunas/computed` | Lazily-evaluated, memoized derived value. |
+| `watch(c, deps, cb, opts?)` | `lunas/watch` | Run `cb` when any of `deps` changes (optionally `immediate`). |
+| `watchEffect(c, deps, fn)` | `lunas/watch` | Run `fn` immediately and again on any `deps` change. |
+| `nextTick(c)` | `lunas/batch` | Promise resolved after the next flush (DOM updated). |
+| `batch(c, fn)` | `lunas/batch` | Run `fn`, then flush synchronously, collapsing writes into one update pass. |
 | `component(tag, attrs, HTML, setup)` | `lunas/dom` | Compiled-component factory: builds the root, parses static HTML, runs `setup`. |
 | `refs(root, paths)` | `lunas/dom` | Positional navigation to dynamic elements by child-index paths. |
 | `on(el, ev, fn)` | `lunas/dom` | `addEventListener` shorthand. |

--- a/packages/lunas/package.json
+++ b/packages/lunas/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "lunas",
+  "version": "0.0.1-beta.11-alpha.0",
+  "description": "Dependency-free ES2015 runtime for Lunas-compiled components.",
+  "type": "module",
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lunasrun/lunas.git",
+    "directory": "packages/lunas"
+  },
+  "homepage": "https://github.com/lunasrun/lunas/tree/main/packages/lunas#readme",
+  "bugs": {
+    "url": "https://github.com/lunasrun/lunas/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "src",
+    "types",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./src/index.mjs",
+  "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./src/index.mjs"
+    },
+    "./core": {
+      "types": "./types/core.d.ts",
+      "import": "./src/core.mjs"
+    },
+    "./boxes": {
+      "types": "./types/boxes.d.ts",
+      "import": "./src/boxes.mjs"
+    },
+    "./dom": {
+      "types": "./types/dom.d.ts",
+      "import": "./src/dom.mjs"
+    },
+    "./blocks": {
+      "types": "./types/blocks.d.ts",
+      "import": "./src/blocks.mjs"
+    },
+    "./for_diff": {
+      "types": "./types/for_diff.d.ts",
+      "import": "./src/for_diff.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "node test/run-all.mjs",
+    "check:treeshake": "node test/treeshake.check.mjs"
+  }
+}

--- a/packages/lunas/package.json
+++ b/packages/lunas/package.json
@@ -38,6 +38,18 @@
       "types": "./types/boxes.d.ts",
       "import": "./src/boxes.mjs"
     },
+    "./computed": {
+      "types": "./types/computed.d.ts",
+      "import": "./src/computed.mjs"
+    },
+    "./watch": {
+      "types": "./types/watch.d.ts",
+      "import": "./src/watch.mjs"
+    },
+    "./batch": {
+      "types": "./types/batch.d.ts",
+      "import": "./src/batch.mjs"
+    },
     "./dom": {
       "types": "./types/dom.d.ts",
       "import": "./src/dom.mjs"

--- a/packages/lunas/test/run-all.mjs
+++ b/packages/lunas/test/run-all.mjs
@@ -1,0 +1,43 @@
+// run-all.mjs — test driver: discovers every *.test.mjs in this directory,
+// runs each in its own child process (node <file>), and fails the whole run
+// if any of them exits nonzero. Used by `npm test` and CI.
+//
+// No dependencies beyond node's builtin modules.
+
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const files = readdirSync(here)
+  .filter((f) => f.endsWith(".test.mjs"))
+  .sort();
+
+if (files.length === 0) {
+  console.error("run-all: no *.test.mjs files found in " + here);
+  process.exit(1);
+}
+
+let failed = 0;
+
+for (const file of files) {
+  const full = join(here, file);
+  console.log("\n> node test/" + file);
+  const res = spawnSync(process.execPath, [full], { stdio: "inherit" });
+  if (res.status !== 0) {
+    failed++;
+    console.error("FAIL  " + file + " (exit " + res.status + ")");
+  }
+}
+
+console.log("");
+if (failed > 0) {
+  console.error(
+    failed + "/" + files.length + " test file(s) failed."
+  );
+  process.exit(1);
+}
+
+console.log("all " + files.length + " test file(s) passed.");

--- a/packages/lunas/test/treeshake.check.mjs
+++ b/packages/lunas/test/treeshake.check.mjs
@@ -1,0 +1,204 @@
+// treeshake.check.mjs — demonstrates that the runtime is tree-shakeable.
+//
+// Two independent checks:
+//
+//   1. Static side-effect check (always runs, no deps): every src/*.mjs
+//      module must contain no top-level statement other than
+//      imports/exports/declarations — i.e. nothing runs merely by
+//      importing the module. This is what makes "sideEffects": false in
+//      package.json truthful and is a necessary condition for bundlers to
+//      tree-shake unused exports.
+//
+//   2. Bundle check (best-effort, uses `npx esbuild`): bundles an entry
+//      that imports a single symbol (`box`) from the package entry point
+//      with tree-shaking enabled, and asserts that unrelated exports
+//      (e.g. `forBlock`, `reconcile`, `component`) do not appear in the
+//      output. Skips gracefully (exit 0, with a notice) if npx/esbuild is
+//      unavailable or there's no network access — this check is a nice-to
+//      -have proof, not a hard requirement, since check #1 already
+//      guarantees shakeability.
+//
+// Run: node test/treeshake.check.mjs
+
+import { readFileSync, readdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(here, "..", "src");
+
+// ---------------------------------------------------------------------------
+// 1. Static side-effect check
+// ---------------------------------------------------------------------------
+
+console.log("check 1/2: static side-effect scan of src/*.mjs");
+
+const srcFiles = readdirSync(srcDir).filter((f) => f.endsWith(".mjs"));
+let sideEffectFound = false;
+
+for (const file of srcFiles) {
+  const full = join(srcDir, file);
+  const src = readFileSync(full, "utf8");
+  const lines = src.split("\n");
+
+  let depth = 0; // brace depth; only inspect top-level (depth 0) lines
+  let inContinuation = false; // mid-statement continuation of a top-level decl
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    // track brace depth using the raw line (rough but sufficient: this
+    // codebase has no braces inside string/template literals at top level)
+    const opens = (rawLine.match(/{/g) || []).length;
+    const closes = (rawLine.match(/}/g) || []).length;
+
+    if (depth === 0 && line.length > 0 && !line.startsWith("//")) {
+      const isDeclarationStart =
+        line.startsWith("export ") ||
+        line.startsWith("import ") ||
+        line.startsWith("function ") ||
+        line.startsWith("const ") ||
+        line.startsWith("let ") ||
+        line.startsWith("class ") ||
+        line.startsWith("}") || // closing brace of a top-level decl
+        line.startsWith(")") || // continuation (e.g. multi-line import)
+        line.startsWith("*/") ||
+        line.startsWith("/*");
+
+      if (!isDeclarationStart && !inContinuation) {
+        console.error(
+          "  FAIL  " + file + ": possible top-level side effect: " + line
+        );
+        sideEffectFound = true;
+      }
+
+      // A top-level statement that doesn't end in `;`, `{` (block opener)
+      // or `*/` is continuing on the next line (e.g. a multi-line arrow
+      // function body) — don't flag its continuation lines.
+      const opensBlock = /\{\s*$/.test(line);
+      const statementEnds =
+        /;\s*$/.test(line) || opensBlock || line.endsWith("*/");
+      if (opens === 0 && closes === 0) {
+        inContinuation = !statementEnds;
+      } else {
+        inContinuation = false;
+      }
+    } else if (depth === 0) {
+      inContinuation = false;
+    }
+
+    depth += opens - closes;
+  }
+}
+
+if (sideEffectFound) {
+  console.error(
+    "\nstatic check failed: a module executes code at import time, " +
+      "which would break tree-shaking / \"sideEffects\": false."
+  );
+  process.exit(1);
+}
+console.log("  ok    no top-level side effects in any src/*.mjs module\n");
+
+// ---------------------------------------------------------------------------
+// 2. Bundle check (best-effort)
+// ---------------------------------------------------------------------------
+
+console.log("check 2/2: esbuild bundle + unused-export elimination (best-effort)");
+
+function tryEsbuild() {
+  const entryDir = mkdtempSync(join(tmpdir(), "lunas-treeshake-"));
+  const entryFile = join(entryDir, "entry.mjs");
+  const outFile = join(entryDir, "out.js");
+  writeFileSync(
+    entryFile,
+    "import { box } from " +
+      JSON.stringify(join(here, "..", "src", "index.mjs")) +
+      ";\n" +
+      "globalThis.__lunasTreeshakeProbe = box;\n"
+  );
+
+  const res = spawnSync(
+    "npx",
+    [
+      "--yes",
+      "esbuild",
+      entryFile,
+      "--bundle",
+      "--format=esm",
+      "--tree-shaking=true",
+      "--outfile=" + outFile,
+    ],
+    { encoding: "utf8", timeout: 60000 }
+  );
+
+  if (res.error || res.status !== 0) {
+    return {
+      ok: false,
+      skip: true,
+      reason:
+        "npx esbuild unavailable (no network or resolution failed): " +
+        (res.error ? res.error.message : res.stderr || "unknown error"),
+    };
+  }
+
+  const bundled = readFileSync(outFile, "utf8");
+  rmSync(entryDir, { recursive: true, force: true });
+
+  // Symbols that are ONLY reachable from other, unimported exports. If
+  // tree-shaking works, none of these identifiers should appear in the
+  // bundle (function names are preserved by esbuild by default at this
+  // optimization level when not minifying).
+  const unrelatedMarkers = [
+    "function forBlock",
+    "function ifBlock",
+    "function component(",
+    "function reconcile(",
+    "function mountChild",
+  ];
+
+  const leaked = unrelatedMarkers.filter((m) => bundled.includes(m));
+  if (leaked.length > 0) {
+    return {
+      ok: false,
+      skip: false,
+      reason:
+        "bundle unexpectedly contains unrelated exports: " + leaked.join(", "),
+    };
+  }
+
+  if (!bundled.includes("__lunasTreeshakeProbe")) {
+    return {
+      ok: false,
+      skip: false,
+      reason: "bundle is missing the imported symbol itself — bundling failed",
+    };
+  }
+
+  return { ok: true, skip: false };
+}
+
+let result;
+try {
+  result = tryEsbuild();
+} catch (e) {
+  result = { ok: false, skip: true, reason: String(e && e.message ? e.message : e) };
+}
+
+if (result.skip) {
+  console.log("  skip  " + result.reason);
+  console.log(
+    "  (this is expected offline; check 1/2 already guarantees shakeability)\n"
+  );
+} else if (!result.ok) {
+  console.error("  FAIL  " + result.reason);
+  process.exit(1);
+} else {
+  console.log(
+    "  ok    bundling only `box` did not pull in forBlock/ifBlock/component/reconcile/mountChild\n"
+  );
+}
+
+console.log("treeshake.check.mjs: done");

--- a/packages/lunas/types/batch.d.ts
+++ b/packages/lunas/types/batch.d.ts
@@ -1,0 +1,21 @@
+// batch.d.ts — types for src/batch.mjs
+// Update coalescing and nextTick.
+
+import type { Context } from "./core.js";
+
+/**
+ * nextTick(c) — a Promise resolved after the next flush completes (i.e.
+ * after the DOM update pass). If nothing is pending the flush is still
+ * scheduled, so `await nextTick(c)` always lands after the current tick's
+ * update pass.
+ */
+export function nextTick(c: Context): Promise<void>;
+
+/**
+ * batch(c, fn) — run fn (which may write many boxes) and flush
+ * synchronously afterward, collapsing the whole group into one update pass
+ * that has completed by the time batch() returns. Nested batches on the
+ * same context flush only at the outermost call. Returns whatever `fn`
+ * returns.
+ */
+export function batch<T>(c: Context, fn: () => T): T;

--- a/packages/lunas/types/blocks.d.ts
+++ b/packages/lunas/types/blocks.d.ts
@@ -1,0 +1,77 @@
+// blocks.d.ts — types for src/blocks.mjs
+// Control-flow blocks anchored at permanent text nodes.
+
+import type { Context } from "./core.js";
+import type { ForSeed, KeyOf, PatchItem, WarnFn } from "./for_diff.js";
+
+/** A branch's DOM output: a single root node, or a multi-root node array. */
+export type BlockNodes = Node | Node[];
+
+/** A handle returned by ifBlock/forBlock/mountChild for whole-block teardown. */
+export interface BlockHandle {
+  destroy(): void;
+}
+
+/**
+ * ifBlock(c, anchor, deps, cond, make)
+ * `make()` returns a node (single-root branch) or an array of nodes
+ * (multi-root branch — the compiler knows which and emits accordingly).
+ * The branch is inserted before the permanent anchor when cond() becomes
+ * truthy and removed (with scope teardown) when it becomes falsy.
+ */
+export function ifBlock(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  cond: () => boolean,
+  make: () => BlockNodes
+): BlockHandle;
+
+/** Options for forBlock; all fields besides `make` are optional. */
+export interface ForBlockOpts<T = unknown> {
+  /** Build one item; returns node or node array. */
+  make(itemData: T, key: unknown): BlockNodes;
+  /** Compiled :key extractor (optional; falls back to item identity/index). */
+  keyOf?: KeyOf<T>;
+  /** Update an existing item's scope in place (optional). */
+  patch?: PatchItem<T>;
+  /** Duplicate-key warning hook (optional). */
+  onWarn?: WarnFn;
+  /** Seed from a bulk innerHTML initial render (optional); when present the
+   * initial reconcile is skipped because the items are already mounted. */
+  seed?: ForSeed<T>;
+}
+
+/**
+ * forBlock(c, anchor, deps, items, opts)
+ * `items` is a closure returning the current array (read lazily at flush
+ * time). Updates go through the keyed LIS reconciler; innerHTML is never
+ * used here.
+ */
+export function forBlock<T = unknown>(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  items: () => T[],
+  opts: ForBlockOpts<T>
+): BlockHandle;
+
+/** A factory that builds one component instance given props. */
+export type ChildFactory<P = Record<string, unknown>> = (props?: P) => Node;
+
+/** Handle for a mounted child component. */
+export interface MountedChild {
+  root: Node;
+  unmount(): void;
+}
+
+/**
+ * mountChild(c, anchor, childFactory, props) — instantiate a child
+ * component and insert its root before the anchor.
+ */
+export function mountChild<P = Record<string, unknown>>(
+  c: Context,
+  anchor: Node,
+  childFactory: ChildFactory<P>,
+  props?: P
+): MountedChild;

--- a/packages/lunas/types/boxes.d.ts
+++ b/packages/lunas/types/boxes.d.ts
@@ -1,0 +1,39 @@
+// boxes.d.ts — types for src/boxes.mjs
+// Per-variable reactive boxes, specialized by the compiler.
+
+import type { Context } from "./core.js";
+
+/** A reassign-only reactive cell backed by reactive index `i` in context `c`. */
+export interface Box<T> {
+  v: T;
+}
+
+/**
+ * box(c, i, v) — reassign-only variable at reactive index i.
+ * Lightest path: plain getter/setter, no Proxy. Same-value writes are no-ops.
+ */
+export function box<T>(c: Context, i: number, v: T): Box<T>;
+
+/**
+ * deepBox(c, i, v) — deeply-mutated variable (arr.push, obj.k = …).
+ * Reads through `.v` return a Proxy that marks the variable dirty on any
+ * nested set/delete. Nested objects are wrapped lazily on property access;
+ * wrappers are cached per underlying object so identity is stable.
+ */
+export function deepBox<T>(c: Context, i: number, v: T): Box<T>;
+
+/**
+ * A value shared across components (prop passed down and mutated). Each
+ * dependent component attaches with its own reactive index; a write marks
+ * the variable dirty in every attached component.
+ */
+export interface Shared<T> {
+  v: T;
+  /** Attach a dependent context/reactive-index pair to this shared value. */
+  attach(c: Context, i: number): void;
+  /** Detach every attachment belonging to context `c`. */
+  detach(c: Context): void;
+}
+
+/** shared(v) — create a value shared across components. */
+export function shared<T>(v: T): Shared<T>;

--- a/packages/lunas/types/computed.d.ts
+++ b/packages/lunas/types/computed.d.ts
@@ -1,0 +1,22 @@
+// computed.d.ts — types for src/computed.mjs
+// Lazily-evaluated derived values in the adjacency model.
+
+import type { Context } from "./core.js";
+
+/** A read-only box-shaped handle whose `.v` getter yields the memoized result. */
+export interface Computed<T> {
+  readonly v: T;
+}
+
+/**
+ * computed(c, i, deps, fn) — derived value at reactive index `i` reading the
+ * upstream reactive indices in `deps`. The compute fn runs only when the
+ * value is actually read AND an upstream dep has changed since the last
+ * computation (lazy + memoized).
+ */
+export function computed<T>(
+  c: Context,
+  i: number,
+  deps: number[],
+  fn: () => T
+): Computed<T>;

--- a/packages/lunas/types/core.d.ts
+++ b/packages/lunas/types/core.d.ts
@@ -1,0 +1,77 @@
+// core.d.ts — types for src/core.mjs
+// A component context `c` created by createContext(root) and threaded
+// through bind/markVar/flush/unbind and the scope helpers.
+
+/** A single registered update function plus its bookkeeping. Opaque to callers. */
+export interface BindRecord {
+  fn: () => void;
+  q: boolean;
+  alive: boolean;
+  deps: number[];
+}
+
+/** Teardown bookkeeping for a control-flow block's inner binds (see blocks.mjs). */
+export interface Scope {
+  subs: BindRecord[];
+  children: Scope[];
+  parent: Scope | null;
+}
+
+/**
+ * A component context: { root, deps, queue, pending, scope }.
+ * `deps[i]` is the adjacency list of bind records that read reactive
+ * variable `i`. `root` is whatever value the caller passed to
+ * createContext (typically the component's root DOM node).
+ */
+export interface Context<R = unknown> {
+  root: R;
+  deps: (BindRecord[] | undefined)[];
+  queue: BindRecord[];
+  pending: boolean;
+  scope: Scope | null;
+}
+
+/** Create a fresh reactive context rooted at `root`. */
+export function createContext<R = unknown>(root: R): Context<R>;
+
+/**
+ * Register an update function that reads the reactive variable indices in
+ * `deps`. Runs `fn` once immediately. Returns the bind record (needed for
+ * unbind).
+ */
+export function bind(
+  c: Context,
+  deps: number[],
+  fn: () => void
+): BindRecord;
+
+/**
+ * Reactive variable `i` changed: enqueue its dependents (deduplicated) and
+ * schedule a microtask flush of `c`.
+ */
+export function markVar(c: Context, i: number): void;
+
+/** Run every queued update once. Only affected parts run. */
+export function flush(c: Context): void;
+
+/**
+ * Permanently unregister a bind record. Safe to call while a flush
+ * containing `s` is pending (the dead record is skipped at flush).
+ */
+export function unbind(c: Context, s: BindRecord): void;
+
+/**
+ * Open a new collection scope, nested under the context's currently-open
+ * scope (if any). Every bind created until the matching endScope is
+ * collected into the returned scope.
+ */
+export function beginScope(c: Context): Scope;
+
+/** Close the currently-open scope, restoring the parent as current. */
+export function endScope(c: Context): void;
+
+/**
+ * Unregister every bind collected in `scope` (recursively, including
+ * nested child scopes) and detach `scope` from its parent.
+ */
+export function dropScope(c: Context, scope: Scope): void;

--- a/packages/lunas/types/core.d.ts
+++ b/packages/lunas/types/core.d.ts
@@ -18,10 +18,12 @@ export interface Scope {
 }
 
 /**
- * A component context: { root, deps, queue, pending, scope }.
+ * A component context: { root, deps, queue, pending, scope, post }.
  * `deps[i]` is the adjacency list of bind records that read reactive
  * variable `i`. `root` is whatever value the caller passed to
- * createContext (typically the component's root DOM node).
+ * createContext (typically the component's root DOM node). `post` is the
+ * list of pending afterFlush callbacks (nextTick's primitive); `batchDepth`
+ * is used internally by batch() in batch.mjs.
  */
 export interface Context<R = unknown> {
   root: R;
@@ -29,6 +31,8 @@ export interface Context<R = unknown> {
   queue: BindRecord[];
   pending: boolean;
   scope: Scope | null;
+  post: (() => void)[] | null;
+  batchDepth?: number;
 }
 
 /** Create a fresh reactive context rooted at `root`. */
@@ -51,8 +55,19 @@ export function bind(
  */
 export function markVar(c: Context, i: number): void;
 
-/** Run every queued update once. Only affected parts run. */
+/**
+ * Run every queued update once. Only affected parts run. After the update
+ * pass, drains any post-flush callbacks registered via `afterFlush`.
+ */
 export function flush(c: Context): void;
+
+/**
+ * Run `cb` once, after the next flush completes (i.e. after the DOM update
+ * pass). If a flush is already pending the callback rides that one;
+ * otherwise a flush is scheduled so the callback still fires this tick.
+ * This is the primitive behind nextTick() (see batch.mjs).
+ */
+export function afterFlush(c: Context, cb: () => void): void;
 
 /**
  * Permanently unregister a bind record. Safe to call while a flush

--- a/packages/lunas/types/dom.d.ts
+++ b/packages/lunas/types/dom.d.ts
@@ -1,0 +1,65 @@
+// dom.d.ts — types for src/dom.mjs
+// DOM construction & wiring helpers.
+
+import type { Context } from "./core.js";
+
+/** Static attributes applied to the component's root element via setAttribute. */
+export type RootAttrs = Record<string, string>;
+
+/** Setup function: wires binds/children against the freshly-parsed root. */
+export type SetupFn<P = Record<string, unknown>> = (
+  c: Context<Element>,
+  props: P
+) => void;
+
+/** The per-instance factory returned by component(...). */
+export type ComponentFactory<P = Record<string, unknown>> = (
+  props?: P
+) => Element;
+
+/**
+ * component(tag, attrs, HTML, setup) — the compiled-component factory.
+ * Builds the root detached, bulk-parses the comment-free static skeleton via
+ * innerHTML, runs setup (wiring happens off-DOM), returns a factory that
+ * builds one instance per call. The caller attaches the returned root to the
+ * live DOM once.
+ */
+export function component<P = Record<string, unknown>>(
+  tag: string,
+  attrs: RootAttrs,
+  HTML: string,
+  setup: SetupFn<P>
+): ComponentFactory<P>;
+
+/**
+ * refs(root, paths) — positional navigation to dynamic elements.
+ * paths = [[0], [1, 2], ...]: each path is child indices from root.
+ */
+export function refs(root: Node, paths: number[][]): Node[];
+
+/** on(el, ev, fn) — addEventListener shorthand. */
+export function on(
+  el: EventTarget,
+  ev: string,
+  fn: EventListenerOrEventListenerObject
+): void;
+
+/**
+ * anchorBefore(node) — create a permanent empty text-node anchor immediately
+ * before an existing node.
+ */
+export function anchorBefore(node: Node): Text;
+
+/**
+ * anchorBeforeSplit(textNode, utf16Offset) — split a static text node at the
+ * given UTF-16 offset and place the anchor between head and tail (i.e. the
+ * anchor sits before the tail). Used when a dynamic seam falls inside a text
+ * run.
+ */
+export function anchorBeforeSplit(textNode: Text, utf16Offset: number): Text;
+
+/**
+ * anchorAppend(parent) — anchor as the last child of parent (e.g. a :for
+ * slot at the end of a container).
+ */
+export function anchorAppend(parent: Node): Text;

--- a/packages/lunas/types/for_diff.d.ts
+++ b/packages/lunas/types/for_diff.d.ts
@@ -1,0 +1,99 @@
+// for_diff.d.ts — types for src/for_diff.mjs
+// The Lunas keyed :for reconciler (update phase). Host-abstracted so it can
+// run without a DOM: the caller supplies a `host` implementing the minimal
+// node-placement interface, plus factory and patch callbacks.
+
+/** A reconciled key: primitives compare by value, objects by identity. */
+export type Key = string | number | boolean | object;
+
+/** Extract the key for item `itemData` at position `i` in the new array. */
+export type KeyOf<T = unknown> = (itemData: T, i: number) => Key;
+
+/** Update an existing mounted item's reactive scope with new data. */
+export type PatchItem<T = unknown> = (node: unknown, itemData: T) => void;
+
+/** Duplicate-key warning hook. */
+export type WarnFn = (message: string) => void;
+
+/**
+ * The minimal node-placement interface the DOM binding provides at runtime.
+ * `node` in insertBefore/remove is whatever makeItem returned (a real DOM
+ * node, or a multi-root handle understood by the caller).
+ */
+export interface ReconcileHost<N = unknown> {
+  /**
+   * Move/insert `node` so it sits immediately before `refNode` in the
+   * parent. `refNode === null` means "append at the end" (before the
+   * permanent `:for` anchor, in the real runtime).
+   */
+  insertBefore(node: N, refNode: N | null): void;
+  /** Detach `node` from the parent. */
+  remove(node: N): void;
+}
+
+/** Build the DOM (or handle) for a new item and return its host node. */
+export type MakeItem<T = unknown, N = unknown> = (
+  itemData: T,
+  key: Key
+) => N;
+
+/**
+ * The mutable state the reconciler threads across updates, in current DOM
+ * order: keys/nodes/data are parallel arrays over the mounted items.
+ */
+export interface ForState<T = unknown, N = unknown> {
+  keys: Key[];
+  nodes: N[];
+  data: T[];
+}
+
+/** Seed data for a bulk-innerHTML initial render (see forBlock's opts.seed). */
+export interface ForSeed<T = unknown, N = unknown> {
+  keys: Key[];
+  handles: N[];
+  data: T[];
+}
+
+/** Options accepted by reconcile(); all fields optional. */
+export interface ReconcileOpts<T = unknown, N = unknown> {
+  keyOf?: KeyOf<T>;
+  patchItem?: PatchItem<T>;
+  onWarn?: WarnFn;
+}
+
+/** createForState() — an empty ForState to seed or reconcile against. */
+export function createForState<T = unknown, N = unknown>(): ForState<T, N>;
+
+/**
+ * seedForState(state, keys, nodes, data) — record the starting order after
+ * an initial bulk-innerHTML render, so the first reconcile() diffs against
+ * reality instead of assuming an empty list.
+ */
+export function seedForState<T = unknown, N = unknown>(
+  state: ForState<T, N>,
+  keys: Key[],
+  nodes: N[],
+  data: T[]
+): void;
+
+/**
+ * reconcile(state, host, items, makeItem, opts) — diff `state`'s previous
+ * mounted order against the new `items` and mutate `host` so its children
+ * end up exactly in the new key order, using prefix/suffix trimming, a
+ * key->index map, and a longest-increasing-subsequence pass to minimize
+ * node moves. Mutates `state` in place to reflect the new order.
+ */
+export function reconcile<T = unknown, N = unknown>(
+  state: ForState<T, N>,
+  host: ReconcileHost<N>,
+  items: T[],
+  makeItem: MakeItem<T, N>,
+  opts?: ReconcileOpts<T, N>
+): void;
+
+/**
+ * longestIncreasingSubsequence(arr) — positions (ascending) into `arr`
+ * forming a longest strictly-increasing run of its non-NADA (-1) values.
+ * O(n log n) patience-sorting with parent links.
+ */
+export function longestIncreasingSubsequence(arr: number[]): number[];

--- a/packages/lunas/types/index.d.ts
+++ b/packages/lunas/types/index.d.ts
@@ -1,0 +1,68 @@
+// index.d.ts — public API surface, mirroring src/index.mjs's re-exports.
+// lunas — minimal runtime for Lunas-compiled components.
+// Plain ESM, no build step. Compatibility floor: ES2015 + Proxy. No BigInt.
+
+export type {
+  BindRecord,
+  Scope,
+  Context,
+} from "./core.js";
+
+export {
+  createContext,
+  bind,
+  markVar,
+  flush,
+  unbind,
+  beginScope,
+  endScope,
+  dropScope,
+} from "./core.js";
+
+export type { Box, Shared } from "./boxes.js";
+
+export { box, deepBox, shared } from "./boxes.js";
+
+export type {
+  RootAttrs,
+  SetupFn,
+  ComponentFactory,
+} from "./dom.js";
+
+export {
+  component,
+  refs,
+  on,
+  anchorBefore,
+  anchorBeforeSplit,
+  anchorAppend,
+} from "./dom.js";
+
+export type {
+  BlockNodes,
+  BlockHandle,
+  ForBlockOpts,
+  ChildFactory,
+  MountedChild,
+} from "./blocks.js";
+
+export { ifBlock, forBlock, mountChild } from "./blocks.js";
+
+export type {
+  Key,
+  KeyOf,
+  PatchItem,
+  WarnFn,
+  ReconcileHost,
+  MakeItem,
+  ForState,
+  ForSeed,
+  ReconcileOpts,
+} from "./for_diff.js";
+
+export {
+  createForState,
+  seedForState,
+  reconcile,
+  longestIncreasingSubsequence,
+} from "./for_diff.js";

--- a/packages/lunas/types/index.d.ts
+++ b/packages/lunas/types/index.d.ts
@@ -13,6 +13,7 @@ export {
   bind,
   markVar,
   flush,
+  afterFlush,
   unbind,
   beginScope,
   endScope,
@@ -22,6 +23,16 @@ export {
 export type { Box, Shared } from "./boxes.js";
 
 export { box, deepBox, shared } from "./boxes.js";
+
+export type { Computed } from "./computed.js";
+
+export { computed } from "./computed.js";
+
+export type { StopHandle, WatchOpts } from "./watch.js";
+
+export { watch, watchEffect } from "./watch.js";
+
+export { nextTick, batch } from "./batch.js";
 
 export type {
   RootAttrs,

--- a/packages/lunas/types/watch.d.ts
+++ b/packages/lunas/types/watch.d.ts
@@ -1,0 +1,37 @@
+// watch.d.ts — types for src/watch.mjs
+// User-facing watchers over the adjacency model.
+
+import type { Context } from "./core.js";
+
+/** Stops (unbinds) the watcher/effect it was returned from. */
+export type StopHandle = () => void;
+
+/** Options accepted by watch(). */
+export interface WatchOpts {
+  /** Also invoke the callback once at registration time (default: false). */
+  immediate?: boolean;
+}
+
+/**
+ * watch(c, deps, cb, opts?) — run `cb` after any of `deps` changes. By
+ * default the first (synchronous) run is suppressed, so the callback fires
+ * only on subsequent changes. Pass { immediate: true } to also invoke it
+ * once at registration time. The watcher is collected by the current scope
+ * (torn down by dropScope) in addition to the returned stop().
+ */
+export function watch(
+  c: Context,
+  deps: number[],
+  cb: () => void,
+  opts?: WatchOpts
+): StopHandle;
+
+/**
+ * watchEffect(c, deps, fn) — run `fn` immediately and again after any of
+ * `deps` changes (no distinction between the initial and later runs).
+ */
+export function watchEffect(
+  c: Context,
+  deps: number[],
+  fn: () => void
+): StopHandle;


### PR DESCRIPTION
## Summary

- Adds `packages/lunas/package.json`: name `lunas`, version `0.0.1-beta.11-alpha.0`, `"type": "module"`, `"sideEffects": false`, an exports map (`.` plus deep-import subpaths for every internal module: `core`, `boxes`, `computed`, `watch`, `batch`, `dom`, `blocks`, `for_diff`), `files` limited to `src` + `types` + `README.md` + `LICENSE`, MIT license metadata, `engines.node >= 18`.
- Adds hand-written `packages/lunas/types/*.d.ts` (one per module + `index.d.ts`) covering the full public API re-exported by `index.mjs`, written from each module's actual exports/JSDoc. Type-checks clean under `tsc --strict` (verified locally; not part of the committed package).
- Adds `packages/lunas/test/run-all.mjs`: a dependency-free driver that discovers every `test/*.test.mjs`, runs each as a child `node` process, and fails (nonzero exit) if any file fails. Wired as `npm test`.
- Adds `packages/lunas/test/treeshake.check.mjs`: (1) a static scan asserting no `src/*.mjs` module executes anything at import time (the precondition for `sideEffects: false` to be true), always runs, no deps; (2) a best-effort `npx esbuild` bundle check that importing only `box` from the package entry point does not pull in unrelated exports (`forBlock`/`ifBlock`/`component`/`reconcile`/`mountChild`) — skips gracefully if network/npx is unavailable, since check (1) already guarantees shakeability.
- Adds `packages/lunas/README.md`: what it is, install, ESM usage (root + deep imports), and a full API table.
- Extends `.github/workflows/ci.yml` with a new `runtime` job (Node 22 via `actions/setup-node`, runs the test driver + tree-shake check). The existing Rust `check`/`wasm` jobs are untouched.

This branch was rebased onto `main` after PR #133 (computed/watch/batch+nextTick) merged mid-flight, so the package.json exports map, types, and README already cover the three new modules and `core.mjs`'s new `afterFlush`.

Per the task brief, `packages/lunas/src/*.mjs` and `roadmap.yml` are **not modified** by this PR.

## Test plan

- [x] `node packages/lunas/test/run-all.mjs` — all 6 test files / 51 assertions pass under Node 22.18.0
- [x] `node packages/lunas/test/treeshake.check.mjs` — static side-effect scan passes; esbuild bundle check passes (network available in this environment; script degrades gracefully offline)
- [x] `npm pack --dry-run` in `packages/lunas` — tarball contains exactly `src/`, `types/`, `README.md`, `LICENSE`, `package.json` (test files correctly excluded)
- [x] `tsc --noEmit --strict` over `packages/lunas/types/*.d.ts` — compiles clean (verified locally, not part of the shipped package)
- [x] `git diff main -- roadmap.yml packages/lunas/src` — empty (no source/roadmap changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)