### PR TITLE
feat(codegen): core bindings emitter (refs, anchors, text, attrs, events)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ npm-pkgs/
 
 .vscode/
 .claude/
+
+# Transient modules written by the codegen execution test (codegen_exec.rs);
+# cleaned up on success, ignored in case a run is interrupted.
+packages/lunas/__exec_*.mjs

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -1,0 +1,816 @@
+//! The JS emitter pass: turns a [`crate::ResolvedComponent`] into a runnable ES
+//! module that targets the runtime in `packages/lunas` (see
+//! `docs/output-design.md`).
+//!
+//! Scope (Wave 1): plain text binds, attribute binds (incl. interpolated static
+//! attrs), and event listeners. Positional refs and runtime text anchors are
+//! emitted per §7–8. Control flow (`:if`/`:for`), two-way bindings, and child
+//! components are **not** wired yet — they are voided with a `/* TODO */` marker
+//! (and, for two-way, a diagnostic) so the module still compiles and runs.
+//!
+//! The reactive model is compile-time adjacency dispatch (§4): each reactive
+//! variable becomes a box at a stable index; references to it are rewritten to
+//! `.v`; each dynamic part `bind(c, deps, …)`s with its precomputed dep indices.
+
+use lunas_parser::{Diagnostic, StaticValue, TemplateAttr, TemplateText, TextRange, TextSegment};
+use lunas_script::module_binding_references;
+
+use crate::codegen::skeleton::{
+    build_skeleton, DynamicElement, InsertPos, Skeleton, Slot, SlotContent,
+};
+use crate::model::{DynamicKind, ReactiveVar, ResolvedComponent};
+
+/// The root wrapper tag. The skeleton HTML is the wrapper's `innerHTML`, so all
+/// positional [`refs`](../../packages/lunas/src/dom.mjs) paths are `childNodes`
+/// indices from this element. A neutral `<div>` is used for every component in
+/// Wave 1 (single-root / multi-root distinction is a later optimization).
+const ROOT_TAG: &str = "div";
+
+/// Compiles a `.lunas` source string into a runnable ES module.
+///
+/// Never panics. Returns `None` for the module only when there is nothing to
+/// emit (no template) or a resolve error prevents emission; diagnostics carry
+/// the detail. Unsupported constructs inside a template are voided gracefully,
+/// not fatal.
+pub fn compile(source: &str) -> (Option<String>, Vec<Diagnostic>) {
+    let (component, mut diags) = crate::resolve(source);
+    if diags.iter().any(|d| d.is_error()) {
+        return (None, diags);
+    }
+    match emit_module(&component, &mut diags) {
+        Some(js) => (Some(js), diags),
+        None => (None, diags),
+    }
+}
+
+/// Emits the module for a resolved component, or `None` if it has no template.
+fn emit_module(component: &ResolvedComponent, diags: &mut Vec<Diagnostic>) -> Option<String> {
+    let template = component.template.as_ref()?;
+    let skeleton = build_skeleton(template);
+
+    let mut e = Emitter::new(component);
+    let setup_body = e.setup_body(&skeleton, diags);
+
+    let mut out = String::new();
+    out.push_str(&e.import_line());
+    out.push('\n');
+    out.push('\n');
+    out.push_str("const HTML = ");
+    push_js_string(&mut out, &skeleton.html);
+    out.push_str(";\n\n");
+    out.push_str("export default component(");
+    push_js_string(&mut out, ROOT_TAG);
+    out.push_str(", {}, HTML, (c, props) => {\n");
+    out.push_str(&setup_body);
+    out.push_str("});\n");
+    Some(out)
+}
+
+struct Emitter<'a> {
+    component: &'a ResolvedComponent,
+    /// Runtime helper names referenced by the emitted module, collected while
+    /// generating so the import line stays minimal.
+    used: std::collections::BTreeSet<&'static str>,
+}
+
+impl<'a> Emitter<'a> {
+    fn new(component: &'a ResolvedComponent) -> Self {
+        Emitter {
+            component,
+            used: std::collections::BTreeSet::new(),
+        }
+    }
+
+    /// `import { … } from "lunas";` covering every helper actually referenced.
+    fn import_line(&self) -> String {
+        // `component` is always used (the module's default export).
+        let mut names: Vec<&str> = self.used.iter().copied().collect();
+        if !names.contains(&"component") {
+            names.insert(0, "component");
+        }
+        format!("import {{ {} }} from \"lunas\";", names.join(", "))
+    }
+
+    fn use_helper(&mut self, name: &'static str) {
+        self.used.insert(name);
+    }
+
+    /// The body of the `setup` closure: props, boxes, refs, anchors, binds and
+    /// event listeners, in the build order of §7.
+    fn setup_body(&mut self, skeleton: &Skeleton, diags: &mut Vec<Diagnostic>) -> String {
+        let mut b = String::new();
+
+        self.emit_props(&mut b);
+        self.emit_boxes(&mut b);
+        self.emit_refs(&mut b, &skeleton.dynamic_elements);
+        self.emit_text_slots(&mut b, &skeleton.slots, diags);
+        self.emit_attr_and_event_wiring(&mut b, &skeleton.dynamic_elements, diags);
+
+        b
+    }
+
+    // --- props ------------------------------------------------------------
+
+    fn emit_props(&mut self, b: &mut String) {
+        for p in &self.component.props {
+            // `@input name = default` -> `let name = props.name ?? default;`
+            // Reactive props are still boxed below; the plain `let` seeds them.
+            b.push_str("  let ");
+            b.push_str(&p.name);
+            b.push_str(" = props.");
+            b.push_str(&p.name);
+            if let Some(d) = &p.default_value {
+                b.push_str(" ?? (");
+                b.push_str(d.trim());
+                b.push(')');
+            }
+            b.push_str(";\n");
+        }
+    }
+
+    // --- boxes ------------------------------------------------------------
+
+    fn emit_boxes(&mut self, b: &mut String) {
+        if self.component.reactive_vars.is_empty() {
+            return;
+        }
+        let script_text = self
+            .component
+            .script
+            .as_ref()
+            .map(|s| s.source.text.as_str())
+            .unwrap_or("");
+        // Rewrite the script body so reactive declarations become boxes and all
+        // references become `.v`.
+        let rewritten = rewrite_script(script_text, &self.component.reactive_vars);
+        let body = dedent(&rewritten);
+        let body = body.trim();
+        if !body.is_empty() {
+            for (kind, _) in reactive_box_kinds(script_text, &self.component.reactive_vars) {
+                self.use_helper(kind);
+            }
+            for line in body.lines() {
+                b.push_str("  ");
+                b.push_str(line);
+                b.push('\n');
+            }
+        }
+    }
+
+    // --- refs -------------------------------------------------------------
+
+    fn emit_refs(&mut self, b: &mut String, elems: &[DynamicElement]) {
+        if elems.is_empty() {
+            return;
+        }
+        self.use_helper("refs");
+        b.push_str("  const [");
+        for (i, _) in elems.iter().enumerate() {
+            if i > 0 {
+                b.push_str(", ");
+            }
+            b.push_str(&ref_name(i));
+        }
+        b.push_str("] = refs(c.root, [");
+        for (i, el) in elems.iter().enumerate() {
+            if i > 0 {
+                b.push_str(", ");
+            }
+            push_path(b, &el.path);
+        }
+        b.push_str("]);\n");
+    }
+
+    // --- text slots -> anchors + binds -----------------------------------
+
+    fn emit_text_slots(&mut self, b: &mut String, slots: &[Slot], diags: &mut Vec<Diagnostic>) {
+        for (i, slot) in slots.iter().enumerate() {
+            match &slot.content {
+                SlotContent::Text(t) => self.emit_text_slot(b, i, t, &slot.pos),
+                SlotContent::If(_) | SlotContent::For(_) | SlotContent::Component(_) => {
+                    b.push_str("  /* TODO(wave2): ");
+                    b.push_str(slot_kind_name(&slot.content));
+                    b.push_str(" block not yet emitted */\n");
+                    let _ = diags; // no diagnostic: these are known deferrals
+                }
+            }
+        }
+    }
+
+    fn emit_text_slot(&mut self, b: &mut String, i: usize, t: &TemplateText, pos: &InsertPos) {
+        let anchor = format!("t{i}");
+        self.emit_anchor(b, &anchor, pos);
+
+        let deps = self.text_run_deps(t);
+        let expr = self.text_run_expr(t);
+
+        if deps.is_empty() {
+            // Static-once: assign at build, no bind.
+            b.push_str("  ");
+            b.push_str(&anchor);
+            b.push_str(".data = ");
+            b.push_str(&expr);
+            b.push_str(";\n");
+        } else {
+            self.use_helper("bind");
+            b.push_str("  bind(c, ");
+            push_dep_list(b, &deps);
+            b.push_str(", () => { ");
+            b.push_str(&anchor);
+            b.push_str(".data = ");
+            b.push_str(&expr);
+            b.push_str("; });\n");
+        }
+    }
+
+    /// Emits the anchor-creation statement for a text run, binding it to a
+    /// local const named `name`.
+    fn emit_anchor(&mut self, b: &mut String, name: &str, pos: &InsertPos) {
+        match pos {
+            InsertPos::Before(path) => {
+                self.use_helper("anchorBefore");
+                b.push_str("  const ");
+                b.push_str(name);
+                b.push_str(" = anchorBefore(");
+                push_node_at(b, path);
+                b.push_str(");\n");
+            }
+            InsertPos::BeforeSplit { path, utf16_offset } => {
+                self.use_helper("anchorBeforeSplit");
+                b.push_str("  const ");
+                b.push_str(name);
+                b.push_str(" = anchorBeforeSplit(");
+                push_node_at(b, path);
+                b.push_str(", ");
+                b.push_str(&utf16_offset.to_string());
+                b.push_str(");\n");
+            }
+            InsertPos::Append(path) => {
+                self.use_helper("anchorAppend");
+                b.push_str("  const ");
+                b.push_str(name);
+                b.push_str(" = anchorAppend(");
+                push_node_at(b, path);
+                b.push_str(");\n");
+            }
+        }
+    }
+
+    /// The combined dependency indices of every interpolation in a text run.
+    fn text_run_deps(&self, t: &TemplateText) -> Vec<u32> {
+        let mut acc = Vec::new();
+        for seg in &t.segments {
+            if let TextSegment::Interpolation(interp) = seg {
+                if let Some(part) =
+                    self.find_dynamic(DynamicKind::Text, &interp.expr, interp.expr_range)
+                {
+                    acc.extend(part.deps.indices().iter().copied());
+                }
+            }
+        }
+        acc.sort_unstable();
+        acc.dedup();
+        acc
+    }
+
+    /// A JS template literal that reproduces the whole text run, with reactive
+    /// references rewritten to `.v`.
+    fn text_run_expr(&self, t: &TemplateText) -> String {
+        let mut out = String::from("`");
+        for seg in &t.segments {
+            match seg {
+                TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut out, text),
+                TextSegment::Interpolation(interp) => {
+                    out.push_str("${");
+                    out.push_str(&rewrite_expr(&interp.expr, &self.component.reactive_vars));
+                    out.push('}');
+                }
+            }
+        }
+        out.push('`');
+        out
+    }
+
+    // --- attribute / event wiring ----------------------------------------
+
+    fn emit_attr_and_event_wiring(
+        &mut self,
+        b: &mut String,
+        elems: &[DynamicElement],
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        for (i, el) in elems.iter().enumerate() {
+            let name = ref_name(i);
+            for attr in &el.attrs {
+                match attr {
+                    TemplateAttr::Bound {
+                        name: attr_name,
+                        expr,
+                        ..
+                    } => {
+                        self.emit_bound_attr(b, &name, attr_name, &expr.text);
+                    }
+                    TemplateAttr::Static {
+                        name: attr_name,
+                        value: Some(v),
+                        ..
+                    } if has_interpolation(v) => {
+                        self.emit_attr_text(b, &name, attr_name, v);
+                    }
+                    TemplateAttr::Event { event, handler, .. } => {
+                        self.emit_event(b, &name, event, &handler.text);
+                    }
+                    TemplateAttr::TwoWay {
+                        name: attr_name,
+                        range,
+                        ..
+                    } => {
+                        b.push_str("  /* TODO(wave2): two-way ::");
+                        b.push_str(attr_name);
+                        b.push_str(" not yet emitted */\n");
+                        diags.push(Diagnostic::warning(
+                            *range,
+                            format!("two-way binding ::{attr_name} is not yet emitted (Wave 2)"),
+                        ));
+                    }
+                    TemplateAttr::Static { .. } => {}
+                }
+            }
+        }
+    }
+
+    fn emit_bound_attr(&mut self, b: &mut String, node: &str, attr: &str, expr: &str) {
+        let deps = self.bound_attr_deps(attr, expr);
+        let value = rewrite_expr(expr, &self.component.reactive_vars);
+        let set = attr_set_statement(node, attr, &value);
+        if deps.is_empty() {
+            b.push_str("  ");
+            b.push_str(&set);
+            b.push('\n');
+        } else {
+            self.use_helper("bind");
+            b.push_str("  bind(c, ");
+            push_dep_list(b, &deps);
+            b.push_str(", () => { ");
+            b.push_str(&set);
+            b.push_str(" });\n");
+        }
+    }
+
+    fn emit_attr_text(&mut self, b: &mut String, node: &str, attr: &str, value: &StaticValue) {
+        let mut deps = Vec::new();
+        let mut lit = String::from("`");
+        for seg in &value.segments {
+            match seg {
+                TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut lit, text),
+                TextSegment::Interpolation(interp) => {
+                    lit.push_str("${");
+                    lit.push_str(&rewrite_expr(&interp.expr, &self.component.reactive_vars));
+                    lit.push('}');
+                    if let Some(part) = self.find_dynamic(
+                        DynamicKind::AttributeText(attr.to_string()),
+                        &interp.expr,
+                        interp.expr_range,
+                    ) {
+                        deps.extend(part.deps.indices().iter().copied());
+                    }
+                }
+            }
+        }
+        lit.push('`');
+        deps.sort_unstable();
+        deps.dedup();
+
+        let set = attr_set_statement(node, attr, &lit);
+        if deps.is_empty() {
+            b.push_str("  ");
+            b.push_str(&set);
+            b.push('\n');
+        } else {
+            self.use_helper("bind");
+            b.push_str("  bind(c, ");
+            push_dep_list(b, &deps);
+            b.push_str(", () => { ");
+            b.push_str(&set);
+            b.push_str(" });\n");
+        }
+    }
+
+    fn emit_event(&mut self, b: &mut String, node: &str, event: &str, handler: &str) {
+        self.use_helper("on");
+        let body = rewrite_expr(handler, &self.component.reactive_vars);
+        b.push_str("  on(");
+        b.push_str(node);
+        b.push_str(", ");
+        push_js_string(b, event);
+        b.push_str(", () => { ");
+        b.push_str(&body);
+        b.push_str("; });\n");
+    }
+
+    // --- dep lookup -------------------------------------------------------
+
+    fn bound_attr_deps(&self, attr: &str, expr: &str) -> Vec<u32> {
+        self.find_dynamic_by(|p| {
+            matches!(&p.kind, DynamicKind::Attribute(n) if n == attr) && p.expr == expr
+        })
+        .map(|p| p.deps.indices().to_vec())
+        .unwrap_or_default()
+    }
+
+    fn find_dynamic(
+        &self,
+        kind: DynamicKind,
+        expr: &str,
+        range: TextRange,
+    ) -> Option<&crate::model::DynamicPart> {
+        self.component
+            .dynamics
+            .iter()
+            .find(|p| p.kind == kind && p.expr == expr && p.range == range)
+            .or_else(|| {
+                self.component
+                    .dynamics
+                    .iter()
+                    .find(|p| p.kind == kind && p.expr == expr)
+            })
+    }
+
+    fn find_dynamic_by<F: Fn(&crate::model::DynamicPart) -> bool>(
+        &self,
+        pred: F,
+    ) -> Option<&crate::model::DynamicPart> {
+        self.component.dynamics.iter().find(|p| pred(p))
+    }
+}
+
+// --- reactive box selection & script rewriting ---------------------------
+
+/// The box helper each reactive var should use, in declaration order: `deepBox`
+/// if the script deeply mutates the var (member/index write or a mutating array
+/// method), else `box`.
+fn reactive_box_kinds(script_text: &str, vars: &[ReactiveVar]) -> Vec<(&'static str, u32)> {
+    vars.iter()
+        .map(|v| {
+            let kind = if is_deeply_mutated(script_text, &v.name) {
+                "deepBox"
+            } else {
+                "box"
+            };
+            (kind, v.index)
+        })
+        .collect()
+}
+
+/// Textual heuristic for deep mutation of `name`: a member/index assignment
+/// (`name.x =`, `name[i] =`, `name.x++`) or a mutating array method call
+/// (`name.push(`, …). Conservative and dependency-free — Wave 1 has no
+/// AST-level deep-mutation analysis. On a false negative the var would use a
+/// plain `box`, which still reacts to whole reassignment.
+fn is_deeply_mutated(script: &str, name: &str) -> bool {
+    const MUTATORS: &[&str] = &[
+        "push",
+        "pop",
+        "shift",
+        "unshift",
+        "splice",
+        "sort",
+        "reverse",
+        "fill",
+        "copyWithin",
+        "set",
+        "add",
+        "delete",
+        "clear",
+    ];
+    for (start, _) in match_identifier_occurrences(script, name) {
+        let after = &script[start + name.len()..];
+        let after_trim = after.trim_start();
+        if let Some(rest) = after_trim.strip_prefix('.') {
+            let rest = rest.trim_start();
+            // name.method( … )  — mutating method call
+            if MUTATORS.iter().any(|m| {
+                rest.strip_prefix(m)
+                    .map(|r| r.trim_start().starts_with('('))
+                    .unwrap_or(false)
+            }) {
+                return true;
+            }
+            // name.prop = / += / ++
+            if let Some(prop_rest) = skip_ident(rest) {
+                let p = prop_rest.trim_start();
+                if p.starts_with('=') && !p.starts_with("==")
+                    || p.starts_with("++")
+                    || p.starts_with("--")
+                    || p.starts_with("+=")
+                    || p.starts_with("-=")
+                    || p.starts_with("*=")
+                    || p.starts_with("/=")
+                {
+                    return true;
+                }
+            }
+        } else if after_trim.starts_with('[') {
+            // name[…] = …   — assume index assignment implies deep mutation
+            return true;
+        }
+    }
+    false
+}
+
+/// Byte offsets where `name` occurs in `script` as a standalone identifier
+/// (not part of a longer identifier). Cheap textual scan — good enough for the
+/// deep-mutation heuristic.
+fn match_identifier_occurrences(script: &str, name: &str) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    if name.is_empty() {
+        return out;
+    }
+    let bytes = script.as_bytes();
+    let mut i = 0;
+    while i <= script.len() {
+        let Some(off) = script[i..].find(name) else {
+            break;
+        };
+        let start = i + off;
+        let end = start + name.len();
+        let before_ok = start == 0 || !is_ident_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_ident_byte(bytes[end]);
+        if before_ok && after_ok {
+            out.push((start, end));
+        }
+        // Advance past this match (matches are ASCII-name-length; `end` is a
+        // valid boundary because `name` is a substring ending at `end`).
+        i = end;
+    }
+    out
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}
+
+/// Skips a leading identifier, returning the remainder, or `None` if there is
+/// no identifier at the front.
+fn skip_ident(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || !(bytes[0].is_ascii_alphabetic() || bytes[0] == b'_' || bytes[0] == b'$')
+    {
+        return None;
+    }
+    let mut i = 1;
+    while i < bytes.len() && is_ident_byte(bytes[i]) {
+        i += 1;
+    }
+    Some(&s[i..])
+}
+
+/// Rewrites the whole script body: reactive `let/const/var name = init`
+/// declarations become `const name = box|deepBox(c, i, init)`, and every
+/// reference to a reactive variable becomes `name.v`. Uses scope-aware
+/// [`module_binding_references`] so shadowed uses are left alone.
+fn rewrite_script(script: &str, vars: &[ReactiveVar]) -> String {
+    if vars.is_empty() {
+        return script.to_string();
+    }
+    let reactive: std::collections::HashMap<&str, &ReactiveVar> =
+        vars.iter().map(|v| (v.name.as_str(), v)).collect();
+
+    let decls = lunas_script::top_level_declarations(script).unwrap_or_default();
+    let refs = module_binding_references(script).unwrap_or_default();
+
+    // Edits over the original text: (start, end, replacement). Applied
+    // right-to-left so byte offsets stay valid; they must not overlap.
+    let mut edits: Vec<(u32, u32, String)> = Vec::new();
+
+    // (1) Reactive declarations become box constructors. Only single-declarator
+    // statements are rewritten (the common case); a reactive var in a multi-
+    // declarator statement is left as a plain `let` and still reacts to whole
+    // reassignment via `.v` reads (it just won't be boxed). The declarator init
+    // is itself rewritten so reactive reads inside it get `.v`.
+    let mut decl_ranges: Vec<TextRange> = Vec::new();
+    for d in &decls {
+        let Some(var) = reactive.get(d.name.as_str()) else {
+            continue;
+        };
+        if d.declarators_in_stmt != 1 {
+            continue;
+        }
+        let kind = if is_deeply_mutated(script, &d.name) {
+            "deepBox"
+        } else {
+            "box"
+        };
+        let init_raw = d
+            .init_range
+            .and_then(|ir| ir.slice(script))
+            .unwrap_or("undefined");
+        let init = rewrite_expr(init_raw, vars);
+        let text = format!("const {} = {}(c, {}, {})", d.name, kind, var.index, init);
+        edits.push((d.stmt_range.start().raw(), d.stmt_range.end().raw(), text));
+        decl_ranges.push(d.stmt_range);
+    }
+
+    // (2) Every reactive reference becomes `name.v`. Skip references inside a
+    // rewritten declaration statement — its init was already rewritten in (1).
+    for r in &refs {
+        if !reactive.contains_key(r.name.as_str()) {
+            continue;
+        }
+        let end = r.range.end().raw();
+        if decl_ranges
+            .iter()
+            .any(|dr| end > dr.start().raw() && end <= dr.end().raw())
+        {
+            continue;
+        }
+        if r.shorthand {
+            // `{ count }` -> `{ count: count.v }`
+            let start = r.range.start().raw();
+            edits.push((start, end, format!("{}: {}.v", r.name, r.name)));
+        } else {
+            edits.push((end, end, ".v".to_string()));
+        }
+    }
+
+    apply_edits(script, edits)
+}
+
+/// Applies `(start, end, replacement)` edits to `src`, right-to-left. Edits
+/// must not overlap (aside from zero-width inserts, which are fine).
+fn apply_edits(src: &str, mut edits: Vec<(u32, u32, String)>) -> String {
+    edits.sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
+    let mut out = src.to_string();
+    for (start, end, text) in edits {
+        let (s, e) = (start as usize, end as usize);
+        if s <= e && e <= out.len() && out.is_char_boundary(s) && out.is_char_boundary(e) {
+            out.replace_range(s..e, &text);
+        }
+    }
+    out
+}
+
+/// Rewrites a standalone JS expression so reactive references become `name.v`.
+/// Uses scope-aware [`free_identifiers_with_spans`] so shadowed locals (e.g. an
+/// arrow parameter of the same name) are left alone.
+fn rewrite_expr(expr: &str, vars: &[ReactiveVar]) -> String {
+    if vars.is_empty() {
+        return expr.trim().to_string();
+    }
+    let reactive: std::collections::HashSet<&str> = vars.iter().map(|v| v.name.as_str()).collect();
+    let spans = match lunas_script::free_identifiers_with_spans(expr) {
+        Ok(s) => s,
+        Err(_) => return expr.trim().to_string(),
+    };
+    let mut edits: Vec<(u32, u32, String)> = Vec::new();
+    for (name, range) in spans {
+        if reactive.contains(name.as_str()) {
+            edits.push((range.end().raw(), range.end().raw(), ".v".to_string()));
+        }
+    }
+    apply_edits(expr, edits).trim().to_string()
+}
+
+// --- attribute set special cases -----------------------------------------
+
+/// The statement that assigns `value` (a JS expression) to `attr` on `node`.
+/// Boolean and property attributes get direct property assignment; everything
+/// else goes through `setAttribute`.
+fn attr_set_statement(node: &str, attr: &str, value: &str) -> String {
+    if let Some(prop) = boolean_property(attr) {
+        // Boolean attribute: reflect truthiness onto the DOM property.
+        format!("{node}.{prop} = !!({value});")
+    } else if let Some(prop) = idl_property(attr) {
+        format!("{node}.{prop} = {value};")
+    } else {
+        format!("{node}.setAttribute(\"{attr}\", {value});")
+    }
+}
+
+/// Attributes best set as a boolean DOM property.
+fn boolean_property(attr: &str) -> Option<&'static str> {
+    match attr {
+        "checked" => Some("checked"),
+        "disabled" => Some("disabled"),
+        "selected" => Some("selected"),
+        "readonly" => Some("readOnly"),
+        "multiple" => Some("multiple"),
+        "hidden" => Some("hidden"),
+        _ => None,
+    }
+}
+
+/// Attributes best set as an IDL property (value type / reflection quirks).
+fn idl_property(attr: &str) -> Option<&'static str> {
+    match attr {
+        "value" => Some("value"),
+        _ => None,
+    }
+}
+
+// --- small emit utilities ------------------------------------------------
+
+fn ref_name(i: usize) -> String {
+    format!("e{i}")
+}
+
+/// Strips the common leading whitespace shared by all non-blank lines, so a
+/// script block written with source indentation re-emits cleanly.
+fn dedent(s: &str) -> String {
+    let min_indent = s
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    s.lines()
+        .map(|l| {
+            if l.len() >= min_indent {
+                &l[min_indent..]
+            } else {
+                l.trim_start()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn slot_kind_name(c: &SlotContent) -> &'static str {
+    match c {
+        SlotContent::Text(_) => "text",
+        SlotContent::If(_) => "if",
+        SlotContent::For(_) => "for",
+        SlotContent::Component(_) => "component",
+    }
+}
+
+fn has_interpolation(v: &StaticValue) -> bool {
+    v.segments
+        .iter()
+        .any(|s| matches!(s, TextSegment::Interpolation(_)))
+}
+
+/// Emits `n.childNodes[i]…` navigation from `c.root` for a positional path.
+/// `[]` is the root itself.
+fn push_node_at(b: &mut String, path: &[u32]) {
+    b.push_str("c.root");
+    for i in path {
+        b.push_str(".childNodes[");
+        b.push_str(&i.to_string());
+        b.push(']');
+    }
+}
+
+/// Emits a positional path as a JS array literal, e.g. `[0, 1]`.
+fn push_path(b: &mut String, path: &[u32]) {
+    b.push('[');
+    for (i, p) in path.iter().enumerate() {
+        if i > 0 {
+            b.push_str(", ");
+        }
+        b.push_str(&p.to_string());
+    }
+    b.push(']');
+}
+
+/// Emits a dependency-index list as a JS array literal, e.g. `[0, 2]`.
+fn push_dep_list(b: &mut String, deps: &[u32]) {
+    b.push('[');
+    for (i, d) in deps.iter().enumerate() {
+        if i > 0 {
+            b.push_str(", ");
+        }
+        b.push_str(&d.to_string());
+    }
+    b.push(']');
+}
+
+/// Emits `s` as a double-quoted JS string literal.
+fn push_js_string(b: &mut String, s: &str) {
+    b.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => b.push_str("\\\""),
+            '\\' => b.push_str("\\\\"),
+            '\n' => b.push_str("\\n"),
+            '\r' => b.push_str("\\r"),
+            '\t' => b.push_str("\\t"),
+            c => b.push(c),
+        }
+    }
+    b.push('"');
+}
+
+/// Pushes a literal chunk into a JS template literal, escaping backtick, `${`,
+/// and backslash so the literal text round-trips.
+fn push_template_literal_chunk(b: &mut String, s: &str) {
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '`' => b.push_str("\\`"),
+            '\\' => b.push_str("\\\\"),
+            '$' if chars.peek() == Some(&'{') => b.push_str("\\$"),
+            c => b.push(c),
+        }
+    }
+}

--- a/crates/lunas_compiler/src/codegen/mod.rs
+++ b/crates/lunas_compiler/src/codegen/mod.rs
@@ -5,6 +5,8 @@
 //! the JS emitter (next pass) turns that plus the resolved reactivity into the
 //! final module text.
 
+pub mod emit;
 pub mod skeleton;
 
+pub use emit::compile;
 pub use skeleton::{build_skeleton, DynamicElement, InsertPos, Skeleton, Slot, SlotContent};

--- a/crates/lunas_compiler/src/lib.rs
+++ b/crates/lunas_compiler/src/lib.rs
@@ -32,6 +32,7 @@ pub mod codegen;
 mod model;
 mod reactivity;
 
+pub use codegen::compile;
 pub use model::{Deps, DynamicKind, DynamicPart, ReactiveVar, ResolvedComponent, ResolvedHandler};
 
 /// Parses and resolves a `.lunas` source string into a [`ResolvedComponent`].

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -1,0 +1,191 @@
+//! Snapshot + robustness tests for the JS emitter (`compile`). Snapshots are
+//! kept inline: the exact emitted text is the contract with the runtime, so a
+//! change should be a visible diff here.
+
+use lunas_compiler::compile;
+
+/// Compiles and asserts no error diagnostics, returning the module text.
+fn emit(source: &str) -> String {
+    let (js, diags) = compile(source);
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "unexpected error diagnostics: {diags:?}"
+    );
+    js.expect("module emitted")
+}
+
+#[test]
+fn plain_text_bind() {
+    let js = emit(
+        "html:\n    <p>${count}</p>\nscript:\n    let count = 0\n    function inc(){ count++ }\n",
+    );
+    assert_eq!(
+        js,
+        "\
+import { component, anchorAppend, bind, box } from \"lunas\";
+
+const HTML = \"<p></p>\";
+
+export default component(\"div\", {}, HTML, (c, props) => {
+  const count = box(c, 0, 0)
+  function inc(){ count.v++ }
+  const t0 = anchorAppend(c.root.childNodes[0]);
+  bind(c, [0], () => { t0.data = `${count.v}`; });
+});
+"
+    );
+}
+
+#[test]
+fn mixed_text_run_is_one_node() {
+    let js = emit(
+        "html:\n    <p>count: ${count}!</p>\nscript:\n    let count = 0\n    function inc(){ count++ }\n",
+    );
+    // The literal "count: " and "!" live in the dynamic text node, not the HTML.
+    assert!(js.contains("const HTML = \"<p></p>\";"), "{js}");
+    assert!(
+        js.contains("t0.data = `count: ${count.v}!`;"),
+        "run reproduced as one template literal: {js}"
+    );
+    assert!(js.contains("bind(c, [0]"), "{js}");
+}
+
+#[test]
+fn static_text_interpolation_no_bind() {
+    // No reactive dep -> assigned once at build, no bind.
+    let js = emit("html:\n    <p>${WIDTH}</p>\nscript:\n    const WIDTH = 5\n");
+    assert!(js.contains("t0.data = `${WIDTH}`;"), "{js}");
+    assert!(
+        !js.contains("bind("),
+        "no bind for static interpolation: {js}"
+    );
+}
+
+#[test]
+fn bound_attribute() {
+    let js = emit(
+        "html:\n    <div :title=\"label\"></div>\nscript:\n    let label = \"hi\"\n    function set(){ label = \"yo\" }\n",
+    );
+    assert!(js.contains("e0.setAttribute(\"title\", label.v);"), "{js}");
+    assert!(js.contains("bind(c, [0], () => {"), "{js}");
+}
+
+#[test]
+fn value_attribute_uses_property() {
+    let js = emit(
+        "html:\n    <input :value=\"name\">\nscript:\n    let name = \"a\"\n    function f(){ name = \"b\" }\n",
+    );
+    assert!(
+        js.contains("e0.value = name.v;"),
+        "value via property: {js}"
+    );
+}
+
+#[test]
+fn boolean_attribute_uses_property() {
+    let js = emit(
+        "html:\n    <input :disabled=\"locked\">\nscript:\n    let locked = false\n    function f(){ locked = true }\n",
+    );
+    assert!(
+        js.contains("e0.disabled = !!(locked.v);"),
+        "boolean via property with truthiness: {js}"
+    );
+}
+
+#[test]
+fn interpolated_static_attribute() {
+    let js = emit(
+        "html:\n    <div class=\"a ${x} b\"></div>\nscript:\n    let x = \"m\"\n    function f(){ x = \"n\" }\n",
+    );
+    assert!(
+        js.contains("e0.setAttribute(\"class\", `a ${x.v} b`);"),
+        "{js}"
+    );
+    assert!(js.contains("bind(c, [0]"), "{js}");
+}
+
+#[test]
+fn event_listener() {
+    let js = emit(
+        "html:\n    <button @click=\"inc()\">x</button>\nscript:\n    let n = 0\n    function inc(){ n++ }\n",
+    );
+    assert!(js.contains("on(e0, \"click\", () => { inc(); });"), "{js}");
+}
+
+#[test]
+fn props_seeded_from_input() {
+    let js = emit(
+        "@input start:number = 0\nhtml:\n    <p>${start}</p>\nscript:\n    let count = start\n    function f(){ count = 1 }\n",
+    );
+    assert!(js.contains("let start = props.start ?? (0);"), "{js}");
+}
+
+#[test]
+fn deep_mutation_uses_deepbox() {
+    // `o.k = 1` mutates a member, so `o` is reactive (root reported) *and*
+    // deeply mutated -> deepBox.
+    let js =
+        emit("html:\n    <p>${o.k}</p>\nscript:\n    let o = {}\n    function add(){ o.k = 1 }\n");
+    assert!(
+        js.contains("deepBox(c, 0, {})"),
+        "deep mutation -> deepBox: {js}"
+    );
+    assert!(
+        js.contains("import { component, anchorAppend, bind, deepBox }"),
+        "{js}"
+    );
+    // The template read is rewritten through the box.
+    assert!(js.contains("t0.data = `${o.v.k}`;"), "{js}");
+}
+
+#[test]
+fn two_way_binding_is_voided_with_diagnostic() {
+    let (js, diags) = compile(
+        "html:\n    <input ::value=\"name\">\nscript:\n    let name = \"a\"\n    function f(){ name = \"b\" }\n",
+    );
+    let js = js.expect("module still emitted");
+    assert!(js.contains("/* TODO(wave2): two-way ::value"), "{js}");
+    assert!(
+        diags
+            .iter()
+            .any(|d| !d.is_error() && d.message.contains("two-way")),
+        "a non-fatal diagnostic is reported: {diags:?}"
+    );
+}
+
+#[test]
+fn if_slot_voided_gracefully() {
+    let js = emit("html:\n    <div><span :if=\"c\">y</span></div>\nscript:\n    let c = true\n    function t(){ c = false }\n");
+    assert!(js.contains("/* TODO(wave2): if block"), "{js}");
+    // Still a valid module.
+    assert!(js.starts_with("import { component"), "{js}");
+}
+
+#[test]
+fn no_template_emits_nothing() {
+    let (js, diags) = compile("script:\n    let x = 0\n");
+    assert!(js.is_none());
+    assert!(!diags.iter().any(|d| d.is_error()));
+}
+
+// --- robustness: never panic ---------------------------------------------
+
+#[test]
+fn malformed_inputs_do_not_panic() {
+    let cases = [
+        "",
+        "html:",
+        "html:\n    <div :if=\"\" :for=\"\" @click=\"\">${}</div>",
+        "html:\n    <p>${ a.b.c( }</p>\nscript:\n    let a = 0",
+        "@input\n@use\nhtml:\n    <X/>",
+        "html:\n    <button @click=\"a = b = c++\">x</button>\nscript:\n    let a=0\n    let b=0",
+        "html:\n    <li :for=\"x of\">y</li>\nscript:\n    let z = 0",
+        "html:\n    <p>${日本語}</p>\nscript:\n    let 日本語 = 0\n    function f(){ 日本語 = 1 }",
+        "html:\n    <div :x=\"{ a }\"></div>\nscript:\n    let a = 0\n    function f(){ a = 1 }",
+        "html:\n    <p>a ${x} b ${y} c</p>\nscript:\n    let x=0\n    let y=0\n    function f(){ x=1; y=2 }",
+        "html:\n    <input ::value=\"o.k\">\nscript:\n    let o = {}\n    function f(){ o.k = 1 }",
+    ];
+    for case in cases {
+        let (_js, _diags) = compile(case);
+    }
+}

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -1,0 +1,153 @@
+//! Execution test: compiles a component with `compile`, then *runs* the emitted
+//! ES module against the real runtime (`packages/lunas/src`) under Node using a
+//! dependency-free DOM shim. Verifies initial render and an event → state
+//! change → text update.
+//!
+//! Skipped gracefully (with an eprintln) if Node is not available at the pinned
+//! path, so CI without that toolchain still passes.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+const NODE: &str = concat!(env!("HOME"), "/.nvm/versions/node/v22.18.0/bin/node");
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = crates/lunas_compiler
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn node_available() -> bool {
+    std::path::Path::new(NODE).exists()
+}
+
+/// Writes the emitted module + a driver script into `packages/lunas/test`, runs
+/// node, returns stdout. The emitted module's `from "lunas"` import is rewritten
+/// to the runtime's index so node resolves it without a package install.
+fn run_component(name: &str, source: &str, driver_body: &str) -> String {
+    let (js, diags) = lunas_compiler::compile(source);
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "compile diagnostics: {diags:?}"
+    );
+    let js = js.expect("module emitted");
+    let js = js.replace("from \"lunas\";", "from \"./src/index.mjs\";");
+
+    let root = repo_root();
+    let test_dir = root.join("packages/lunas");
+    let mod_path = test_dir.join(format!("test/__exec_{name}.gen.mjs"));
+    let drv_path = test_dir.join(format!("test/__exec_{name}.drv.mjs"));
+
+    // The module imports "./src/index.mjs" — it lives at packages/lunas/, so
+    // write it there (not under test/) to keep that relative path valid.
+    let mod_at_root = test_dir.join(format!("__exec_{name}.gen.mjs"));
+    std::fs::write(&mod_at_root, &js).unwrap();
+
+    let driver = format!(
+        "import {{ installDom }} from \"./test/dom-shim.mjs\";\n\
+         import factory from \"./__exec_{name}.gen.mjs\";\n\
+         const tick = () => new Promise((r) => setTimeout(r, 0));\n\
+         installDom();\n\
+         {driver_body}\n"
+    );
+    let drv_at_root = test_dir.join(format!("__exec_{name}.drv.mjs"));
+    std::fs::write(&drv_at_root, driver).unwrap();
+
+    let out = Command::new(NODE)
+        .arg(&drv_at_root)
+        .current_dir(&test_dir)
+        .output()
+        .expect("spawn node");
+
+    // Clean up generated files.
+    let _ = std::fs::remove_file(&mod_at_root);
+    let _ = std::fs::remove_file(&drv_at_root);
+    let _ = std::fs::remove_file(&mod_path);
+    let _ = std::fs::remove_file(&drv_path);
+
+    if !out.status.success() {
+        std::io::stderr().write_all(&out.stderr).unwrap();
+        panic!("node exited with failure for {name}");
+    }
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn counter_renders_and_reacts() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    let source = "@input start:number = 0\n\
+        html:\n\
+        \x20   <button @click=\"inc()\">count: ${count}</button>\n\
+        script:\n\
+        \x20   let count = start\n\
+        \x20   function inc(){ count++ }\n";
+
+    let driver = "\
+        const root = factory({ start: 2 });\n\
+        const btn = root.childNodes[0];\n\
+        console.log('INITIAL:' + btn.innerHTMLString());\n\
+        btn.dispatch('click');\n\
+        await tick();\n\
+        console.log('AFTER:' + btn.innerHTMLString());\n";
+
+    let out = run_component("counter", source, driver);
+    assert!(out.contains("INITIAL:count: 2"), "initial render: {out}");
+    assert!(out.contains("AFTER:count: 3"), "post-event render: {out}");
+}
+
+#[test]
+fn attr_bind_reacts() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    let source = "html:\n\
+        \x20   <input :value=\"name\" @focus=\"clear()\">\n\
+        script:\n\
+        \x20   let name = \"alice\"\n\
+        \x20   function clear(){ name = \"\" }\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const input = root.childNodes[0];\n\
+        console.log('INITIAL:' + input.value);\n\
+        input.dispatch('focus');\n\
+        await tick();\n\
+        console.log('AFTER:[' + input.value + ']');\n";
+
+    let out = run_component("attr", source, driver);
+    assert!(out.contains("INITIAL:alice"), "initial value: {out}");
+    assert!(out.contains("AFTER:[]"), "post-event value: {out}");
+}
+
+#[test]
+fn mixed_text_anchor_updates_in_place() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Interpolation between two static text runs: the anchor is a split text
+    // node; only the dynamic node's data changes on update.
+    let source = "html:\n\
+        \x20   <p>a=${a} b=${b}!</p>\n\
+        script:\n\
+        \x20   let a = 1\n\
+        \x20   let b = 2\n\
+        \x20   function bumpA(){ a = 9 }\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const p = root.childNodes[0];\n\
+        console.log('INITIAL:' + p.innerHTMLString());\n";
+
+    let out = run_component("mixed", source, driver);
+    assert!(out.contains("INITIAL:a=1 b=2!"), "mixed render: {out}");
+}

--- a/crates/lunas_parser/docs/ROADMAP.md
+++ b/crates/lunas_parser/docs/ROADMAP.md
@@ -84,8 +84,13 @@ Legend: `[x]` done · `[ ]` remaining · `[~]` partial / documented limitation.
 - [x] `examples/resolve_demo.rs`; robustness/never-panic tests
 
 ## Remaining (separate phase, owner decision required)
-- [ ] **Code generator** — emit JS + reactivity wiring from a `ResolvedComponent`
-      (the project is built up to *just before* this; needs the runtime API spec)
+- [~] **Code generator** — emit JS + reactivity wiring from a `ResolvedComponent`
+      - [x] Wave 1 (`lunas_compiler::compile`): static skeleton + positional
+            refs + runtime text anchors + reactive text/attr binds + event
+            listeners; script rewrite (reactive `let` → box, refs → `.v`).
+            Verified end-to-end against the real runtime under Node.
+      - [ ] Wave 2: `:if` / `:for` / two-way / child components (currently voided
+            with a `/* TODO(wave2) */` marker so modules still compile & run).
 - [ ] `lunas_css` crate for `style:` scoping (style is raw text today, by design)
 
 ## Status

--- a/packages/lunas/test/dom-shim.mjs
+++ b/packages/lunas/test/dom-shim.mjs
@@ -1,0 +1,191 @@
+// dom-shim.mjs — a minimal, dependency-free DOM sufficient to *run* a compiled
+// Lunas component: it supports the narrow surface the runtime + emitted code
+// touch, plus an `innerHTML` setter that parses the comment-free, whitespace-
+// free static skeleton the compiler emits.
+//
+// This is a test fixture, not a spec-compliant DOM. It parses only the subset
+// the skeleton pass produces: nested tags, void elements, plain text, and
+// double-quoted attributes. That is exactly what `build_skeleton` emits.
+//
+// Installing this sets a global `document`, which the runtime's
+// `component()`/anchor helpers read.
+
+class FakeNode {
+  constructor(doc, kind, data) {
+    this.ownerDocument = doc;
+    this.kind = kind; // "element" | "text"
+    this.data = data || "";
+    this.childNodes = [];
+    this.parentNode = null;
+    this.attributes = {};
+    this._listeners = {};
+    this._props = {}; // IDL properties set via `el.value = …` etc.
+  }
+  insertBefore(n, ref) {
+    if (n.parentNode) n.parentNode._drop(n);
+    const at =
+      ref === null || ref === undefined
+        ? this.childNodes.length
+        : this.childNodes.indexOf(ref);
+    this.childNodes.splice(at, 0, n);
+    n.parentNode = this;
+    return n;
+  }
+  appendChild(n) {
+    return this.insertBefore(n, null);
+  }
+  _drop(n) {
+    const i = this.childNodes.indexOf(n);
+    if (i >= 0) this.childNodes.splice(i, 1);
+    n.parentNode = null;
+  }
+  remove() {
+    if (this.parentNode) this.parentNode._drop(this);
+  }
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const sib = this.parentNode.childNodes;
+    return sib[sib.indexOf(this) + 1] || null;
+  }
+  get firstChild() {
+    return this.childNodes[0] || null;
+  }
+  splitText(off) {
+    const tail = this.ownerDocument.createTextNode(this.data.slice(off));
+    this.data = this.data.slice(0, off);
+    this.parentNode.insertBefore(tail, this.nextSibling);
+    return tail;
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  getAttribute(name) {
+    return name in this.attributes ? this.attributes[name] : null;
+  }
+  removeAttribute(name) {
+    delete this.attributes[name];
+  }
+  addEventListener(ev, fn) {
+    (this._listeners[ev] || (this._listeners[ev] = [])).push(fn);
+  }
+  dispatch(ev) {
+    for (const fn of this._listeners[ev] || []) fn({ type: ev });
+  }
+  // IDL-property reflection so `el.value`, `el.checked`, `el.disabled` behave.
+  get value() {
+    return this._props.value ?? "";
+  }
+  set value(v) {
+    this._props.value = v;
+  }
+  get checked() {
+    return !!this._props.checked;
+  }
+  set checked(v) {
+    this._props.checked = v;
+  }
+  get disabled() {
+    return !!this._props.disabled;
+  }
+  set disabled(v) {
+    this._props.disabled = v;
+  }
+  set innerHTML(html) {
+    this.childNodes.length = 0;
+    for (const n of parseHTML(html, this.ownerDocument)) {
+      this.appendChild(n);
+    }
+  }
+  // Serialize the subtree back to HTML — used to assert rendered output.
+  get outerHTML() {
+    if (this.kind === "text") return this.data;
+    let s = "<" + this.tag;
+    for (const k in this.attributes) s += ` ${k}="${this.attributes[k]}"`;
+    s += ">";
+    s += this.innerHTMLString();
+    if (!VOID.has(this.tag)) s += `</${this.tag}>`;
+    return s;
+  }
+  innerHTMLString() {
+    return this.childNodes.map((n) => n.outerHTML).join("");
+  }
+}
+
+const VOID = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
+  "param", "source", "track", "wbr",
+]);
+
+// Tiny recursive-descent parser for the skeleton subset.
+function parseHTML(html, doc) {
+  let i = 0;
+  const roots = [];
+  const stack = [];
+  const push = (node) => {
+    if (stack.length) stack[stack.length - 1].appendChild(node);
+    else roots.push(node);
+  };
+  while (i < html.length) {
+    if (html[i] === "<") {
+      if (html[i + 1] === "/") {
+        // closing tag
+        const end = html.indexOf(">", i);
+        stack.pop();
+        i = end + 1;
+      } else {
+        const end = html.indexOf(">", i);
+        const raw = html.slice(i + 1, end);
+        const { tag, attrs } = parseTag(raw);
+        const el = doc.createElement(tag);
+        for (const [k, v] of attrs) el.setAttribute(k, v);
+        push(el);
+        if (!VOID.has(tag)) stack.push(el);
+        i = end + 1;
+      }
+    } else {
+      const next = html.indexOf("<", i);
+      const end = next === -1 ? html.length : next;
+      const text = html.slice(i, end);
+      if (text.length) push(doc.createTextNode(decode(text)));
+      i = end;
+    }
+  }
+  return roots;
+}
+
+function parseTag(raw) {
+  const m = raw.match(/^([a-zA-Z][a-zA-Z0-9-]*)/);
+  const tag = m[1];
+  const attrs = [];
+  const re = /([a-zA-Z_:][a-zA-Z0-9_:.-]*)(?:="([^"]*)")?/g;
+  let rest = raw.slice(tag.length);
+  let mm;
+  while ((mm = re.exec(rest))) {
+    if (!mm[1]) continue;
+    attrs.push([mm[1], decode(mm[2] ?? "")]);
+  }
+  return { tag, attrs };
+}
+
+function decode(s) {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+export function installDom() {
+  const doc = {
+    createTextNode(data) {
+      return new FakeNode(doc, "text", data);
+    },
+    createElement(tag) {
+      const n = new FakeNode(doc, "element", "");
+      n.tag = tag;
+      return n;
+    },
+  };
+  globalThis.document = doc;
+  return doc;
+}


### PR DESCRIPTION
## What

Implements the Wave 1 JS emitter for `lunas_compiler`: a new public
`compile(source: &str) -> (Option<String>, Vec<Diagnostic>)` that turns a
`.lunas` component (without `:if`/`:for`/child-components) into a runnable ES
module targeting the runtime in `packages/lunas`.

New pass: `crates/lunas_compiler/src/codegen/emit.rs`, layered on top of the
existing `build_skeleton` static pass and the resolved reactivity model.

Roadmap items covered: **cg-refs, cg-anchors, cg-text, cg-attrs, cg-events**.

### Emitted per output-design.md
- **Positional refs** (§2/§7): `refs(c.root, [[…]])` navigating `childNodes`.
- **Runtime text anchors** (§8): `anchorBefore` / `anchorBeforeSplit` /
  `anchorAppend` — no HTML-comment anchors (benchmark-locked).
- **Reactive text binds** (§6): `${…}` runs become one text node updated via
  `bind(c, deps, () => t.data = \`…\`)` with the compile-time dep indices; a
  whole mixed run (`count: ${x}!`) is one template literal / one node.
- **Attribute binds** (§6): `:attr` and interpolated static attrs
  (`AttributeText`); `value` → property, boolean attrs (`disabled`, `checked`,
  …) → `el.prop = !!(…)`, everything else → `setAttribute`.
- **Event listeners** (§6): `@event` → `on(el, ev, () => { handler; })`; box
  setters notify, so no explicit write mask is wired at runtime.
- **Script rewrite**: reactive `let x = init` → `const x = box|deepBox(c, i,
  init)`, and every reactive reference → `x.v`, scope-aware via
  `module_binding_references` / `free_identifiers_with_spans` (shadowed locals
  untouched; object-shorthand `{ x }` expanded to `{ x: x.v }`).

### Graceful voiding (Wave 2)
`:if` / `:for` / child components / two-way bindings are not wired yet — they
emit a `/* TODO(wave2) */` marker (two-way also emits a non-fatal diagnostic)
so the module still compiles and runs. `compile` never panics on any parseable
input.

## Why
The resolution layer was built up to *just before* codegen. This is the first
pass that emits actual JS from a `ResolvedComponent`, unblocking end-to-end
compilation of the common (control-flow-free) component shape.

## Tests
- `tests/codegen_emit.rs` — inline snapshot tests (plain text bind, mixed-text
  anchor, static-once interpolation, bound attr, value/boolean property attrs,
  interpolated static attr, event listener, props seeding, deepBox selection,
  two-way voiding + diagnostic, `:if` voiding) + a never-panic robustness set.
- `tests/codegen_exec.rs` — **execution test**: compiles a component, rewrites
  its `from "lunas"` import to the real runtime, and runs the emitted module
  under Node (`v22.18.0`) against a dependency-free DOM shim, asserting initial
  render HTML and **event → state change → text update** (also an attr-bind
  reaction and a mixed-text-anchor render). Skips gracefully if Node is absent.
- `packages/lunas/test/dom-shim.mjs` — new minimal, no-dep DOM fixture with an
  `innerHTML` parser for the skeleton subset; the existing runtime test suites
  (core/boxes/blocks) still pass.

Quality gates: `cargo fmt`, `cargo clippy --workspace --all-targets -D
warnings`, and `cargo test --workspace` all green (33 test binaries, 0
failures). Node runtime suites all green.

## Contract notes / deviations
- **Root wrapper**: every component is emitted as `component("div", {}, HTML,
  setup)`. The design's single-root fast path (and multi-root fragment) are a
  later optimization; the wrapper matches the skeleton's path semantics
  (`c.root.innerHTML = HTML`, refs are `childNodes` from `c.root`) exactly.
- **deepBox heuristic**: box vs deepBox is chosen by a dependency-free textual
  scan for member/index writes and mutating array methods. Note the resolution
  layer only classifies a var reactive on *assignment* (incl. `obj.k = …`), so
  a push-only var isn't reactive yet upstream — orthogonal to this PR.
- No new runtime helpers were needed: the anchor-split helper the design
  promises already exists (`anchorBeforeSplit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)