### PR TITLE
feat(css): lunas_css crate — scoped CSS transform

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -648,6 +648,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lunas_css"
+version = "0.1.0"
+dependencies = [
+ "lunas_span",
+]
+
+[[package]]
 name = "lunas_html_parser"
 version = "0.1.0"
 dependencies = [

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "lunas_script",
     "lunas_parser",
     "lunas_compiler",
+    "lunas_css",
 ]

--- a/crates/lunas_css/Cargo.toml
+++ b/crates/lunas_css/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "lunas_css"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Component-scoped CSS transform for the Lunas compiler"
+repository = "https://github.com/lunasrun/lunas"
+
+[dependencies]
+lunas_span = { path = "../lunas_span" }
+
+[dev-dependencies]

--- a/crates/lunas_css/README.md
+++ b/crates/lunas_css/README.md
@@ -1,0 +1,68 @@
+# lunas_css
+
+Component-scoped CSS for the Lunas compiler, Vue-SFC style. Hand-written
+tokenizer and structural walker — no external CSS parser dependencies, builds
+on `wasm32-unknown-unknown`, and never panics (malformed regions pass through
+as-is with a `lunas_span::Diagnostic`).
+
+## Public API
+
+```rust
+pub fn scope_css(css: &str, scope_attr: &str) -> (String, Vec<Diagnostic>);
+pub fn scope_id(component_source: &str) -> String; // "data-lunas-<fnv1a hex>"
+```
+
+## What the transform does
+
+Every compound selector in every rule gains `[scope_attr]`:
+
+| input | output (`scope_attr = data-lunas-x`) |
+| --- | --- |
+| `.btn:hover` | `.btn[data-lunas-x]:hover` |
+| `ul li` | `ul[data-lunas-x] li[data-lunas-x]` |
+| `a > b` | `a[data-lunas-x] > b[data-lunas-x]` |
+| `::before` | `[data-lunas-x]::before` |
+| `.a :deep(.b)` | `.a[data-lunas-x] .b` |
+| `:global(.modal)` | `.modal` |
+
+At-rules:
+
+- `@media` / `@supports` / `@layer` / `@container` / `@scope` — recursed into;
+  rules inside are scoped.
+- `@keyframes name` (incl. vendor-prefixed) — renamed `name-<hash>`, and
+  `animation` / `animation-name` declarations referencing it are rewritten
+  (forward references work; a pre-pass collects names).
+- `@font-face` / `@page` / `@import` / `@charset` / unknown — passed through
+  untouched.
+
+## How codegen will use this (integration surface)
+
+Integration into `lunas_compiler` is a later task; the contract is:
+
+1. Compute the component's scope attribute once per component *type*:
+   `let attr = scope_id(component_source);` — stable across builds, so SSR
+   output and client hydration agree.
+2. **DOM side:** codegen stamps `attr` (as a value-less attribute) on the
+   component's root element and every descendant element it renders. Elements
+   rendered by *child* components do not get the parent's attribute — that is
+   exactly what makes `:deep()` meaningful.
+3. **CSS side:** the raw `style:` block text (from
+   `lunas_parser::ParsedFile::style`, verbatim with a file-absolute
+   `TextRange`) is passed through `scope_css(css, &attr)`. The rewritten CSS is
+   injected in a `<style>` tag once per component type (first mount inserts it,
+   a refcount or `Set` of injected ids prevents duplicates).
+4. Diagnostics returned by `scope_css` carry ranges relative to the style
+   block's text; rebase them onto the `.lunas` file with
+   `TextRange::shifted(style_block_start)` before rendering.
+
+## Non-goals / known limitations
+
+- Not a CSS validator: structurally unparseable regions are emitted verbatim
+  with a warning diagnostic; declarations are not grammar-checked.
+- CSS nesting (`&`) is not scoped specially — nested blocks inside a
+  qualified rule's declaration block are passed through as declarations.
+- A top-level `:global(...)` anywhere makes the *entire* selector global
+  (each wrapper is unwrapped, nothing is scoped) — Lunas does not support the
+  CSS-Modules-style mixed form where only part of a selector is global.
+- String-based rewrite: output preserves the input's formatting rather than
+  re-serializing an AST.

--- a/crates/lunas_css/src/lib.rs
+++ b/crates/lunas_css/src/lib.rs
@@ -1,0 +1,119 @@
+//! Component-scoped CSS for the Lunas compiler.
+//!
+//! This crate takes a component's raw `style:` block text and rewrites its
+//! selectors so the styles only match that component's DOM, exactly like a
+//! Vue single-file-component `<style scoped>`. It is a hand-written transform:
+//! there is no external CSS parser dependency (keeping the wasm32 build lean),
+//! and it never panics — malformed input is passed through as-is for the
+//! unparseable region and reported with a [`Diagnostic`].
+//!
+//! # What scoping means
+//!
+//! Every compound selector gains the component's scope attribute:
+//!
+//! ```
+//! use lunas_css::scope_css;
+//!
+//! let (out, diags) = scope_css(".btn:hover { color: red }", "data-lunas-x");
+//! assert_eq!(out, ".btn[data-lunas-x]:hover { color: red }");
+//! assert!(diags.is_empty());
+//! ```
+//!
+//! Descendant selectors scope every compound:
+//!
+//! ```
+//! # use lunas_css::scope_css;
+//! let (out, _) = scope_css("ul li { }", "data-lunas-x");
+//! assert_eq!(out, "ul[data-lunas-x] li[data-lunas-x] { }");
+//! ```
+//!
+//! # Escape hatches (Vue semantics)
+//!
+//! * `:deep(sel)` — the compound it is attached to is scoped, and everything
+//!   from `sel` onward is left unscoped, letting styles reach into child
+//!   components:
+//!
+//! ```
+//! # use lunas_css::scope_css;
+//! let (out, _) = scope_css(".a :deep(.b) { }", "data-lunas-x");
+//! assert_eq!(out, ".a[data-lunas-x] .b { }");
+//! ```
+//!
+//! * `:global(sel)` — the selector is emitted verbatim, unscoped:
+//!
+//! ```
+//! # use lunas_css::scope_css;
+//! let (out, _) = scope_css(":global(.modal) { }", "data-lunas-x");
+//! assert_eq!(out, ".modal { }");
+//! ```
+//!
+//! # At-rules
+//!
+//! * `@media` / `@supports` / `@layer` / `@container` — the walker recurses into
+//!   the block and scopes the rules inside.
+//! * `@keyframes name` — the animation name is renamed with a scope-derived
+//!   suffix, and `animation` / `animation-name` declarations that reference it
+//!   are rewritten to match.
+//! * `@font-face` / `@page` / `@import` / `@charset` and unknown at-rules — passed
+//!   through untouched (their bodies hold declarations, not selectors).
+//!
+//! ```
+//! # use lunas_css::scope_css;
+//! let src = "@keyframes spin { to { transform: rotate(1turn) } }\n\
+//!            .x { animation: spin 1s }";
+//! let (out, _) = scope_css(src, "data-lunas-ab12");
+//! assert!(out.contains("@keyframes spin-ab12"));
+//! assert!(out.contains("animation: spin-ab12 1s"));
+//! ```
+
+mod rewrite;
+mod scope_hash;
+mod selector;
+mod tokenizer;
+
+pub use lunas_span::Diagnostic;
+
+/// Rewrites a component's CSS so every selector is scoped by `scope_attr`.
+///
+/// `scope_attr` is the bare attribute name that codegen also stamps onto the
+/// component's DOM elements (e.g. `data-lunas-abc123`, as produced by
+/// [`scope_id`]). Each compound selector in every rule gains `[scope_attr]`.
+///
+/// The returned [`Diagnostic`]s (all warnings) describe recoverable problems
+/// such as unterminated blocks; their [`TextRange`](lunas_span::TextRange) is a
+/// byte range into the input `css`. Even when diagnostics are produced, the
+/// returned string is always a valid best-effort transform of the whole input.
+///
+/// This function never panics for any input.
+///
+/// ```
+/// use lunas_css::scope_css;
+///
+/// let (out, diags) = scope_css("a, b > c { color: red }", "data-lunas-x");
+/// assert_eq!(out, "a[data-lunas-x], b[data-lunas-x] > c[data-lunas-x] { color: red }");
+/// assert!(diags.is_empty());
+/// ```
+pub fn scope_css(css: &str, scope_attr: &str) -> (String, Vec<Diagnostic>) {
+    rewrite::rewrite_stylesheet(css, scope_attr)
+}
+
+/// Produces a short, stable scope attribute name for a component from its
+/// source text: `data-lunas-<hash>`, where `<hash>` is a hex FNV-1a digest.
+///
+/// The same source always yields the same id (stable across builds and
+/// platforms), and different sources almost always differ. Codegen uses this
+/// as the single source of truth for a component's scope: the attribute is
+/// stamped on the component's root and descendant elements, and the same string
+/// is passed to [`scope_css`] so the emitted `<style>` matches.
+///
+/// ```
+/// use lunas_css::scope_id;
+///
+/// let id = scope_id("<template>…</template>");
+/// assert!(id.starts_with("data-lunas-"));
+/// // Deterministic.
+/// assert_eq!(id, scope_id("<template>…</template>"));
+/// ```
+pub fn scope_id(component_source: &str) -> String {
+    format!("data-lunas-{}", scope_hash::fnv1a_hex(component_source))
+}

--- a/crates/lunas_css/src/rewrite.rs
+++ b/crates/lunas_css/src/rewrite.rs
@@ -1,0 +1,709 @@
+//! Structural CSS walker that drives selector scoping and at-rule handling.
+//!
+//! The walker splits a stylesheet body into a sequence of top-level items:
+//!
+//! * an **at-rule** — starts with `@`, ends at either the matching `;` (e.g.
+//!   `@import …;`) or a balanced `{ … }` block;
+//! * a **qualified rule** — a selector list followed by a `{ … }` declaration
+//!   block;
+//! * trailing junk (e.g. an unterminated block) which is emitted verbatim with
+//!   a diagnostic.
+//!
+//! Only selectors of qualified rules and the bodies of conditional group
+//! at-rules (`@media`, `@supports`, `@layer`) are rewritten. `@keyframes` are
+//! renamed; `@font-face`, `@page`, `@import`, `@charset` and unknown at-rules
+//! pass through (their bodies are declaration blocks with no selectors, so they
+//! must not be scoped).
+
+use lunas_span::{Diagnostic, TextRange};
+
+use crate::selector::{scope_complex_selector, split_selector_list};
+use crate::tokenizer::{consume_bracketed, consume_comment, consume_string, Bracket, Scanner};
+
+/// Shared state threaded through the recursive walk.
+pub(crate) struct Ctx<'a> {
+    pub(crate) scope_attr: &'a str,
+    /// Base byte offset of the region currently being walked, so diagnostics
+    /// point into the *original* css even when we recurse into a sub-slice.
+    pub(crate) base: usize,
+    pub(crate) diagnostics: Vec<Diagnostic>,
+    /// Keyframe names discovered in this stylesheet, mapped to their scoped
+    /// rename, so `animation`/`animation-name` references can be rewritten.
+    pub(crate) keyframes: Vec<(String, String)>,
+}
+
+impl Ctx<'_> {
+    fn diag(&mut self, start: usize, end: usize, msg: impl Into<String>) {
+        let range = TextRange::at((self.base + start) as u32, (self.base + end) as u32);
+        self.diagnostics.push(Diagnostic::warning(range, msg));
+    }
+}
+
+/// Rewrites a stylesheet `body`, appending output to `out`. Two passes are run:
+/// pass one collects `@keyframes` names (so forward references in `animation`
+/// resolve), pass two performs the rewrite. Both passes use the same walker.
+pub(crate) fn rewrite_stylesheet(css: &str, scope_attr: &str) -> (String, Vec<Diagnostic>) {
+    let mut ctx = Ctx {
+        scope_attr,
+        base: 0,
+        diagnostics: Vec::new(),
+        keyframes: Vec::new(),
+    };
+
+    // Pass one: collect keyframe names (no output, no diagnostics kept).
+    collect_keyframes(css, scope_attr, &mut ctx.keyframes);
+
+    let mut out = String::with_capacity(css.len() + 16);
+    walk_block(css, &mut ctx, &mut out);
+    (out, ctx.diagnostics)
+}
+
+/// Pass one: find every `@keyframes name` (and `@-*-keyframes name`) and record
+/// `name -> name-<scopehash>`.
+fn collect_keyframes(css: &str, scope_attr: &str, out: &mut Vec<(String, String)>) {
+    let suffix = keyframe_suffix(scope_attr);
+    let mut sc = Scanner::new(css);
+    while !sc.is_eof() {
+        if skip_inert(&mut sc) {
+            continue;
+        }
+        if sc.peek() == Some(b'@') {
+            let at_start = sc.pos();
+            let name = read_at_keyword(&mut sc);
+            if is_keyframes_keyword(name) {
+                // Read the animation name that follows.
+                skip_ws_and_comments(&mut sc);
+                let n_start = sc.pos();
+                read_ident(&mut sc);
+                let kf_name = &css[n_start..sc.pos()];
+                if !kf_name.is_empty() {
+                    let scoped = format!("{kf_name}-{suffix}");
+                    if !out.iter().any(|(k, _)| k == kf_name) {
+                        out.push((kf_name.to_string(), scoped));
+                    }
+                }
+                // Skip the block so nested `{` from keyframe selectors don't
+                // confuse the top-level scan.
+                skip_to_block_and_over(&mut sc);
+            } else {
+                let _ = at_start;
+                // Not keyframes: skip to end of its statement/block.
+                skip_at_rule_tail(&mut sc);
+            }
+        } else {
+            // Qualified rule: skip its block.
+            skip_prelude_and_block(&mut sc);
+        }
+    }
+}
+
+/// The recursive workhorse: walks a `{`-delimited body (or the whole sheet when
+/// `base`-relative), emitting rewritten CSS into `out`.
+fn walk_block(body: &str, ctx: &mut Ctx, out: &mut String) {
+    let mut sc = Scanner::new(body);
+    loop {
+        // Emit leading inert (whitespace/comments) verbatim.
+        let inert_start = sc.pos();
+        while skip_inert(&mut sc) {}
+        out.push_str(&body[inert_start..sc.pos()]);
+
+        if sc.is_eof() {
+            break;
+        }
+
+        if sc.peek() == Some(b'@') {
+            walk_at_rule(body, &mut sc, ctx, out);
+        } else {
+            walk_qualified_rule(body, &mut sc, ctx, out);
+        }
+    }
+}
+
+/// Handles a qualified rule: `<selector-list> { <declarations> }`.
+fn walk_qualified_rule(body: &str, sc: &mut Scanner, ctx: &mut Ctx, out: &mut String) {
+    let prelude_start = sc.pos();
+    // Scan the prelude up to the opening brace (or `;`/EOF for malformed input).
+    let brace = scan_to_brace_or_semi(sc);
+    match brace {
+        BraceScan::Brace(open) => {
+            let prelude = &body[prelude_start..open];
+            let scoped = scope_selector_list_text(prelude, ctx.scope_attr);
+            out.push_str(&scoped);
+            out.push('{');
+            // Move past `{`.
+            sc.seek(open + 1);
+            walk_declaration_block(body, sc, ctx, out);
+        }
+        BraceScan::Semi(semi) => {
+            // A stray `;` with no block — emit prelude+`;` verbatim.
+            out.push_str(&body[prelude_start..=semi]);
+            sc.seek(semi + 1);
+        }
+        BraceScan::Eof => {
+            let text = &body[prelude_start..sc.len()];
+            if !text.trim().is_empty() {
+                ctx.diag(prelude_start, sc.len(), "unterminated rule (missing `{`)");
+            }
+            out.push_str(text);
+            sc.seek(sc.len());
+        }
+    }
+}
+
+/// Walks the declarations inside a qualified rule's block, rewriting
+/// `animation`/`animation-name` values that reference a scoped keyframe. The
+/// cursor starts just after `{`.
+fn walk_declaration_block(body: &str, sc: &mut Scanner, ctx: &mut Ctx, out: &mut String) {
+    let block_start = sc.pos();
+    match balanced_block_end(sc) {
+        Some(close) => {
+            let inner = &body[block_start..close];
+            rewrite_declarations(inner, ctx, out);
+            out.push('}');
+            sc.seek(close + 1);
+        }
+        None => {
+            let inner = &body[block_start..sc.len()];
+            ctx.diag(block_start, sc.len(), "unterminated block (missing `}`)");
+            rewrite_declarations(inner, ctx, out);
+            sc.seek(sc.len());
+        }
+    }
+}
+
+/// Rewrites `animation` / `animation-name` values inside a declaration block so
+/// keyframe references point at their scoped rename. Everything else passes
+/// through byte-for-byte.
+fn rewrite_declarations(inner: &str, ctx: &mut Ctx, out: &mut String) {
+    if ctx.keyframes.is_empty() {
+        out.push_str(inner);
+        return;
+    }
+    let mut sc = Scanner::new(inner);
+    // Track declaration boundaries: a declaration is `prop : value ;`.
+    loop {
+        // Read a property name up to `:` (or `}`/`;`/EOF).
+        let seg_start = sc.pos();
+        let mut colon: Option<usize> = None;
+        while !sc.is_eof() {
+            if consume_comment(&mut sc) {
+                continue;
+            }
+            match sc.peek() {
+                Some(b'"' | b'\'') => {
+                    consume_string(&mut sc);
+                }
+                Some(b'{') => {
+                    // Nested block (shouldn't normally appear); bail to verbatim.
+                    consume_bracketed_curly(&mut sc);
+                }
+                Some(b';') => break,
+                Some(b':') => {
+                    colon = Some(sc.pos());
+                    break;
+                }
+                _ => {
+                    sc.bump();
+                }
+            }
+        }
+        let Some(colon_pos) = colon else {
+            // No `:` — emit the rest verbatim.
+            out.push_str(&inner[seg_start..sc.pos()]);
+            if sc.is_eof() {
+                break;
+            }
+            // We stopped on `;`; emit it and continue.
+            if sc.peek() == Some(b';') {
+                out.push(';');
+                sc.bump();
+            }
+            continue;
+        };
+        let prop = inner[seg_start..colon_pos].trim();
+        let is_anim =
+            prop.eq_ignore_ascii_case("animation") || prop.eq_ignore_ascii_case("animation-name");
+        // Emit `prop:`.
+        out.push_str(&inner[seg_start..=colon_pos]);
+        sc.bump(); // past `:`
+        let val_start = sc.pos();
+        // Read the value up to `;` or EOF, respecting strings/comments/parens.
+        while !sc.is_eof() {
+            if consume_comment(&mut sc) {
+                continue;
+            }
+            match sc.peek() {
+                Some(b'"' | b'\'') => {
+                    consume_string(&mut sc);
+                }
+                Some(b'(') => {
+                    consume_bracketed(&mut sc, Bracket::Paren);
+                }
+                Some(b';') => break,
+                _ => {
+                    sc.bump();
+                }
+            }
+        }
+        let value = &inner[val_start..sc.pos()];
+        if is_anim {
+            out.push_str(&rewrite_animation_value(value, &ctx.keyframes));
+        } else {
+            out.push_str(value);
+        }
+        if sc.peek() == Some(b';') {
+            out.push(';');
+            sc.bump();
+        } else {
+            break;
+        }
+    }
+}
+
+/// Replaces whole-token keyframe names inside an `animation`/`animation-name`
+/// value. Tokens are runs of ident characters; only exact matches are renamed.
+fn rewrite_animation_value(value: &str, keyframes: &[(String, String)]) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if is_ident_byte(b) || b == b'-' {
+            let start = i;
+            while i < bytes.len() && (is_ident_byte(bytes[i]) || bytes[i] == b'-') {
+                i += 1;
+            }
+            let tok = &value[start..i];
+            if let Some((_, scoped)) = keyframes.iter().find(|(k, _)| k == tok) {
+                out.push_str(scoped);
+            } else {
+                out.push_str(tok);
+            }
+        } else {
+            // Copy the (possibly multi-byte) char verbatim.
+            let ch_len = utf8_len(b);
+            let end = (i + ch_len).min(bytes.len());
+            out.push_str(&value[i..end]);
+            i = end;
+        }
+    }
+    out
+}
+
+/// Handles any at-rule.
+fn walk_at_rule(body: &str, sc: &mut Scanner, ctx: &mut Ctx, out: &mut String) {
+    let at_start = sc.pos();
+    let name = read_at_keyword(sc);
+
+    if is_conditional_group(name) {
+        // `@media (...)` / `@supports (...)` / `@layer name` { <rules> }
+        // Emit the prelude verbatim, then recurse into the block.
+        let prelude_start = sc.pos();
+        match scan_to_brace_or_semi(sc) {
+            BraceScan::Brace(open) => {
+                out.push_str(&body[at_start..open]);
+                out.push('{');
+                let block_start = open + 1;
+                sc.seek(block_start);
+                match balanced_block_end(sc) {
+                    Some(close) => {
+                        let inner = &body[block_start..close];
+                        // Recurse with a shifted base for correct diagnostics.
+                        let saved_base = ctx.base;
+                        ctx.base = saved_base + block_start;
+                        walk_block(inner, ctx, out);
+                        ctx.base = saved_base;
+                        out.push('}');
+                        sc.seek(close + 1);
+                    }
+                    None => {
+                        let inner = &body[block_start..sc.len()];
+                        ctx.diag(block_start, sc.len(), "unterminated at-rule block");
+                        let saved_base = ctx.base;
+                        ctx.base = saved_base + block_start;
+                        walk_block(inner, ctx, out);
+                        ctx.base = saved_base;
+                        sc.seek(sc.len());
+                    }
+                }
+            }
+            BraceScan::Semi(semi) => {
+                // `@layer a, b;` — statement form. Pass through.
+                out.push_str(&body[at_start..=semi]);
+                sc.seek(semi + 1);
+            }
+            BraceScan::Eof => {
+                out.push_str(&body[at_start..sc.len()]);
+                let _ = prelude_start;
+                sc.seek(sc.len());
+            }
+        }
+    } else if is_keyframes_keyword(name) {
+        walk_keyframes(body, sc, at_start, ctx, out);
+    } else {
+        // @font-face / @page / @import / @charset / unknown: pass through.
+        // Their body (if any) is a declaration block with no selectors.
+        match scan_to_brace_or_semi(sc) {
+            BraceScan::Brace(open) => {
+                out.push_str(&body[at_start..=open]);
+                let block_start = open + 1;
+                sc.seek(block_start);
+                match balanced_block_end(sc) {
+                    Some(close) => {
+                        // Rewrite declarations (for animation refs) but do NOT
+                        // scope selectors.
+                        let inner = &body[block_start..close];
+                        rewrite_declarations(inner, ctx, out);
+                        out.push('}');
+                        sc.seek(close + 1);
+                    }
+                    None => {
+                        let inner = &body[block_start..sc.len()];
+                        ctx.diag(block_start, sc.len(), "unterminated at-rule block");
+                        out.push_str(inner);
+                        sc.seek(sc.len());
+                    }
+                }
+            }
+            BraceScan::Semi(semi) => {
+                out.push_str(&body[at_start..=semi]);
+                sc.seek(semi + 1);
+            }
+            BraceScan::Eof => {
+                out.push_str(&body[at_start..sc.len()]);
+                sc.seek(sc.len());
+            }
+        }
+    }
+}
+
+/// Rewrites `@keyframes name { … }` → `@keyframes name-<suffix> { … }`. The
+/// keyframe selectors inside (`from`, `to`, `0%`…) are NOT scoped.
+fn walk_keyframes(body: &str, sc: &mut Scanner, at_start: usize, ctx: &mut Ctx, out: &mut String) {
+    // Emit `@keyframes` (and any vendor prefix) verbatim up to the name.
+    let after_kw = sc.pos();
+    out.push_str(&body[at_start..after_kw]);
+    skip_ws_and_comments_emit(body, sc, out);
+    let name_start = sc.pos();
+    read_ident(sc);
+    let name = &body[name_start..sc.pos()];
+    if let Some((_, scoped)) = ctx.keyframes.iter().find(|(k, _)| k == name) {
+        out.push_str(scoped);
+    } else {
+        out.push_str(name);
+    }
+    // Emit the rest (the `{ … }` block) verbatim.
+    let after_name = sc.pos();
+    match scan_to_brace_or_semi(sc) {
+        BraceScan::Brace(open) => {
+            out.push_str(&body[after_name..=open]);
+            let block_start = open + 1;
+            sc.seek(block_start);
+            match balanced_block_end(sc) {
+                Some(close) => {
+                    out.push_str(&body[block_start..close]);
+                    out.push('}');
+                    sc.seek(close + 1);
+                }
+                None => {
+                    ctx.diag(block_start, sc.len(), "unterminated @keyframes block");
+                    out.push_str(&body[block_start..sc.len()]);
+                    sc.seek(sc.len());
+                }
+            }
+        }
+        BraceScan::Semi(semi) => {
+            out.push_str(&body[after_name..=semi]);
+            sc.seek(semi + 1);
+        }
+        BraceScan::Eof => {
+            out.push_str(&body[after_name..sc.len()]);
+            sc.seek(sc.len());
+        }
+    }
+}
+
+/// Scopes a raw selector-list text (the prelude before `{`), preserving the
+/// original whitespace around commas as far as reasonable.
+fn scope_selector_list_text(list: &str, scope_attr: &str) -> String {
+    let parts = split_selector_list(list);
+    let mut out = String::with_capacity(list.len() + scope_attr.len() + 4);
+    for (i, (s, e)) in parts.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        let sel = &list[*s..*e];
+        // Preserve leading/trailing whitespace of the selector so formatting is
+        // stable; scope only the trimmed core. A whitespace-only selector (e.g.
+        // around a stray comma) passes through verbatim.
+        if sel.trim().is_empty() {
+            out.push_str(sel);
+            continue;
+        }
+        let leading_len = sel.len() - sel.trim_start().len();
+        let trailing_len = sel.len() - sel.trim_end().len();
+        let core = &sel[leading_len..sel.len() - trailing_len];
+        out.push_str(&sel[..leading_len]);
+        out.push_str(&scope_complex_selector(core, scope_attr));
+        out.push_str(&sel[sel.len() - trailing_len..]);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Low-level scanning helpers (structure only; no rewriting).
+// ---------------------------------------------------------------------------
+
+enum BraceScan {
+    Brace(usize),
+    Semi(usize),
+    Eof,
+}
+
+/// Scans forward until the first top-level `{` or `;`, respecting strings,
+/// comments, escapes, and paren/bracket nesting. Leaves the cursor *at* the
+/// terminator.
+fn scan_to_brace_or_semi(sc: &mut Scanner) -> BraceScan {
+    while !sc.is_eof() {
+        if consume_comment(sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'(') => {
+                consume_bracketed(sc, Bracket::Paren);
+            }
+            Some(b'[') => {
+                consume_bracketed(sc, Bracket::Square);
+            }
+            Some(b'{') => {
+                let p = sc.pos();
+                return BraceScan::Brace(p);
+            }
+            Some(b';') => {
+                let p = sc.pos();
+                return BraceScan::Semi(p);
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    BraceScan::Eof
+}
+
+/// Given a cursor just after an opening `{`, returns the byte position of the
+/// matching `}`, respecting nesting/strings/comments. Leaves the cursor *at*
+/// the closing brace on success, or at EOF if unbalanced. Returns `None` if
+/// unbalanced.
+fn balanced_block_end(sc: &mut Scanner) -> Option<usize> {
+    let mut depth = 1usize;
+    while !sc.is_eof() {
+        if consume_comment(sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'(') => {
+                consume_bracketed(sc, Bracket::Paren);
+            }
+            Some(b'[') => {
+                consume_bracketed(sc, Bracket::Square);
+            }
+            Some(b'{') => {
+                depth += 1;
+                sc.bump();
+            }
+            Some(b'}') => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(sc.pos());
+                }
+                sc.bump();
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    None
+}
+
+/// Consumes a balanced `{ … }` group starting at the cursor (used only as a
+/// bail-out inside declaration parsing).
+fn consume_bracketed_curly(sc: &mut Scanner) {
+    if sc.peek() != Some(b'{') {
+        return;
+    }
+    sc.bump();
+    let _ = balanced_block_end(sc);
+    if sc.peek() == Some(b'}') {
+        sc.bump();
+    }
+}
+
+/// Skips one inert construct (whitespace run or comment). Returns `true` if it
+/// advanced.
+fn skip_inert(sc: &mut Scanner) -> bool {
+    if consume_comment(sc) {
+        return true;
+    }
+    if matches!(sc.peek(), Some(b' ' | b'\t' | b'\n' | b'\r') | Some(0x0c)) {
+        while matches!(sc.peek(), Some(b' ' | b'\t' | b'\n' | b'\r') | Some(0x0c)) {
+            sc.bump();
+        }
+        return true;
+    }
+    false
+}
+
+fn skip_ws_and_comments(sc: &mut Scanner) {
+    while skip_inert(sc) {}
+}
+
+fn skip_ws_and_comments_emit(body: &str, sc: &mut Scanner, out: &mut String) {
+    let start = sc.pos();
+    while skip_inert(sc) {}
+    out.push_str(&body[start..sc.pos()]);
+}
+
+/// Reads an at-keyword `@name`, returning the name without the `@`. The cursor
+/// starts on `@` and ends just after the keyword.
+fn read_at_keyword<'a>(sc: &mut Scanner<'a>) -> &'a str {
+    debug_assert_eq!(sc.peek(), Some(b'@'));
+    sc.bump(); // '@'
+    let start = sc.pos();
+    // Vendor prefixes and names: [-a-zA-Z0-9].
+    while matches!(sc.peek(), Some(b) if is_ident_byte(b) || b == b'-') {
+        sc.bump();
+    }
+    &sc.src()[start..sc.pos()]
+}
+
+/// Reads a CSS identifier at the cursor (used for keyframe/animation names).
+fn read_ident(sc: &mut Scanner) {
+    while let Some(b) = sc.peek() {
+        if b == b'\\' {
+            sc.bump();
+            sc.bump();
+        } else if is_ident_byte(b) || b == b'-' || b >= 0x80 {
+            sc.bump();
+        } else {
+            break;
+        }
+    }
+}
+
+// --- pass-one skip helpers (structure only, no output) ---
+
+fn skip_at_rule_tail(sc: &mut Scanner) {
+    match scan_to_brace_or_semi(sc) {
+        BraceScan::Brace(open) => {
+            sc.seek(open + 1);
+            if let Some(close) = balanced_block_end(sc) {
+                sc.seek(close + 1);
+            } else {
+                sc.seek(sc.len());
+            }
+        }
+        BraceScan::Semi(semi) => sc.seek(semi + 1),
+        BraceScan::Eof => sc.seek(sc.len()),
+    }
+}
+
+fn skip_prelude_and_block(sc: &mut Scanner) {
+    match scan_to_brace_or_semi(sc) {
+        BraceScan::Brace(open) => {
+            sc.seek(open + 1);
+            if let Some(close) = balanced_block_end(sc) {
+                sc.seek(close + 1);
+            } else {
+                sc.seek(sc.len());
+            }
+        }
+        BraceScan::Semi(semi) => sc.seek(semi + 1),
+        BraceScan::Eof => sc.seek(sc.len()),
+    }
+}
+
+fn skip_to_block_and_over(sc: &mut Scanner) {
+    match scan_to_brace_or_semi(sc) {
+        BraceScan::Brace(open) => {
+            sc.seek(open + 1);
+            if let Some(close) = balanced_block_end(sc) {
+                sc.seek(close + 1);
+            } else {
+                sc.seek(sc.len());
+            }
+        }
+        BraceScan::Semi(semi) => sc.seek(semi + 1),
+        BraceScan::Eof => sc.seek(sc.len()),
+    }
+}
+
+fn is_conditional_group(name: &str) -> bool {
+    let n = strip_vendor(name);
+    n.eq_ignore_ascii_case("media")
+        || n.eq_ignore_ascii_case("supports")
+        || n.eq_ignore_ascii_case("layer")
+        || n.eq_ignore_ascii_case("container")
+        || n.eq_ignore_ascii_case("scope")
+}
+
+fn is_keyframes_keyword(name: &str) -> bool {
+    strip_vendor(name).eq_ignore_ascii_case("keyframes")
+}
+
+/// Strips a leading vendor prefix like `-webkit-` from an at-keyword name.
+fn strip_vendor(name: &str) -> &str {
+    if let Some(rest) = name.strip_prefix('-') {
+        if let Some(dash) = rest.find('-') {
+            return &rest[dash + 1..];
+        }
+    }
+    name
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+}
+
+fn utf8_len(first: u8) -> usize {
+    match first {
+        0x00..=0x7f => 1,
+        0xc0..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf7 => 4,
+        _ => 1,
+    }
+}
+
+/// The suffix appended to keyframe names. Derived from the scope attribute so
+/// two components with different scopes get distinct animation names. We reuse
+/// the hash embedded in the attribute (`data-lunas-<hash>` → `<hash>`); if the
+/// attribute has no recognizable hash we fall back to the whole attribute with
+/// non-ident bytes stripped.
+fn keyframe_suffix(scope_attr: &str) -> String {
+    let tail = scope_attr.rsplit('-').next().unwrap_or(scope_attr);
+    let cleaned: String = tail
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if cleaned.is_empty() {
+        "lunas".to_string()
+    } else {
+        cleaned
+    }
+}

--- a/crates/lunas_css/src/scope_hash.rs
+++ b/crates/lunas_css/src/scope_hash.rs
@@ -1,0 +1,40 @@
+//! A tiny inline FNV-1a hash, so scope ids need no external dependency and
+//! stay identical across platforms and the wasm32 target.
+
+/// 32-bit FNV-1a of `input`, rendered as 8 lowercase hex digits.
+pub(crate) fn fnv1a_hex(input: &str) -> String {
+    const OFFSET: u32 = 0x811c_9dc5;
+    const PRIME: u32 = 0x0100_0193;
+    let mut hash = OFFSET;
+    for &b in input.as_bytes() {
+        hash ^= b as u32;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    format!("{hash:08x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_and_hex() {
+        let a = fnv1a_hex("hello");
+        let b = fnv1a_hex("hello");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 8);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn distinct_inputs_differ() {
+        assert_ne!(fnv1a_hex("a"), fnv1a_hex("b"));
+        assert_ne!(fnv1a_hex(""), fnv1a_hex("x"));
+    }
+
+    #[test]
+    fn known_vector() {
+        // FNV-1a 32-bit of the empty string is the offset basis.
+        assert_eq!(fnv1a_hex(""), "811c9dc5");
+    }
+}

--- a/crates/lunas_css/src/selector.rs
+++ b/crates/lunas_css/src/selector.rs
@@ -1,0 +1,452 @@
+//! Selector-list rewriting.
+//!
+//! Given the raw selector text that precedes a `{` (a *selector list*, e.g.
+//! `.a, ul li`), this module rewrites each selector so every compound selector
+//! carries the scope attribute, Vue-SFC style:
+//!
+//! ```text
+//! .btn:hover        →  .btn[data-lunas-x]:hover
+//! ul li             →  ul[data-lunas-x] li[data-lunas-x]
+//! a > b             →  a[data-lunas-x] > b[data-lunas-x]
+//! ```
+//!
+//! `:deep(inner)` scopes the compound it is attached to, then leaves everything
+//! after it untouched. `:global(sel)` drops the pseudo and leaves its argument
+//! fully unscoped.
+
+use crate::tokenizer::{consume_bracketed, consume_comment, consume_string, Bracket, Scanner};
+
+/// Splits a selector list into its top-level selectors (comma-separated),
+/// respecting strings, comments, escapes, and bracket/paren nesting. Returns
+/// each selector as a byte range `[start, end)` into `list`.
+pub(crate) fn split_selector_list(list: &str) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    let mut sc = Scanner::new(list);
+    let mut start = 0usize;
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(&mut sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'(') => {
+                consume_bracketed(&mut sc, Bracket::Paren);
+            }
+            Some(b'[') => {
+                consume_bracketed(&mut sc, Bracket::Square);
+            }
+            Some(b',') => {
+                out.push((start, sc.pos()));
+                sc.bump();
+                start = sc.pos();
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    out.push((start, sc.len()));
+    out
+}
+
+/// A single lexical unit of a complex selector: either a combinator (` `, `>`,
+/// `+`, `~`) or a compound selector (a run of simple selectors with no
+/// combinator between them).
+enum Unit {
+    /// A combinator token, kept verbatim including surrounding whitespace.
+    Combinator(String),
+    /// A compound selector's byte range `[start, end)` into the selector text.
+    Compound(usize, usize),
+}
+
+/// Rewrites one complex selector (no top-level commas) by attaching the scope
+/// attribute to each compound selector. `scope_attr` is the bare attribute name
+/// (e.g. `data-lunas-abc`); it is wrapped in `[…]` here.
+///
+/// `:deep(x)` — the compound it is attached to is scoped, then the descendant
+/// combinator and `x` are emitted unscoped. `:global(x)` — the whole selector
+/// from that point is emitted unscoped (Vue treats `:global` as a top-level
+/// escape hatch; we scope nothing once it appears).
+pub(crate) fn scope_complex_selector(sel: &str, scope_attr: &str) -> String {
+    // Whitespace-only or empty (can happen with trailing commas): pass through.
+    if sel.trim().is_empty() {
+        return sel.to_string();
+    }
+
+    // A top-level `:global(...)` anywhere means the selector is authored as
+    // global: nothing in it is scoped, and each `:global(x)` wrapper is
+    // unwrapped to `x`, matching Vue.
+    if let Some(unwrapped) = strip_globals(sel) {
+        return unwrapped;
+    }
+
+    let units = split_units(sel);
+    let mut out = String::with_capacity(sel.len() + scope_attr.len() + 2);
+    let mut deep_reached = false;
+
+    for unit in &units {
+        match unit {
+            Unit::Combinator(c) => out.push_str(c),
+            Unit::Compound(s, e) => {
+                let text = &sel[*s..*e];
+                if deep_reached {
+                    // Past a :deep(): emit compounds untouched.
+                    out.push_str(text);
+                    continue;
+                }
+                match find_deep(text) {
+                    Some((before, inner, after)) => {
+                        // `before:deep(inner)after` → scope `before`, then emit
+                        // `inner` (unscoped) followed by `after` unscoped, and
+                        // stop scoping the rest of the selector.
+                        let scoped_before = attach_scope(before, scope_attr);
+                        out.push_str(&scoped_before);
+                        if !inner.is_empty() {
+                            // Separate the scoped compound from the deep target
+                            // with a descendant combinator, mirroring Vue.
+                            if !scoped_before.is_empty() {
+                                out.push(' ');
+                            }
+                            out.push_str(inner);
+                        }
+                        out.push_str(after);
+                        deep_reached = true;
+                    }
+                    None => {
+                        out.push_str(&attach_scope(text, scope_attr));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// If `sel` contains a top-level `:global(...)`, returns the selector with each
+/// such wrapper replaced by its inner content (and nothing scoped). Returns
+/// `None` when the selector has no top-level `:global`.
+fn strip_globals(sel: &str) -> Option<String> {
+    let mut out = String::with_capacity(sel.len());
+    let mut found = false;
+    let mut sc = Scanner::new(sel);
+    let mut copied_to = 0usize;
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(&mut sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'[') => {
+                consume_bracketed(&mut sc, Bracket::Square);
+            }
+            Some(b':') if sc.starts_with(":global") => {
+                let kw_start = sc.pos();
+                for _ in 0..7 {
+                    sc.bump();
+                }
+                // Reject `:global-foo` style idents (longer keyword).
+                if matches!(sc.peek(), Some(b) if is_ident_like(b)) {
+                    continue;
+                }
+                while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                    sc.bump();
+                }
+                if sc.peek() != Some(b'(') {
+                    continue;
+                }
+                let paren_start = sc.pos();
+                consume_bracketed(&mut sc, Bracket::Paren);
+                let paren_end = sc.pos();
+                // Copy everything before `:global`, then the unwrapped inner.
+                out.push_str(&sel[copied_to..kw_start]);
+                let inner = sel
+                    .get(paren_start + 1..paren_end.saturating_sub(1))
+                    .unwrap_or("")
+                    .trim();
+                out.push_str(inner);
+                copied_to = paren_end;
+                found = true;
+            }
+            Some(b'(') => {
+                consume_bracketed(&mut sc, Bracket::Paren);
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    if found {
+        out.push_str(&sel[copied_to..]);
+        Some(out)
+    } else {
+        None
+    }
+}
+
+fn is_ident_like(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b >= 0x80
+}
+
+/// Splits a complex selector into an alternating-ish sequence of compounds and
+/// combinators. Whitespace runs that separate compounds become descendant
+/// combinators; `>`, `+`, `~` (with any surrounding whitespace) become their
+/// respective combinators.
+#[allow(unused_assignments)]
+fn split_units(sel: &str) -> Vec<Unit> {
+    let mut units = Vec::new();
+    let mut sc = Scanner::new(sel);
+    let mut compound_start = 0usize;
+    let mut have_compound = false;
+
+    // Helper to flush a pending compound.
+    macro_rules! flush {
+        ($end:expr) => {{
+            if have_compound && $end > compound_start {
+                units.push(Unit::Compound(compound_start, $end));
+            }
+            have_compound = false;
+        }};
+    }
+
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            // A comment on its own does not constitute a compound selector; it
+            // is inert text attached to whatever compound surrounds it.
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                have_compound = true;
+                consume_string(&mut sc);
+            }
+            Some(b'\\') => {
+                have_compound = true;
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'(') => {
+                have_compound = true;
+                consume_bracketed(&mut sc, Bracket::Paren);
+            }
+            Some(b'[') => {
+                have_compound = true;
+                consume_bracketed(&mut sc, Bracket::Square);
+            }
+            Some(b) if is_ws(b) => {
+                let ws_start = sc.pos();
+                // Consume the whitespace run.
+                while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                    sc.bump();
+                }
+                // Skip any comments embedded between the whitespace and a
+                // following combinator symbol so `a /* c */ > b` still parses.
+                while consume_comment(&mut sc) {
+                    while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                        sc.bump();
+                    }
+                }
+                // A combinator symbol may follow the whitespace.
+                if matches!(sc.peek(), Some(b'>' | b'+' | b'~')) {
+                    sc.bump(); // the symbol
+                               // trailing whitespace after the symbol
+                    while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                        sc.bump();
+                    }
+                }
+                // The combinator text starts where the preceding compound ends.
+                // If there was a real compound, that is `ws_start`; otherwise the
+                // whole `[compound_start, ws_start)` region is inert (comments)
+                // and belongs to the combinator so it is not dropped.
+                let comb_start = if have_compound {
+                    ws_start
+                } else {
+                    compound_start
+                };
+                flush!(ws_start);
+                units.push(Unit::Combinator(sel[comb_start..sc.pos()].to_string()));
+                compound_start = sc.pos();
+            }
+            Some(b'>' | b'+' | b'~') => {
+                // Combinator with no leading whitespace.
+                let sym_pos = sc.pos();
+                let comb_start = if have_compound {
+                    sym_pos
+                } else {
+                    compound_start
+                };
+                flush!(sym_pos);
+                sc.bump();
+                while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                    sc.bump();
+                }
+                units.push(Unit::Combinator(sel[comb_start..sc.pos()].to_string()));
+                compound_start = sc.pos();
+            }
+            _ => {
+                have_compound = true;
+                sc.bump();
+            }
+        }
+    }
+    flush!(sc.len());
+    units
+}
+
+/// Within a single compound selector, finds a top-level `:deep(...)` and
+/// returns `(before, inner, after)` byte-slices where `before` is the compound
+/// text preceding `:deep`, `inner` is the argument, and `after` is any trailing
+/// text after the closing paren.
+fn find_deep(compound: &str) -> Option<(&str, &str, &str)> {
+    let mut sc = Scanner::new(compound);
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(&mut sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b'[') => {
+                consume_bracketed(&mut sc, Bracket::Square);
+            }
+            Some(b':') if sc.starts_with(":deep") => {
+                let before_end = sc.pos();
+                // Advance past ":deep".
+                for _ in 0..5 {
+                    sc.bump();
+                }
+                // Skip whitespace before the paren.
+                while matches!(sc.peek(), Some(w) if is_ws(w)) {
+                    sc.bump();
+                }
+                if sc.peek() != Some(b'(') {
+                    // `:deep` without `(` — not our pseudo, keep scanning.
+                    continue;
+                }
+                let paren_start = sc.pos();
+                consume_bracketed(&mut sc, Bracket::Paren);
+                let paren_end = sc.pos();
+                let before = &compound[..before_end];
+                // inner excludes the parens; clamp for malformed input.
+                let inner = compound
+                    .get(paren_start + 1..paren_end.saturating_sub(1))
+                    .unwrap_or("")
+                    .trim();
+                let after = &compound[paren_end..];
+                return Some((before, inner, after));
+            }
+            Some(b'(') => {
+                consume_bracketed(&mut sc, Bracket::Paren);
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    None
+}
+
+/// Attaches `[scope_attr]` to a compound selector, inserting it after the type/
+/// universal/class/id/attribute part but *before* any pseudo-class or
+/// pseudo-element so that e.g. `.btn:hover` → `.btn[scope]:hover` and `::before`
+/// → `[scope]::before`.
+fn attach_scope(compound: &str, scope_attr: &str) -> String {
+    // A compound with no real selector token (only comments / whitespace) is
+    // inert and passed through untouched.
+    if !has_selector_content(compound) {
+        return compound.to_string();
+    }
+    let insert_at = pseudo_insertion_point(compound);
+    let mut out = String::with_capacity(compound.len() + scope_attr.len() + 2);
+    out.push_str(&compound[..insert_at]);
+    out.push('[');
+    out.push_str(scope_attr);
+    out.push(']');
+    out.push_str(&compound[insert_at..]);
+    out
+}
+
+/// Finds the byte offset in a compound selector at which to insert the scope
+/// attribute: just before the first top-level pseudo (`:` or `::`) that is not
+/// part of a functional pseudo we scan through. If the compound is only a
+/// pseudo (e.g. `::before` or `:hover`), the insertion point is 0.
+fn pseudo_insertion_point(compound: &str) -> usize {
+    let mut sc = Scanner::new(compound);
+    // Position just past the last real (non-comment, non-whitespace) token, so a
+    // trailing comment like `a/* c */` gets the scope inserted before it.
+    let mut last_content_end = 0usize;
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(&mut sc);
+                last_content_end = sc.pos();
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+                last_content_end = sc.pos();
+            }
+            Some(b'[') => {
+                consume_bracketed(&mut sc, Bracket::Square);
+                last_content_end = sc.pos();
+            }
+            Some(b'(') => {
+                consume_bracketed(&mut sc, Bracket::Paren);
+                last_content_end = sc.pos();
+            }
+            Some(b':') => {
+                return sc.pos();
+            }
+            Some(b) if is_ws(b) => {
+                sc.bump();
+            }
+            _ => {
+                sc.bump();
+                last_content_end = sc.pos();
+            }
+        }
+    }
+    last_content_end
+}
+
+/// True if a compound contains at least one real selector token (i.e. something
+/// other than comments and whitespace).
+fn has_selector_content(compound: &str) -> bool {
+    let mut sc = Scanner::new(compound);
+    while !sc.is_eof() {
+        if consume_comment(&mut sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b) if is_ws(b) => {
+                sc.bump();
+            }
+            Some(_) => return true,
+            None => break,
+        }
+    }
+    false
+}
+
+fn is_ws(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0c)
+}

--- a/crates/lunas_css/src/tokenizer.rs
+++ b/crates/lunas_css/src/tokenizer.rs
@@ -1,0 +1,179 @@
+//! Low-level CSS scanning helpers.
+//!
+//! CSS scoping does not need a full CSS grammar. It needs to walk the source
+//! byte-by-byte while respecting the four constructs that can hide otherwise
+//! significant characters:
+//!
+//! * strings (`"…"` / `'…'`) — a `{`, `}`, `,`, `]` or `/*` inside a string is
+//!   literal text, not structure;
+//! * comments (`/* … */`) — likewise inert;
+//! * escapes (`\`) — the next byte is consumed verbatim, so `\]` inside an
+//!   attribute selector does not close the bracket;
+//! * bracket / paren nesting — `,` inside `:not(a, b)` or `[x="a,b"]` does not
+//!   split a selector list.
+//!
+//! The helpers here are deliberately small and total: every function makes
+//! forward progress and never indexes out of bounds, which is what lets the
+//! higher layers guarantee they never panic.
+
+/// A cursor over CSS source bytes. All positions are byte offsets into the
+/// original `&str`, so they can be handed straight to [`lunas_span::TextRange`].
+pub(crate) struct Scanner<'a> {
+    src: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn new(src: &'a str) -> Self {
+        Scanner {
+            src,
+            bytes: src.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    pub(crate) fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn src(&self) -> &'a str {
+        self.src
+    }
+
+    pub(crate) fn is_eof(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+
+    /// The byte at the current position, or `None` at EOF.
+    pub(crate) fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    /// Advances one byte. Returns the byte consumed, or `None` at EOF.
+    pub(crate) fn bump(&mut self) -> Option<u8> {
+        let b = self.bytes.get(self.pos).copied();
+        if b.is_some() {
+            self.pos += 1;
+        }
+        b
+    }
+
+    /// Sets the cursor position (clamped to the input length).
+    pub(crate) fn seek(&mut self, pos: usize) {
+        self.pos = pos.min(self.bytes.len());
+    }
+
+    /// True if the remaining input starts with `s`.
+    pub(crate) fn starts_with(&self, s: &str) -> bool {
+        self.bytes[self.pos.min(self.bytes.len())..].starts_with(s.as_bytes())
+    }
+}
+
+/// Consumes a `/* … */` comment, assuming the cursor is on the opening `/*`.
+/// An unterminated comment consumes to EOF. Returns `true` if a comment was
+/// consumed. This never panics and always makes progress when it returns true.
+pub(crate) fn consume_comment(sc: &mut Scanner) -> bool {
+    if !sc.starts_with("/*") {
+        return false;
+    }
+    sc.bump();
+    sc.bump();
+    while !sc.is_eof() {
+        if sc.starts_with("*/") {
+            sc.bump();
+            sc.bump();
+            return true;
+        }
+        sc.bump();
+    }
+    true
+}
+
+/// Consumes a string literal, assuming the cursor is on the opening quote
+/// (`"` or `'`). Handles backslash escapes; an unterminated string consumes to
+/// EOF. Returns `true` if a string was consumed.
+pub(crate) fn consume_string(sc: &mut Scanner) -> bool {
+    let quote = match sc.peek() {
+        Some(q @ (b'"' | b'\'')) => q,
+        _ => return false,
+    };
+    sc.bump();
+    while let Some(b) = sc.bump() {
+        if b == b'\\' {
+            // Escape: consume the next byte too (if any).
+            sc.bump();
+        } else if b == quote {
+            return true;
+        }
+    }
+    true
+}
+
+/// The four kinds of nesting-balanced brackets CSS uses.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Bracket {
+    Paren,
+    Square,
+}
+
+impl Bracket {
+    fn open(self) -> u8 {
+        match self {
+            Bracket::Paren => b'(',
+            Bracket::Square => b'[',
+        }
+    }
+
+    fn close(self) -> u8 {
+        match self {
+            Bracket::Paren => b')',
+            Bracket::Square => b']',
+        }
+    }
+}
+
+/// Consumes a balanced bracket group, assuming the cursor is on the opening
+/// bracket. Respects nested brackets of the same kind, strings, comments, and
+/// escapes. An unbalanced group consumes to EOF. Returns `true` if a group was
+/// consumed (i.e. the cursor was on the opening bracket).
+pub(crate) fn consume_bracketed(sc: &mut Scanner, kind: Bracket) -> bool {
+    if sc.peek() != Some(kind.open()) {
+        return false;
+    }
+    sc.bump();
+    let mut depth = 1usize;
+    while !sc.is_eof() {
+        if consume_comment(sc) {
+            continue;
+        }
+        match sc.peek() {
+            Some(b'"' | b'\'') => {
+                consume_string(sc);
+            }
+            Some(b'\\') => {
+                sc.bump();
+                sc.bump();
+            }
+            Some(b) if b == kind.open() => {
+                depth += 1;
+                sc.bump();
+            }
+            Some(b) if b == kind.close() => {
+                depth -= 1;
+                sc.bump();
+                if depth == 0 {
+                    return true;
+                }
+            }
+            _ => {
+                sc.bump();
+            }
+        }
+    }
+    true
+}

--- a/crates/lunas_css/tests/robustness.rs
+++ b/crates/lunas_css/tests/robustness.rs
@@ -1,0 +1,241 @@
+//! `scope_css` must never panic, for any input. These tests throw a large
+//! deterministic corpus of adversarial and pseudo-random strings at it and
+//! assert each call returns (a panic would unwind and be caught here). They
+//! also check two structural invariants that must hold for every input:
+//!
+//! * the transform is idempotent-safe in the sense that it never produces a
+//!   string that fails on a second pass;
+//! * every diagnostic range stays within the bounds of the input.
+
+use lunas_css::scope_css;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+const SCOPE: &str = "data-lunas-abcd1234";
+
+fn assert_ok(input: &str) {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let (out, diags) = scope_css(input, SCOPE);
+        // Diagnostic ranges must land inside the input.
+        for d in &diags {
+            assert!(
+                d.range.end().as_usize() <= input.len(),
+                "diagnostic range {:?} exceeds input len {} for {:?}",
+                d.range,
+                input.len(),
+                input
+            );
+            assert!(d.range.start().as_usize() <= d.range.end().as_usize());
+        }
+        // A second pass over the output must also not panic.
+        let _ = scope_css(&out, SCOPE);
+    }));
+    assert!(result.is_ok(), "scope_css panicked on input: {input:?}");
+}
+
+#[test]
+fn adversarial_literals_do_not_panic() {
+    let cases = [
+        "",
+        "{",
+        "}",
+        "{}",
+        "}{",
+        "/*",
+        "*/",
+        "/* unterminated",
+        "a {",
+        "a { b",
+        "a }",
+        ".",
+        "#",
+        ":",
+        "::",
+        ":::",
+        "[",
+        "]",
+        "[]",
+        "[[[]]]",
+        "((()))",
+        "a[",
+        "a[b",
+        "a[b=",
+        "a[b=\"",
+        "a[b='",
+        "a[b=\"c]",
+        ":not(",
+        ":not()",
+        ":deep(",
+        ":deep()",
+        ":global(",
+        ":global()",
+        ":deep",
+        ":global",
+        "@",
+        "@media",
+        "@media {",
+        "@media { a {",
+        "@keyframes",
+        "@keyframes {",
+        "@keyframes x {",
+        "@keyframes x { from {",
+        "@import",
+        "@import ;",
+        "@font-face {",
+        "@layer",
+        "@layer;",
+        "@-webkit-keyframes x {}",
+        ",",
+        ",,,",
+        "a,,b {}",
+        "  ,  { }",
+        ">",
+        "> >",
+        "a > > b {}",
+        "\\",
+        "\\}",
+        "a\\{b {}",
+        "\0",
+        "a\0b {}",
+        "/* } { ; @ */",
+        "\"unterminated string",
+        "'x",
+        "あ { color: 赤 }",
+        "\u{1F600} {}",
+        ".a { animation: }",
+        ".a { animation }",
+        ".a { : val }",
+        "* { }",
+        "&& {}",
+        "@keyframes @ {}",
+    ];
+    for c in cases {
+        assert_ok(c);
+    }
+}
+
+#[test]
+fn deeply_nested_does_not_panic() {
+    let open_braces = "@media screen {".repeat(2000);
+    let close_braces = "}".repeat(2000);
+    assert_ok(&open_braces);
+    assert_ok(&close_braces);
+    assert_ok(&format!("{open_braces}.a{{}}{close_braces}"));
+
+    let deep_parens = format!(".x:not({}) {{}}", "(".repeat(1000));
+    assert_ok(&deep_parens);
+}
+
+/// A tiny deterministic LCG so the fuzz corpus is reproducible.
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+}
+
+#[test]
+fn pseudo_random_fuzz_does_not_panic() {
+    // Alphabet weighted toward characters that drive the scanner's states.
+    let alphabet: &[char] = &[
+        '{',
+        '}',
+        '(',
+        ')',
+        '[',
+        ']',
+        ':',
+        ';',
+        ',',
+        '.',
+        '#',
+        '*',
+        '>',
+        '+',
+        '~',
+        '/',
+        '*',
+        '"',
+        '\'',
+        '\\',
+        '@',
+        '-',
+        ' ',
+        '\n',
+        '\t',
+        '\0',
+        'a',
+        'b',
+        'c',
+        'x',
+        'k',
+        'e',
+        'y',
+        'あ',
+        '\u{1F600}',
+    ];
+    let mut rng = Lcg(0x0bad_c0de_dead_beef);
+    for _ in 0..8000 {
+        let len = (rng.next() % 60) as usize;
+        let mut s = String::with_capacity(len);
+        for _ in 0..len {
+            let idx = (rng.next() as usize) % alphabet.len();
+            s.push(alphabet[idx]);
+        }
+        assert_ok(&s);
+    }
+}
+
+#[test]
+fn keyword_soup_fuzz_does_not_panic() {
+    // Fuzz built from CSS keywords/tokens, which stresses the at-rule dispatch.
+    let tokens: &[&str] = &[
+        "@media",
+        "@supports",
+        "@keyframes",
+        "@font-face",
+        "@import",
+        "@layer",
+        "@charset",
+        "@-webkit-keyframes",
+        ":deep(",
+        ":global(",
+        ":not(",
+        ":hover",
+        "::before",
+        "{",
+        "}",
+        "(",
+        ")",
+        "[",
+        "]",
+        ";",
+        ",",
+        ".a",
+        "#b",
+        "> c",
+        "animation:",
+        "spin",
+        "1s",
+        "from",
+        "to",
+        "url(x)",
+        "/* c */",
+        "\"s\"",
+        "\\",
+        "  ",
+    ];
+    let mut rng = Lcg(0x1234_5678_9abc_def0);
+    for _ in 0..8000 {
+        let n = (rng.next() % 30) as usize;
+        let mut s = String::new();
+        for _ in 0..n {
+            let idx = (rng.next() as usize) % tokens.len();
+            s.push_str(tokens[idx]);
+        }
+        assert_ok(&s);
+    }
+}

--- a/crates/lunas_css/tests/scoping.rs
+++ b/crates/lunas_css/tests/scoping.rs
@@ -1,0 +1,419 @@
+//! Behavioural tests for the scoped-CSS transform.
+
+use lunas_css::scope_css;
+
+const S: &str = "data-lunas-x";
+
+/// Convenience: scope with the default attribute and assert no diagnostics.
+fn scope(css: &str) -> String {
+    let (out, diags) = scope_css(css, S);
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {diags:?}\ninput: {css:?}"
+    );
+    out
+}
+
+// --- plain selectors -------------------------------------------------------
+
+#[test]
+fn type_selector() {
+    assert_eq!(
+        scope("div { color: red }"),
+        "div[data-lunas-x] { color: red }"
+    );
+}
+
+#[test]
+fn class_and_id() {
+    assert_eq!(scope(".btn {}"), ".btn[data-lunas-x] {}");
+    assert_eq!(scope("#main {}"), "#main[data-lunas-x] {}");
+}
+
+#[test]
+fn universal_selector() {
+    assert_eq!(scope("* {}"), "*[data-lunas-x] {}");
+}
+
+#[test]
+fn chained_simple_selectors() {
+    assert_eq!(scope("a.b#c {}"), "a.b#c[data-lunas-x] {}");
+}
+
+// --- combinators -----------------------------------------------------------
+
+#[test]
+fn descendant_combinator() {
+    assert_eq!(scope("ul li {}"), "ul[data-lunas-x] li[data-lunas-x] {}");
+}
+
+#[test]
+fn child_combinator() {
+    assert_eq!(scope("a > b {}"), "a[data-lunas-x] > b[data-lunas-x] {}");
+}
+
+#[test]
+fn adjacent_and_general_sibling() {
+    assert_eq!(scope("a + b {}"), "a[data-lunas-x] + b[data-lunas-x] {}");
+    assert_eq!(scope("a ~ b {}"), "a[data-lunas-x] ~ b[data-lunas-x] {}");
+}
+
+#[test]
+fn combinator_without_spaces() {
+    assert_eq!(scope("a>b {}"), "a[data-lunas-x]>b[data-lunas-x] {}");
+}
+
+#[test]
+fn multiple_descendants() {
+    assert_eq!(
+        scope("main section p {}"),
+        "main[data-lunas-x] section[data-lunas-x] p[data-lunas-x] {}"
+    );
+}
+
+// --- pseudo-classes / elements ---------------------------------------------
+
+#[test]
+fn pseudo_class_after_scope() {
+    assert_eq!(scope(".btn:hover {}"), ".btn[data-lunas-x]:hover {}");
+}
+
+#[test]
+fn pseudo_element_after_scope() {
+    assert_eq!(scope("a::before {}"), "a[data-lunas-x]::before {}");
+}
+
+#[test]
+fn bare_pseudo_element() {
+    // `::before` alone → scope goes at the front.
+    assert_eq!(scope("::before {}"), "[data-lunas-x]::before {}");
+}
+
+#[test]
+fn functional_pseudo_not_split() {
+    // `:not(.a, .b)` — the inner comma must not split the list, and the scope
+    // attaches before the pseudo.
+    assert_eq!(
+        scope(".x:not(.a, .b) {}"),
+        ".x[data-lunas-x]:not(.a, .b) {}"
+    );
+}
+
+#[test]
+fn nth_child() {
+    assert_eq!(
+        scope("li:nth-child(2n+1) {}"),
+        "li[data-lunas-x]:nth-child(2n+1) {}"
+    );
+}
+
+// --- attribute selectors ---------------------------------------------------
+
+#[test]
+fn attribute_selector() {
+    assert_eq!(
+        scope("input[type=text] {}"),
+        "input[type=text][data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn attribute_selector_with_bracket_in_string() {
+    // A `]` inside the attribute value string must not close the attribute.
+    let out = scope(r#"a[href="a]b"] {}"#);
+    assert_eq!(out, r#"a[href="a]b"][data-lunas-x] {}"#);
+}
+
+#[test]
+fn attribute_selector_with_comma_in_string() {
+    let out = scope(r#"a[title="x, y"], b {}"#);
+    assert_eq!(out, r#"a[title="x, y"][data-lunas-x], b[data-lunas-x] {}"#);
+}
+
+#[test]
+fn attribute_before_pseudo() {
+    assert_eq!(
+        scope("input[disabled]:focus {}"),
+        "input[disabled][data-lunas-x]:focus {}"
+    );
+}
+
+// --- selector lists --------------------------------------------------------
+
+#[test]
+fn selector_list() {
+    assert_eq!(scope("a, b {}"), "a[data-lunas-x], b[data-lunas-x] {}");
+}
+
+#[test]
+fn selector_list_complex() {
+    assert_eq!(
+        scope("a, b > c {}"),
+        "a[data-lunas-x], b[data-lunas-x] > c[data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn selector_list_whitespace_preserved() {
+    let out = scope("a ,\n  b {}");
+    assert_eq!(out, "a[data-lunas-x] ,\n  b[data-lunas-x] {}");
+}
+
+// --- :deep / :global -------------------------------------------------------
+
+#[test]
+fn deep_leaves_descendants_unscoped() {
+    assert_eq!(scope(".a :deep(.b) {}"), ".a[data-lunas-x] .b {}");
+}
+
+#[test]
+fn deep_attached_to_compound() {
+    // `.a:deep(.b)` → scope `.a`, then `.b` unscoped.
+    assert_eq!(scope(".a:deep(.b) {}"), ".a[data-lunas-x] .b {}");
+}
+
+#[test]
+fn deep_with_trailing_selector() {
+    assert_eq!(scope(".a :deep(.b .c) {}"), ".a[data-lunas-x] .b .c {}");
+}
+
+#[test]
+fn global_leaves_selector_unscoped() {
+    assert_eq!(scope(":global(.modal) {}"), ".modal {}");
+}
+
+#[test]
+fn global_with_descendants() {
+    assert_eq!(scope(":global(.a .b) {}"), ".a .b {}");
+}
+
+#[test]
+fn global_anywhere_makes_selector_fully_global() {
+    assert_eq!(scope(":global(.a) .b {}"), ".a .b {}");
+}
+
+#[test]
+fn global_in_list_only_affects_its_selector() {
+    assert_eq!(scope(":global(.a), .b {}"), ".a, .b[data-lunas-x] {}");
+}
+
+#[test]
+fn global_prefixed_ident_is_not_global() {
+    // `:globalish` is a (bogus) pseudo-class, not our escape hatch.
+    assert_eq!(scope("a:globalish {}"), "a[data-lunas-x]:globalish {}");
+}
+
+// --- nested at-rules -------------------------------------------------------
+
+#[test]
+fn media_recurses() {
+    let out = scope("@media (min-width: 700px) { .a {} }");
+    assert_eq!(out, "@media (min-width: 700px) { .a[data-lunas-x] {} }");
+}
+
+#[test]
+fn supports_recurses() {
+    let out = scope("@supports (display: grid) { a b {} }");
+    assert_eq!(
+        out,
+        "@supports (display: grid) { a[data-lunas-x] b[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn layer_block_recurses() {
+    let out = scope("@layer base { .a {} }");
+    assert_eq!(out, "@layer base { .a[data-lunas-x] {} }");
+}
+
+#[test]
+fn layer_statement_passthrough() {
+    assert_eq!(scope("@layer a, b;"), "@layer a, b;");
+}
+
+#[test]
+fn nested_media_inside_media() {
+    let out = scope("@media screen { @media (min-width: 1px) { .a {} } }");
+    assert_eq!(
+        out,
+        "@media screen { @media (min-width: 1px) { .a[data-lunas-x] {} } }"
+    );
+}
+
+// --- keyframes -------------------------------------------------------------
+
+#[test]
+fn keyframes_renamed_and_referenced() {
+    let src = "@keyframes spin { from { opacity: 0 } to { opacity: 1 } } .x { animation: spin 1s }";
+    let (out, diags) = scope_css(src, "data-lunas-ab12");
+    assert!(diags.is_empty());
+    assert!(out.contains("@keyframes spin-ab12 "), "{out}");
+    assert!(out.contains("animation: spin-ab12 1s"), "{out}");
+    // The keyframe selectors `from`/`to` are NOT scoped.
+    assert!(out.contains("from { opacity: 0 }"), "{out}");
+}
+
+#[test]
+fn animation_name_property_rewritten() {
+    let src = "@keyframes pulse {} .x { animation-name: pulse }";
+    let (out, _) = scope_css(src, "data-lunas-ab12");
+    assert!(out.contains("animation-name: pulse-ab12"), "{out}");
+}
+
+#[test]
+fn animation_shorthand_only_name_token_rewritten() {
+    let src = "@keyframes fade {} .x { animation: 2s ease-in fade infinite }";
+    let (out, _) = scope_css(src, "data-lunas-ab12");
+    assert!(
+        out.contains("animation: 2s ease-in fade-ab12 infinite"),
+        "{out}"
+    );
+}
+
+#[test]
+fn unrelated_animation_name_untouched() {
+    let src = "@keyframes spin {} .x { animation: wobble 1s }";
+    let (out, _) = scope_css(src, "data-lunas-ab12");
+    assert!(out.contains("animation: wobble 1s"), "{out}");
+}
+
+#[test]
+fn keyframes_forward_reference() {
+    // animation appears before the @keyframes rule — pass one collects the name.
+    let src = ".x { animation: spin 1s } @keyframes spin {}";
+    let (out, _) = scope_css(src, "data-lunas-ab12");
+    assert!(out.contains("animation: spin-ab12 1s"), "{out}");
+    assert!(out.contains("@keyframes spin-ab12"), "{out}");
+}
+
+#[test]
+fn vendor_prefixed_keyframes() {
+    let src = "@-webkit-keyframes spin {} .x { animation: spin 1s }";
+    let (out, _) = scope_css(src, "data-lunas-ab12");
+    assert!(out.contains("@-webkit-keyframes spin-ab12"), "{out}");
+    assert!(out.contains("animation: spin-ab12 1s"), "{out}");
+}
+
+// --- pass-through at-rules -------------------------------------------------
+
+#[test]
+fn font_face_untouched() {
+    let src = "@font-face { font-family: 'X'; src: url(x.woff) }";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn import_untouched() {
+    let src = "@import url('theme.css');";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn charset_untouched() {
+    let src = "@charset \"utf-8\";";
+    assert_eq!(scope(src), src);
+}
+
+// --- comments --------------------------------------------------------------
+
+#[test]
+fn comment_before_selector() {
+    let out = scope("/* c */ .a {}");
+    assert_eq!(out, "/* c */ .a[data-lunas-x] {}");
+}
+
+#[test]
+fn comment_inside_selector() {
+    let out = scope("a /* x */ b {}");
+    assert_eq!(out, "a[data-lunas-x] /* x */ b[data-lunas-x] {}");
+}
+
+#[test]
+fn comment_with_braces_inside() {
+    // Braces inside a comment must not be treated as block delimiters.
+    let out = scope("/* } { */ .a {}");
+    assert_eq!(out, "/* } { */ .a[data-lunas-x] {}");
+}
+
+#[test]
+fn comment_in_declaration_block() {
+    let out = scope(".a { /* comment */ color: red }");
+    assert_eq!(out, ".a[data-lunas-x] { /* comment */ color: red }");
+}
+
+// --- unicode ---------------------------------------------------------------
+
+#[test]
+fn unicode_class_name() {
+    let out = scope(".café {}");
+    assert_eq!(out, ".café[data-lunas-x] {}");
+}
+
+#[test]
+fn unicode_in_content_value() {
+    let out = scope(".a { content: '→あ' }");
+    assert_eq!(out, ".a[data-lunas-x] { content: '→あ' }");
+}
+
+#[test]
+fn emoji_in_string() {
+    let out = scope(r#".a[data-x="😀"] {}"#);
+    assert_eq!(out, r#".a[data-x="😀"][data-lunas-x] {}"#);
+}
+
+// --- multiple rules & whitespace -------------------------------------------
+
+#[test]
+fn multiple_rules_preserve_formatting() {
+    let src = ".a {\n  color: red;\n}\n\n.b {\n  color: blue;\n}\n";
+    let out = scope(src);
+    assert_eq!(
+        out,
+        ".a[data-lunas-x] {\n  color: red;\n}\n\n.b[data-lunas-x] {\n  color: blue;\n}\n"
+    );
+}
+
+#[test]
+fn empty_input() {
+    assert_eq!(scope(""), "");
+}
+
+#[test]
+fn whitespace_only() {
+    assert_eq!(scope("   \n  "), "   \n  ");
+}
+
+#[test]
+fn comments_only() {
+    assert_eq!(scope("/* just a comment */"), "/* just a comment */");
+}
+
+// --- diagnostics on malformed input ----------------------------------------
+
+#[test]
+fn unterminated_block_reports_diagnostic() {
+    let (out, diags) = scope_css(".a { color: red", S);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("unterminated"));
+    // Output still contains the scoped selector.
+    assert!(out.starts_with(".a[data-lunas-x] {"), "{out}");
+    // The diagnostic range points into the original css.
+    let r = diags[0].range;
+    assert!(r.start().as_usize() < r.end().as_usize());
+    assert!(r.end().as_usize() <= ".a { color: red".len());
+}
+
+#[test]
+fn rule_without_brace_reports_diagnostic() {
+    let (_out, diags) = scope_css(".a .b", S);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("missing `{`"));
+}
+
+// --- scope attribute variations --------------------------------------------
+
+#[test]
+fn different_scope_attr() {
+    let (out, _) = scope_css(".a {}", "data-lunas-deadbeef");
+    assert_eq!(out, ".a[data-lunas-deadbeef] {}");
+}


### PR DESCRIPTION
## What

New workspace crate `crates/lunas_css` implementing component-scoped CSS (roadmap item **a-css**), Vue-SFC style.

### Public API
- `scope_css(css, scope_attr) -> (String, Vec<Diagnostic>)` — attaches `[scope_attr]` to every compound selector: `.btn:hover` → `.btn[data-lunas-x]:hover`, `ul li` → `ul[data-lunas-x] li[data-lunas-x]`.
- `scope_id(component_source) -> String` — stable `data-lunas-<fnv1a hex>` id for codegen (inline FNV-1a, zero deps).

### Supported CSS surface
- Selectors: type/universal/class/id, attribute selectors (incl. `]`/`,` inside quoted values), pseudo-classes/elements (scope inserted *before* the pseudo), functional pseudos (`:not(a, b)` commas don't split lists), all combinators, selector lists, comments anywhere, unicode/escapes.
- Escape hatches: `:deep(x)` (everything past it unscoped), `:global(x)` (whole selector unscoped, wrapper unwrapped).
- At-rules: `@media`/`@supports`/`@layer`/`@container`/`@scope` recurse (incl. vendor prefixes); `@keyframes` renamed `name-<hash>` with `animation`/`animation-name` references rewritten (forward refs resolve via a pre-pass); `@font-face`/`@page`/`@import`/`@charset`/unknown pass through untouched.

## Why

Prerequisite for scoped-style codegen: codegen will stamp `scope_id(...)` on the component's rendered elements and inject `scope_css(...)` output in a per-component-type `<style>` (contract documented in the crate README). No codegen wiring in this PR by design.

## How

Hand-written scanner (strings, comments, escapes, paren/bracket/brace balancing) + structural walker — **no external CSS parser dependencies** (workspace philosophy; keeps wasm32 lean). Never panics: malformed regions are emitted verbatim with a `lunas_span::Diagnostic` warning whose `TextRange` points into the original css.

## Tests

- 57 behavioural tests (`tests/scoping.rs`): selectors, combinators, pseudos, attribute edge cases, lists, nested at-rules, keyframes renaming + property rewrite, `:deep`/`:global`, comments, unicode, malformed-input diagnostics.
- 4 fuzz/never-panic tests (`tests/robustness.rs`): adversarial literal corpus, deep nesting, 16k pseudo-random inputs (deterministic LCG, sibling-crate pattern), plus diagnostic-range-in-bounds and second-pass invariants.
- 7 doctests + 3 hash unit tests. `cargo build -p lunas_css --target wasm32-unknown-unknown` passes.
- Quality gates green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`.

### Known limitations (documented in README)
- CSS nesting (`&`) not specially handled; nested blocks pass through.
- `:global` anywhere makes the entire selector global (no CSS-Modules-style partial-global).
- String-based rewrite (formatting-preserving), not an AST re-serializer; declarations are not grammar-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)