### PR TITLE
feat(runtime): client-side router

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -211,6 +211,31 @@ export function useStore(c, i, store, key) { /* adopt field `key` at c's reactiv
 export function derivedStore(store, deps, fn) { /* computed's laziness policy re-hosted on store
                                                     subscriptions; field-shaped output, so it can
                                                     be placed under a createStore() key */ }
+
+// --- client-side router (the @useRouting/@useAutoRouting codegen target;
+//     conceptually a store whose one field "route" is the current route) ---
+export function createRouter(routes, options) { /* routes=[{path,component}]; matching ranks
+                                                    static > param > catch-all; { history?,
+                                                    beforeEach?(to,from)=>bool|Promise }; exposes
+                                                    push/replace/back, current {path,params,query,
+                                                    matched}, subscribe(fn), adopt(c,i) */ }
+export function memoryHistory(initial) { /* injectable in-memory History-API stand-in (tests/SSR);
+                                            historyAdapter(win) is the browser default */ }
+export function routerOutlet(c, before, router, opts) { /* mountChild the matched route's component
+                                                            at an anchor; swap on nav (re-mount only
+                                                            when the matched route def changes);
+                                                            params passed as props */ }
+export function routerLink(el, router, path, opts) { /* click -> preventDefault + router.push(path)
+                                                         (aux/modified clicks fall through); the
+                                                         codegen target for <a :href> route links */ }
+
+// Intended emitted shape for a routed component (future codegen):
+//   const appRouter = createRouter(routes);      // module scope, from the route table
+//   // inside setup(c, props):
+//   appRouter.adopt(c, i);                       // component reads router.current at index i
+//   const a = anchorBefore(placeholder);
+//   routerOutlet(c, a, appRouter);               // <router-outlet/>
+//   routerLink(linkEl, appRouter, "/users/1");   // <a :href="/users/1">
 ```
 
 No signal-tracking stack, no VDOM, no per-node effect objects.

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -29,7 +29,7 @@ import { box } from "lunas/boxes";
 
 Available deep-import subpaths mirror the internal modules: `lunas/core`,
 `lunas/boxes`, `lunas/computed`, `lunas/watch`, `lunas/batch`, `lunas/dom`,
-`lunas/blocks`, `lunas/for_diff`, `lunas/store`.
+`lunas/blocks`, `lunas/for_diff`, `lunas/store`, `lunas/router`.
 
 TypeScript types are included (`types/index.d.ts`, plus one `.d.ts` per
 subpath) — no `@types` package needed.
@@ -90,6 +90,11 @@ main repo for the calling contract.
 | `createStore(initial)` | `lunas/store` | Module-level reactive state (named fields) usable by many components. |
 | `useStore(c, i, store, key)` | `lunas/store` | Adopt store field `key` at component context `c`'s reactive index `i`. |
 | `derivedStore(store, deps, fn)` | `lunas/store` | Lazily-evaluated, memoized value derived from one or more store fields. |
+| `createRouter(routes, options)` | `lunas/router` | Client-side router: route table + matching (static > param > catch-all), store-backed reactive current route, navigation guards. |
+| `memoryHistory(initial)` | `lunas/router` | In-memory History-API stand-in for tests/SSR (injectable via `options.history`). |
+| `historyAdapter(win)` | `lunas/router` | Default History-API adapter (pushState/replaceState/popstate). |
+| `routerOutlet(c, anchor, router, opts)` | `lunas/router` | Mount the matched route's component at an anchor, swapping on navigation; params passed as props. |
+| `routerLink(el, router, path, opts)` | `lunas/router` | Wire an element's click to a client-side navigation (preventDefault + push). |
 
 ## Testing
 

--- a/packages/lunas/package.json
+++ b/packages/lunas/package.json
@@ -66,6 +66,10 @@
       "types": "./types/store.d.ts",
       "import": "./src/store.mjs"
     },
+    "./router": {
+      "types": "./types/router.d.ts",
+      "import": "./src/router.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -42,3 +42,11 @@ export {
 } from "./for_diff.mjs";
 
 export { createStore, useStore, derivedStore } from "./store.mjs";
+
+export {
+  createRouter,
+  memoryHistory,
+  historyAdapter,
+  routerOutlet,
+  routerLink,
+} from "./router.mjs";

--- a/packages/lunas/src/router.mjs
+++ b/packages/lunas/src/router.mjs
@@ -1,0 +1,462 @@
+// router.mjs — client-side router runtime for Lunas-compiled apps.
+// See output-design.md §5 (router block) and the old @useRouting/@useAutoRouting
+// directives (crates/lunas_parser) whose codegen targets this module.
+//
+// A router is conceptually a store of the current route: exactly one reactive
+// field ("route") holding `{ path, params, query }`. It reuses store.mjs so a
+// component adopts the current route at a reactive index the same way it adopts
+// any other store field — `useStore`-shaped adoption — and plain consumers
+// (tests, devtools, the outlet) can `subscribe` without a component context.
+//
+// History access is abstracted behind an injectable adapter so the runtime is
+// testable without a real browser: `historyAdapter()` wraps the History API in
+// the browser, `memoryHistory()` is an in-memory stand-in for tests/SSR.
+//
+// Dependency-free ES2015 + Proxy (the runtime's compatibility floor). No BigInt.
+
+import { createStore, useStore } from "./store.mjs";
+import { mountChild } from "./blocks.mjs";
+
+// ---------------------------------------------------------------------------
+// Path parsing & query strings
+// ---------------------------------------------------------------------------
+
+// splitPath(p) — the pathname portion of `p`, without its query string, split
+// into non-empty segments. Leading/trailing slashes collapse away so "/a/b/"
+// and "/a/b" segment identically (trailing-slash normalization, §1).
+function splitPath(p) {
+  const q = p.indexOf("?");
+  const path = q === -1 ? p : p.slice(0, q);
+  const out = [];
+  for (const seg of path.split("/")) if (seg.length) out.push(decode(seg));
+  return out;
+}
+
+// parseQuery(p) — the `?a=1&b=2` portion of `p` as a plain object. Repeated
+// keys keep the last value (the common case; a router is not a form parser).
+// Keys/values are percent-decoded and `+` is treated as a space.
+function parseQuery(p) {
+  const i = p.indexOf("?");
+  const out = {};
+  if (i === -1) return out;
+  const qs = p.slice(i + 1);
+  if (!qs.length) return out;
+  for (const pair of qs.split("&")) {
+    if (!pair.length) continue;
+    const eq = pair.indexOf("=");
+    const k = eq === -1 ? pair : pair.slice(0, eq);
+    const v = eq === -1 ? "" : pair.slice(eq + 1);
+    out[decode(k.replace(/\+/g, " "))] = decode(v.replace(/\+/g, " "));
+  }
+  return out;
+}
+
+function decode(s) {
+  try {
+    return decodeURIComponent(s);
+  } catch (_e) {
+    return s; // malformed %-sequence: hand back the raw text rather than throw
+  }
+}
+
+// normalizePath(p) — a canonical pathname (leading slash, no trailing slash,
+// query stripped). "" and "/" both normalize to "/".
+function normalizePath(p) {
+  const segs = splitPath(p);
+  return segs.length ? "/" + segs.map(encodeURIComponent).join("/") : "/";
+}
+
+// ---------------------------------------------------------------------------
+// Route table + matching (§1)
+// ---------------------------------------------------------------------------
+
+// compileRoute(route) — pre-split a route's `path` into a matcher spec once at
+// createRouter time. Each segment is classified:
+//   { kind: "static", value }  — must equal the incoming segment
+//   { kind: "param",  name }   — ":name", captures one segment
+//   { kind: "catch",  name }   — "*" or "*name", captures the rest (0+ segs)
+// Specificity is scored so a matcher can be ranked: static beats param beats
+// catch-all, earlier segments dominate later ones.
+function compileRoute(route) {
+  const raw = splitPath(route.path);
+  const segs = [];
+  for (const s of raw) {
+    if (s === "*" || s[0] === "*") {
+      segs.push({ kind: "catch", name: s.length > 1 ? s.slice(1) : "rest" });
+      break; // a catch-all consumes everything after it
+    } else if (s[0] === ":") {
+      segs.push({ kind: "param", name: s.slice(1) });
+    } else {
+      segs.push({ kind: "static", value: s });
+    }
+  }
+  return { route, segs };
+}
+
+// matchOne(spec, segs) — try to match compiled `spec` against the incoming
+// path segments. Returns the captured params object on success, or null.
+function matchOne(spec, segs) {
+  const params = {};
+  const specSegs = spec.segs;
+  for (let i = 0; i < specSegs.length; i++) {
+    const s = specSegs[i];
+    if (s.kind === "catch") {
+      // Greedily capture every remaining segment as a single "/"-joined string.
+      params[s.name] = segs.slice(i).map(encodeURIComponent).join("/");
+      return params;
+    }
+    if (i >= segs.length) return null; // spec wants more segments than we have
+    if (s.kind === "static") {
+      if (s.value !== segs[i]) return null;
+    } else {
+      params[s.name] = segs[i];
+    }
+  }
+  // No catch-all: every incoming segment must have been consumed.
+  return segs.length === specSegs.length ? params : null;
+}
+
+// rank(spec) — a comparable score for a matching spec: static segments weigh
+// most, params less, a catch-all least. Longer static prefixes win. The number
+// is only ever compared against other ranks, never interpreted.
+function rank(spec) {
+  let score = 0;
+  for (const s of spec.segs) {
+    score *= 8;
+    if (s.kind === "static") score += 4;
+    else if (s.kind === "param") score += 2;
+    else score += 1; // catch-all
+  }
+  return score;
+}
+
+// matchRoute(compiled, path) — best matching route for `path`, or null.
+// All matching specs are ranked (static > param > catch-all) and the highest
+// wins; ties fall back to declaration order (first wins), matching the
+// intuition that earlier routes are more specific by author intent.
+function matchRoute(compiled, path) {
+  const segs = splitPath(path);
+  let best = null;
+  let bestRank = -1;
+  for (let i = 0; i < compiled.length; i++) {
+    const spec = compiled[i];
+    const params = matchOne(spec, segs);
+    if (params === null) continue;
+    const r = rank(spec);
+    if (r > bestRank) {
+      bestRank = r;
+      best = { route: spec.route, params };
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// History adapters (§2)
+// ---------------------------------------------------------------------------
+
+// memoryHistory(initial) — an in-memory History-API stand-in for tests/SSR.
+// Keeps its own back-stack; `listen`'s callback is invoked on back()/forward()
+// (the popstate analogue) but NOT on push()/replace() (mirrors the browser,
+// where pushState does not emit popstate — the router calls its own resolve
+// after a programmatic navigation).
+export function memoryHistory(initial) {
+  const stack = [initial || "/"];
+  let idx = 0;
+  let onChange = null;
+  return {
+    get location() {
+      return stack[idx];
+    },
+    push(path) {
+      stack.length = idx + 1; // drop any forward entries
+      stack.push(path);
+      idx = stack.length - 1;
+    },
+    replace(path) {
+      stack[idx] = path;
+    },
+    go(delta) {
+      const next = idx + delta;
+      if (next < 0 || next >= stack.length) return;
+      idx = next;
+      if (onChange) onChange(stack[idx]);
+    },
+    listen(fn) {
+      onChange = fn;
+      return () => {
+        if (onChange === fn) onChange = null;
+      };
+    },
+  };
+}
+
+// historyAdapter(win) — the default adapter wrapping the browser History API.
+// `win` defaults to the global `window`; passing one explicitly aids testing
+// and future SSR shims. Reads location from `pathname + search`, writes via
+// pushState/replaceState, and forwards popstate to `listen`'s callback.
+export function historyAdapter(win) {
+  const w = win || (typeof window !== "undefined" ? window : null);
+  if (!w) {
+    throw new Error(
+      "historyAdapter: no window available; pass options.history (e.g. memoryHistory()) for non-browser environments"
+    );
+  }
+  const here = () => w.location.pathname + w.location.search;
+  return {
+    get location() {
+      return here();
+    },
+    push(path) {
+      w.history.pushState({}, "", path);
+    },
+    replace(path) {
+      w.history.replaceState({}, "", path);
+    },
+    go(delta) {
+      w.history.go(delta);
+    },
+    listen(fn) {
+      const handler = () => fn(here());
+      w.addEventListener("popstate", handler);
+      return () => w.removeEventListener("popstate", handler);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router (§2, §3, §6)
+// ---------------------------------------------------------------------------
+
+// resolve(compiled, path) — the full reactive route object for `path`:
+// `{ path, params, query, matched }` where `matched` is the winning route
+// definition (or null for a total miss — but a `*` catch-all route, if
+// declared, always matches, giving apps a natural 404 slot).
+function resolve(compiled, path) {
+  const m = matchRoute(compiled, path);
+  return {
+    path: normalizePath(path),
+    params: m ? m.params : {},
+    query: parseQuery(path),
+    matched: m ? m.route : null,
+  };
+}
+
+// createRouter(routes, options) — build a router over `routes`
+//   routes  = [{ path: "/users/:id", component: UserPage }, …]
+//   options = {
+//     history?:    an adapter (defaults to historyAdapter() over `window`)
+//     beforeEach?: (to, from) => boolean | Promise<boolean>  — false cancels
+//   }
+//
+// The current route lives in a store field named "route", so components adopt
+// it via `useStore(c, i, router.store, "route")` (or the `router.adopt` sugar)
+// and plain consumers via `router.subscribe(fn)`.
+export function createRouter(routes, options) {
+  const opts = options || {};
+  const history = opts.history || historyAdapter();
+  const beforeEach = opts.beforeEach || null;
+  const compiled = (routes || []).map(compileRoute);
+
+  const store = createStore({ route: resolve(compiled, history.location) });
+
+  // navigate(path, mode) — the single entry point behind push/replace and the
+  // popstate listener. Runs the (optional) async guard first: a falsy result
+  // cancels the navigation (the store is left untouched). `mode` is "push",
+  // "replace", or "pop" (a browser-driven change already reflected in history,
+  // so we only update the store, never call history again).
+  function navigate(path, mode) {
+    const from = store.get("route");
+    const to = resolve(compiled, path);
+    const commit = () => {
+      if (mode === "push") history.push(path);
+      else if (mode === "replace") history.replace(path);
+      store.set("route", to);
+    };
+    if (!beforeEach) {
+      commit();
+      return Promise.resolve(true);
+    }
+    return Promise.resolve(beforeEach(to, from)).then((ok) => {
+      if (ok === false) return false;
+      commit();
+      return true;
+    });
+  }
+
+  // Browser back/forward (or memoryHistory.go) lands here already committed to
+  // history; resolve into the store without pushing again.
+  const stopListen = history.listen((path) => {
+    navigate(path, "pop");
+  });
+
+  return {
+    // The backing store — components adopt the route field through it.
+    store,
+
+    // current — the reactive route object `{ path, params, query, matched }`.
+    // Reading it declares no dependency by itself; adoption is what wires
+    // reactivity (see `adopt`/`useStore`).
+    get current() {
+      return store.get("route");
+    },
+
+    // push(path) — navigate, pushing a new history entry. Returns a Promise
+    // resolving to whether the navigation committed (a guard may cancel it).
+    push(path) {
+      return navigate(path, "push");
+    },
+
+    // replace(path) — navigate, replacing the current history entry.
+    replace(path) {
+      return navigate(path, "replace");
+    },
+
+    // back() — go back one history entry (guard-free, like the browser button).
+    back() {
+      history.go(-1);
+    },
+
+    // forward() — go forward one history entry.
+    forward() {
+      history.go(1);
+    },
+
+    // subscribe(fn) — plain-JS subscription to route changes; `fn(route)` runs
+    // synchronously on every committed navigation. Returns an unsubscribe fn.
+    subscribe(fn) {
+      return store.subscribe("route", fn);
+    },
+
+    // adopt(c, i) — sugar over `useStore(c, i, router.store, "route")`: adopt
+    // the current route at component context `c`'s reactive index `i`. Returns
+    // a detach() (idempotent, scope-aware). This is the compiler-facing hook
+    // for a component that reads `router.current` in its template/handlers.
+    adopt(c, i) {
+      return useStore(c, i, store, "route");
+    },
+
+    // destroy() — detach the history listener (for teardown/HMR).
+    destroy() {
+      stopListen();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Outlet (§4)
+// ---------------------------------------------------------------------------
+
+// routerOutlet(c, anchor, router, options) — mount the matched route's
+// component at the text `anchor` (mountChild semantics: inserted before the
+// anchor), swapping it out whenever navigation changes which route matches.
+//
+// The matched route's captured params are passed as props to the component;
+// `options.props(route)` can override/augment that mapping (e.g. to inject the
+// router itself or the parsed query). Re-mounts only when the *matched route
+// definition* changes, not on every param tweak — a `/users/:id` component
+// stays mounted across `1 → 2` (its own props reactivity handles the change);
+// the outlet only owns mount/unmount.
+//
+// Teardown: mountChild returns an { unmount } that removes the root node.
+// blocks.mjs's mountChild does not itself open a scope, so an outlet-mounted
+// component owns its own reactive context (created by `component()`), which is
+// dropped along with the removed subtree — nothing to dropScope here. The
+// outlet subscribes to the router directly (plain-JS subscribe), so it needs
+// no reactive index of its own and returns a handle with destroy().
+//
+// Intended emitted shape (compiler-facing contract): the `<router-outlet/>`
+// element (or the placeholder an @useAutoRouting directive expands to) compiles
+// to an anchor + a single routerOutlet call:
+//
+//   const a = anchorBefore(placeholder);
+//   const outlet = routerOutlet(c, a, appRouter);
+function routerOutlet(c, anchor, router, options) {
+  const opts = options || {};
+  const makeProps = opts.props || null;
+  let mounted = null; // { root, unmount } from mountChild
+  let currentKey = undefined; // stable key of the route def currently mounted
+
+  const propsFor = (route) =>
+    makeProps ? makeProps(route) : Object.assign({}, route.params);
+
+  // The route object read from the store is deep-proxy-wrapped (store.mjs), so
+  // `route.matched` is a *view* of the route definition, never `===` the
+  // original — identity checks won't work. Route `path`s are the unique keys of
+  // the route table, so use the matched def's path (or a null sentinel for a
+  // 404 miss) as the "did the matched route change?" signal.
+  const keyOf = (route) => (route.matched ? route.matched.path : null);
+
+  const render = (route) => {
+    const key = keyOf(route);
+    // Same route definition still matches: leave the mounted component in
+    // place. A distinct key (including null → route, or route → null on a 404
+    // miss with no catch-all) swaps.
+    if (key === currentKey) return;
+    if (mounted) {
+      mounted.unmount();
+      mounted = null;
+    }
+    currentKey = key;
+    if (route.matched && route.matched.component) {
+      mounted = mountChild(c, anchor, route.matched.component, propsFor(route));
+    }
+  };
+
+  render(router.current);
+  const unsub = router.subscribe(render);
+
+  return {
+    destroy() {
+      unsub();
+      if (mounted) {
+        mounted.unmount();
+        mounted = null;
+      }
+      currentKey = undefined;
+    },
+  };
+}
+
+export { routerOutlet };
+
+// ---------------------------------------------------------------------------
+// Links (§5)
+// ---------------------------------------------------------------------------
+
+// routerLink(el, router, path, options) — wire `el`'s click to a client-side
+// navigation: preventDefault + router.push(path) (or router.replace when
+// `options.replace`). Modified clicks (ctrl/meta/shift/alt) and non-primary
+// buttons fall through to the browser so "open in new tab" still works — the
+// standard SPA-link contract. Returns an unbind() that removes the listener.
+//
+// This is the codegen target for `<a :href="/users/1">…</a>` route links: the
+// compiler emits `routerLink(aEl, router, "/users/1")` alongside setting the
+// element's static `href` (kept for SSR/no-JS and middle-click).
+function routerLink(el, router, path, options) {
+  const opts = options || {};
+  const handler = (e) => {
+    // Respect modifier/aux clicks and any handler that already handled it.
+    if (
+      e.defaultPrevented ||
+      (e.button !== undefined && e.button !== 0) ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey
+    ) {
+      return;
+    }
+    if (typeof e.preventDefault === "function") e.preventDefault();
+    if (opts.replace) router.replace(path);
+    else router.push(path);
+  };
+  el.addEventListener("click", handler);
+  return () => el.removeEventListener("click", handler);
+}
+
+export { routerLink };
+
+// Pure helpers — useful for compiler tests and advanced use (a router is not
+// required to parse a query string or canonicalize a path).
+export { parseQuery, normalizePath };

--- a/packages/lunas/test/router.test.mjs
+++ b/packages/lunas/test/router.test.mjs
@@ -1,0 +1,317 @@
+// router.test.mjs — client-side router runtime (createRouter/routerOutlet/
+// routerLink) driven with memoryHistory, no real browser.
+// Run: node packages/lunas/test/router.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind } from "../src/core.mjs";
+import { component } from "../src/dom.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import {
+  createRouter,
+  memoryHistory,
+  routerOutlet,
+  routerLink,
+  parseQuery,
+  normalizePath,
+} from "../src/router.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// A trivial compiled component: <div>tag</div>, records the props it got.
+function makeComponent(tag, sink) {
+  return component("div", {}, "", (c, props) => {
+    c.root.setAttribute("data-page", tag);
+    if (sink) sink.push({ tag, props });
+  });
+}
+
+// -- pure matching -----------------------------------------------------------
+
+await test("matching: static beats param beats catch-all", async () => {
+  // Route objects read back through the store are deep-proxy-wrapped, so we
+  // assert on the matched route's stable `path` rather than object identity.
+  const routes = [
+    { path: "/users/:id", component: makeComponent("param") },
+    { path: "/users/me", component: makeComponent("static") },
+    { path: "*", component: makeComponent("catch") },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/users/me") });
+  assert.strictEqual(router.current.matched.path, "/users/me",
+    "static /users/me wins over /users/:id");
+  await router.push("/users/42");
+  assert.strictEqual(router.current.matched.path, "/users/:id",
+    "param matches a non-literal segment");
+  assert.deepStrictEqual(router.current.params, { id: "42" });
+  await router.push("/nope/here");
+  assert.strictEqual(router.current.matched.path, "*",
+    "catch-all is the fallback");
+});
+
+await test("matching: params captured, catch-all captures the rest", async () => {
+  const routes = [
+    { path: "/a/:x/:y", component: null },
+    { path: "/files/*rest", component: null },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/a/1/2") });
+  assert.deepStrictEqual(router.current.params, { x: "1", y: "2" });
+  await router.push("/files/deep/nested/path");
+  assert.deepStrictEqual(router.current.params, { rest: "deep/nested/path" });
+});
+
+await test("query parsing + trailing-slash normalization", async () => {
+  assert.deepStrictEqual(parseQuery("/x?a=1&b=two&flag"), {
+    a: "1",
+    b: "two",
+    flag: "",
+  });
+  assert.deepStrictEqual(parseQuery("/x?q=a+b%20c"), { q: "a b c" });
+  assert.strictEqual(normalizePath("/a/b/"), "/a/b");
+  assert.strictEqual(normalizePath("/"), "/");
+  assert.strictEqual(normalizePath(""), "/");
+
+  const router = createRouter(
+    [{ path: "/search", component: null }],
+    { history: memoryHistory("/search/?q=hi&page=2") }
+  );
+  assert.strictEqual(router.current.path, "/search", "trailing slash normalized");
+  assert.deepStrictEqual(router.current.query, { q: "hi", page: "2" });
+  assert.strictEqual(router.current.matched.path, "/search",
+    "trailing slash still matches the route");
+});
+
+// -- navigation --------------------------------------------------------------
+
+await test("push / replace / back over memoryHistory", async () => {
+  const hist = memoryHistory("/");
+  const router = createRouter([{ path: "*", component: null }], { history: hist });
+  await router.push("/a");
+  assert.strictEqual(router.current.path, "/a");
+  assert.strictEqual(hist.location, "/a");
+  await router.push("/b");
+  assert.strictEqual(router.current.path, "/b");
+  await router.replace("/b2");
+  assert.strictEqual(router.current.path, "/b2");
+  assert.strictEqual(hist.location, "/b2");
+  router.back();
+  await tick();
+  assert.strictEqual(router.current.path, "/a", "back returns to /a (replace kept one entry)");
+});
+
+await test("popstate (history.go) drives the store without re-pushing", async () => {
+  const hist = memoryHistory("/one");
+  const router = createRouter([{ path: "*", component: null }], { history: hist });
+  await router.push("/two");
+  router.back();
+  await tick();
+  assert.strictEqual(router.current.path, "/one");
+  router.forward();
+  await tick();
+  assert.strictEqual(router.current.path, "/two");
+});
+
+// -- reactive current route through a component context ----------------------
+
+await test("reactive current-route updates through a component (bind fires on nav)", async () => {
+  const hist = memoryHistory("/home");
+  const router = createRouter([{ path: "*", component: null }], { history: hist });
+  const c = createContext(null);
+  router.adopt(c, 0); // adopt route field at reactive index 0
+
+  const seen = [];
+  bind(c, [0], () => seen.push(router.current.path));
+  assert.deepStrictEqual(seen, ["/home"], "bind ran once immediately");
+
+  await router.push("/about");
+  await tick();
+  assert.deepStrictEqual(seen, ["/home", "/about"], "bind re-ran on navigation");
+
+  await router.push("/contact");
+  await tick();
+  assert.deepStrictEqual(seen, ["/home", "/about", "/contact"]);
+});
+
+await test("plain subscribe fires synchronously on commit", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/"),
+  });
+  const seen = [];
+  const unsub = router.subscribe((r) => seen.push(r.path));
+  await router.push("/x");
+  assert.deepStrictEqual(seen, ["/x"]);
+  unsub();
+  await router.push("/y");
+  assert.deepStrictEqual(seen, ["/x"], "no callback after unsubscribe");
+});
+
+// -- outlet mount / unmount + params-as-props --------------------------------
+
+await test("outlet mounts the matched component, passing params as props", async () => {
+  const hits = [];
+  const routes = [
+    { path: "/users/:id", component: makeComponent("user", hits) },
+    { path: "/about", component: makeComponent("about", hits) },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/users/7") });
+
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  const outlet = routerOutlet(c, anchor, router);
+
+  // The user page is mounted before the anchor with its id prop.
+  assert.strictEqual(parent.childNodes.length, 2, "component + anchor");
+  assert.strictEqual(parent.childNodes[0].getAttribute("data-page"), "user");
+  assert.strictEqual(hits.length, 1);
+  assert.deepStrictEqual(hits[0].props, { id: "7" });
+
+  const firstRoot = parent.childNodes[0];
+  await router.push("/about");
+  assert.strictEqual(parent.childNodes[0].getAttribute("data-page"), "about",
+    "swapped to the about page");
+  assert.strictEqual(firstRoot.parentNode, null, "old page unmounted (removed)");
+  assert.strictEqual(hits.length, 2);
+
+  outlet.destroy();
+  assert.strictEqual(parent.childNodes.length, 1, "destroy unmounts, anchor remains");
+});
+
+await test("outlet keeps the same component mounted across param-only changes", async () => {
+  const hits = [];
+  const routes = [
+    { path: "/users/:id", component: makeComponent("user", hits) },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/users/1") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  routerOutlet(c, anchor, router);
+
+  const root1 = parent.childNodes[0];
+  assert.strictEqual(hits.length, 1);
+  await router.push("/users/2"); // same route def, different param
+  assert.strictEqual(parent.childNodes[0], root1, "component instance reused");
+  assert.strictEqual(hits.length, 1, "no re-mount for a param-only change");
+});
+
+await test("outlet 404: catch-all mounts, no match leaves the anchor empty", async () => {
+  const hits = [];
+  const routes = [
+    { path: "/home", component: makeComponent("home", hits) },
+    { path: "*", component: makeComponent("notfound", hits) },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/does/not/exist") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  routerOutlet(c, anchor, router);
+  assert.strictEqual(parent.childNodes[0].getAttribute("data-page"), "notfound",
+    "catch-all 404 component mounted");
+
+  // A router with NO catch-all: a miss mounts nothing.
+  const router2 = createRouter(
+    [{ path: "/home", component: makeComponent("home") }],
+    { history: memoryHistory("/missing") }
+  );
+  const p2 = document.createElement("div");
+  const a2 = anchorAppend(p2);
+  routerOutlet(createContext(p2), a2, router2);
+  assert.strictEqual(p2.childNodes.length, 1, "only the anchor, nothing mounted");
+  assert.strictEqual(router2.current.matched, null);
+});
+
+// -- navigation guards -------------------------------------------------------
+
+await test("beforeEach (sync) cancels navigation when it returns false", async () => {
+  let allow = true;
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/start"),
+    beforeEach: (to) => allow || to.path === "/start",
+  });
+  const ok = await router.push("/blocked");
+  allow = false;
+  const ok2 = await router.push("/also-blocked");
+  assert.strictEqual(ok, true);
+  assert.strictEqual(router.current.path, "/blocked");
+  assert.strictEqual(ok2, false, "guard returned false");
+  assert.strictEqual(router.current.path, "/blocked", "route unchanged after cancel");
+});
+
+await test("beforeEach (async) supported; false cancels, true commits", async () => {
+  const gate = { pass: false };
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/"),
+    beforeEach: (to) =>
+      new Promise((res) => setTimeout(() => res(gate.pass), 0)),
+  });
+  const denied = await router.push("/secret");
+  assert.strictEqual(denied, false);
+  assert.strictEqual(router.current.path, "/");
+  gate.pass = true;
+  const allowed = await router.push("/secret");
+  assert.strictEqual(allowed, true);
+  assert.strictEqual(router.current.path, "/secret");
+});
+
+await test("beforeEach receives (to, from)", async () => {
+  const seen = [];
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/a"),
+    beforeEach: (to, from) => {
+      seen.push([from.path, to.path]);
+      return true;
+    },
+  });
+  await router.push("/b");
+  await router.push("/c");
+  assert.deepStrictEqual(seen, [["/a", "/b"], ["/b", "/c"]]);
+});
+
+// -- links -------------------------------------------------------------------
+
+await test("routerLink: plain click navigates, modified click falls through", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/"),
+  });
+  const a = document.createElement("a");
+  // The minimal dom-shim omits removeEventListener; add it locally so we can
+  // verify routerLink's returned unbind() actually detaches (browsers have it).
+  a.removeEventListener = function (ev, fn) {
+    const l = this._listeners[ev];
+    if (l) {
+      const i = l.indexOf(fn);
+      if (i >= 0) l.splice(i, 1);
+    }
+  };
+  const unbind = routerLink(a, router, "/target");
+
+  // Plain primary click: navigates, preventDefault called.
+  let prevented = false;
+  a.dispatch("click"); // dom-shim dispatch sends { type } — button undefined => primary
+  await tick();
+  assert.strictEqual(router.current.path, "/target");
+
+  // Modified click: falls through (no navigation).
+  a.addEventListener("click", () => {});
+  // Simulate a meta-click by dispatching a custom event object.
+  for (const fn of a._listeners.click) fn({ type: "click", metaKey: true, preventDefault() { prevented = true; } });
+  await tick();
+  assert.strictEqual(router.current.path, "/target", "meta-click did not navigate");
+  assert.strictEqual(prevented, false, "preventDefault not called for modified click");
+
+  unbind();
+  a.dispatch("click");
+  await tick();
+  assert.strictEqual(router.current.path, "/target", "no navigation after unbind");
+});
+
+console.log("router.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/types/router.d.ts
+++ b/packages/lunas/types/router.d.ts
@@ -1,0 +1,178 @@
+// router.d.ts — types for src/router.mjs
+// Client-side router runtime: route table + matching, history integration,
+// store-backed reactive current route, outlet, links, and navigation guards.
+
+import type { Context } from "./core.js";
+import type { Store } from "./store.js";
+
+/** Parsed query string: last-value-wins for repeated keys. */
+export type Query = Record<string, string>;
+
+/** Captured route params (`:name` segments and `*name` catch-all). */
+export type Params = Record<string, string>;
+
+/** A route definition in the route table. */
+export interface Route<C = unknown> {
+  /** Path pattern: static segments, `:param`s, and a trailing `*`/`*name`. */
+  path: string;
+  /** The component factory to mount when this route matches (outlet target). */
+  component?: C;
+  /** Arbitrary extra data carried on the route (name, meta, …). */
+  [extra: string]: unknown;
+}
+
+/** The reactive current-route value held in the router's store. */
+export interface RouteState<C = unknown> {
+  /** Normalized pathname (leading slash, no trailing slash, query stripped). */
+  path: string;
+  /** Captured params from the matched route. */
+  params: Params;
+  /** Parsed query string. */
+  query: Query;
+  /** The matched route definition, or null on a total miss (no catch-all). */
+  matched: Route<C> | null;
+}
+
+/** Unsubscribe / detach function. */
+export type Unsubscribe = () => void;
+
+/**
+ * A history adapter: the injectable seam between the router and the browser
+ * History API. `memoryHistory()` and `historyAdapter()` both satisfy it.
+ */
+export interface HistoryAdapter {
+  /** Current location as `pathname + search`. */
+  readonly location: string;
+  /** Push a new history entry (does NOT invoke `listen`'s callback). */
+  push(path: string): void;
+  /** Replace the current history entry (does NOT invoke `listen`'s callback). */
+  replace(path: string): void;
+  /** Go `delta` entries in history; invokes `listen`'s callback on a move. */
+  go(delta: number): void;
+  /** Subscribe to popstate-style changes; returns an unsubscribe. */
+  listen(fn: (path: string) => void): Unsubscribe;
+}
+
+/**
+ * memoryHistory(initial) — an in-memory History-API stand-in for tests/SSR.
+ * Keeps its own back-stack; `listen`'s callback fires on back()/forward()
+ * (the popstate analogue) but not on push()/replace().
+ */
+export function memoryHistory(initial?: string): HistoryAdapter;
+
+/**
+ * historyAdapter(win) — the default adapter over the browser History API.
+ * `win` defaults to the global `window`. Throws if no window is available
+ * (pass a memoryHistory() via options.history for non-browser environments).
+ */
+export function historyAdapter(win?: Window): HistoryAdapter;
+
+/** Options for createRouter. */
+export interface RouterOptions<C = unknown> {
+  /** History adapter; defaults to historyAdapter() over `window`. */
+  history?: HistoryAdapter;
+  /**
+   * Navigation guard run before every push/replace. Returning `false` (sync or
+   * via a resolved Promise) cancels the navigation; anything else commits it.
+   */
+  beforeEach?: (
+    to: RouteState<C>,
+    from: RouteState<C>
+  ) => boolean | Promise<boolean>;
+}
+
+/** A router instance created by createRouter. */
+export interface Router<C = unknown> {
+  /** The backing store; components adopt the route field through it. */
+  readonly store: Store<{ route: RouteState<C> }>;
+  /** The current reactive route object. */
+  readonly current: RouteState<C>;
+  /**
+   * Navigate, pushing a new history entry. Resolves to whether the navigation
+   * committed (a beforeEach guard may cancel it).
+   */
+  push(path: string): Promise<boolean>;
+  /** Navigate, replacing the current history entry. */
+  replace(path: string): Promise<boolean>;
+  /** Go back one history entry (guard-free, like the browser button). */
+  back(): void;
+  /** Go forward one history entry. */
+  forward(): void;
+  /**
+   * Plain-JS subscription to route changes; `fn(route)` runs synchronously on
+   * every committed navigation. Returns an unsubscribe.
+   */
+  subscribe(fn: (route: RouteState<C>) => void): Unsubscribe;
+  /**
+   * adopt(c, i) — sugar over `useStore(c, i, router.store, "route")`: adopt the
+   * current route at component context `c`'s reactive index `i`. Returns a
+   * detach() (idempotent, scope-aware). Compiler-facing hook for a component
+   * that reads `router.current`.
+   */
+  adopt(c: Context, i: number): Unsubscribe;
+  /** Detach the history listener (for teardown/HMR). */
+  destroy(): void;
+}
+
+/**
+ * createRouter(routes, options) — build a router over `routes`. The current
+ * route lives in a store field named "route", so components adopt it via
+ * `router.adopt(c, i)` (or `useStore`) and plain consumers via
+ * `router.subscribe(fn)`. Matching ranks static > param > catch-all.
+ */
+export function createRouter<C = unknown>(
+  routes: Route<C>[],
+  options?: RouterOptions<C>
+): Router<C>;
+
+/** A handle for whole-outlet teardown. */
+export interface OutletHandle {
+  destroy(): void;
+}
+
+/** Options for routerOutlet. */
+export interface OutletOptions<C = unknown> {
+  /**
+   * Map the current route to the props passed to the mounted component.
+   * Defaults to the matched route's captured params.
+   */
+  props?: (route: RouteState<C>) => Record<string, unknown>;
+}
+
+/**
+ * routerOutlet(c, anchor, router, options) — mount the matched route's
+ * component at the text `anchor` (mountChild semantics), swapping it out
+ * whenever navigation changes which route matches. Params are passed as props.
+ * Re-mounts only when the matched route definition changes, not on every param
+ * tweak. Returns a handle with destroy().
+ */
+export function routerOutlet<C = unknown>(
+  c: Context,
+  anchor: Node,
+  router: Router<C>,
+  options?: OutletOptions<C>
+): OutletHandle;
+
+/** Options for routerLink. */
+export interface LinkOptions {
+  /** Use router.replace instead of router.push. */
+  replace?: boolean;
+}
+
+/**
+ * routerLink(el, router, path, options) — wire `el`'s click to a client-side
+ * navigation (preventDefault + router.push, or replace when options.replace).
+ * Modified/aux clicks fall through to the browser. Returns an unbind().
+ */
+export function routerLink(
+  el: Element,
+  router: Router,
+  path: string,
+  options?: LinkOptions
+): Unsubscribe;
+
+/** parseQuery(p) — the `?a=1&b=2` portion of `p` as a plain object. */
+export function parseQuery(p: string): Query;
+
+/** normalizePath(p) — canonical pathname (leading slash, no trailing, no query). */
+export function normalizePath(p: string): string;


### PR DESCRIPTION
## What

Adds `packages/lunas/src/router.mjs` — a dependency-free, tree-shakeable client-side router runtime that the future `@useRouting`/`@useAutoRouting` codegen will target. A router is conceptually a store of the current route: it reuses `store.mjs` so components adopt the route at a reactive index the same way they adopt any store field.

**Public API (all from `lunas/router`):**
- `createRouter(routes, options)` — route table with static / `:param` / `*` catch-all matching, ranked **static > param > catch-all**; trailing-slash normalization; query-string parsing. `router.current` is the reactive `{ path, params, query, matched }`; `push`/`replace`/`back`/`forward`; `subscribe(fn)`; `adopt(c, i)`.
- `memoryHistory(initial)` / `historyAdapter(win)` — history is behind an injectable adapter; the History-API adapter is the default, `memoryHistory()` is the in-memory stand-in for tests/SSR (injectable via `options.history`).
- `routerOutlet(c, anchor, router, opts)` — mounts the matched component via `mountChild` semantics, swaps on navigation (re-mounts **only** when the matched route definition changes, not on param-only changes), passes params as props.
- `routerLink(el, router, path, opts)` — `click → preventDefault + router.push` (aux/modified clicks fall through); codegen target for `<a :href>` route links.
- `options.beforeEach(to, from)` guard — returning `false` cancels; sync **and** async (Promise) supported.

## Why

Roadmap item `a-router` ("Router runtime"). This is the runtime the compiler will emit calls into; the intended emitted shape is documented in `router.mjs` doc comments and `output-design.md` §5.

## Notes

- Append-only integration, no refactors of `blocks.mjs`/`for_diff.mjs`/dom-shim: `index.mjs` re-exports, `types/router.d.ts` (strict-clean under `tsc --strict`), `package.json` `./router` subpath, README rows, `output-design.md` §5 block + intended emitted shape.
- One subtlety handled: the route object read back through the store is deep-proxy-wrapped, so the outlet keys re-mounts on the matched route's unique `path` string rather than object identity.

## Tests

`packages/lunas/test/router.test.mjs` — 14 cases driven by `memoryHistory` (no real browser): matching/ranking, params + query, push/replace/back, popstate via `history.go`, reactive current-route through a component context, outlet mount/unmount + param-only reuse, 404 catch-all (and no-catch-all miss), sync/async `beforeEach` cancel, `(to, from)` args, links. All runtime tests green via `node test/run-all.mjs` (8 files); tree-shake side-effect scan passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)