### PR TITLE
chore(ci): restore branch-prefix PR labels and beta release PR automation

### DIFF
--- a/.github/pr-release-templates/release-template.erb
+++ b/.github/pr-release-templates/release-template.erb
@@ -1,0 +1,37 @@
+🚀 Release (<%= Time.now.strftime('%Y-%m-%d') %> - <%= ENV['GIT_PR_RELEASE_BRANCH_PRODUCTION'] %>)
+## 🛠 Fixes
+<%- pull_requests.each do |pr| -%>
+<%- if pr.labels.any? { |l| l.name == 'fix' } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>
+## ✨ New Features
+<%- pull_requests.each do |pr| -%>
+<%- if pr.labels.any? { |l| l.name == 'feature' } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>
+## 🔨 Refactoring
+<%- pull_requests.each do |pr| -%>
+<%- if pr.labels.any? { |l| l.name == 'refactor' } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>
+## 📌 Version Updates
+<%- pull_requests.each do |pr| -%>
+<%- if pr.labels.any? { |l| l.name == 'version' } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>
+## 🔧 Chore
+<%- pull_requests.each do |pr| -%>
+<%- if pr.labels.any? { |l| l.name == 'chore' } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>
+## 👻 Others
+<%- pull_requests.each do |pr| -%>
+<%- unless pr.labels.any? { |l| ['fix', 'feature', 'refactor', 'version', 'chore'].include?(l.name) } -%>
+- [ ] #<%= pr.number %> @<%= pr.user.login %>
+<%- end -%>
+<%- end -%>

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -1,0 +1,47 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine label and apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          case "$BRANCH_NAME" in
+            fix/*)
+              LABEL="fix"
+              ;;
+            feat/*|feature/*)
+              LABEL="feature"
+              ;;
+            refactor/*)
+              LABEL="refactor"
+              ;;
+            version/*)
+              LABEL="version"
+              ;;
+            chore/*)
+              LABEL="chore"
+              ;;
+            docs/*)
+              LABEL="documentation"
+              ;;
+            *)
+              LABEL=""
+              ;;
+          esac
+
+          if [[ -n "$LABEL" ]]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+          fi

--- a/.github/workflows/pr-release-beta.yml
+++ b/.github/workflows/pr-release-beta.yml
@@ -1,0 +1,25 @@
+name: Create Release Pull Request to Beta Branch
+on:
+  push:
+    branches: [main]
+jobs:
+  release-pull-request:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - run: gem install --no-document git-pr-release
+      - run: git-pr-release
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: beta
+          GIT_PR_RELEASE_BRANCH_STAGING: main
+          GIT_PR_RELEASE_LABELS: beta
+          GIT_PR_RELEASE_TEMPLATE: .github/pr-release-templates/release-template.erb
+          TZ: Asia/Tokyo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ Claude drives development from the roadmap autonomously:
    and open a PR with `gh pr create`. The orchestrator merges PRs (squash)
    once checks pass — merging is pre-authorized, no need to ask. Merge
    sequentially; rebase follow-ups on fresh `main`.
+   - Branch prefix convention (also drives automatic PR labeling via
+     `add-labels.yml`): `feat/` features, `fix/` bug fixes, `refactor/`
+     refactors, `chore/` chores, `docs/` documentation, `version/` release
+     version bumps. Those same labels categorize PRs into the auto-generated
+     beta release PR (`pr-release-beta.yml`, `git-pr-release` from `main`
+     into `beta`), so picking the right prefix keeps the release notes
+     accurate.
 4. **Quality gate before any PR:** `cargo fmt --check`, `cargo clippy
    --workspace -D warnings`, `cargo test --workspace` (run inside `crates/`),
    plus the runtime test driver (`node packages/lunas/test/run-all.mjs`) for


### PR DESCRIPTION
## What

Restores the release automation deleted during the rewrite, recovered from git history at `1b36b2db3d624c43d9f962e9b454e70d98ddf91e` and modernized:

- **`.github/workflows/add-labels.yml`** — labels PRs from their head-branch prefix (`fix/`, `feat/`|`feature/`, `refactor/`, `version/`, `chore/`, `docs/`).
- **`.github/workflows/pr-release-beta.yml`** — `git-pr-release`-driven PR from `main` into `beta` on every push to `main`.
- **`.github/pr-release-templates/release-template.erb`** — restored verbatim (byte-for-byte diff-clean against the historical file).
- **`CLAUDE.md`** — documents the branch-prefix convention and how it feeds labeling + release-note categorization.

## Why

The repo lost its release automation during the rewrite. `origin/beta` still exists and the labels these workflows rely on (`fix`, `feature`, `refactor`, `version`, `chore`, `beta`, `documentation`) are already present, so this just reconnects the wiring.

## Modernizations vs. the historical files

**`add-labels.yml`**
- Trigger widened to `[opened, reopened]`; added explicit `permissions: pull-requests: write`.
- Dropped the `actions/checkout` + `actions/setup-node` steps — unnecessary for a single `gh` call.
- Replaced the `if/elif` chain with a `case` statement.
- Inputs (`BRANCH_NAME`, `PR_NUMBER`) now passed through `env:` instead of interpolated directly into `run:` — avoids script-injection from a crafted branch name.
- `gh pr edit` now takes `--repo "$GITHUB_REPOSITORY"` explicitly and uses `GH_TOKEN` (gh's preferred env var name).
- Added a `docs/*` → `documentation` mapping (not present in the original).

**`pr-release-beta.yml`**
- `actions/checkout@v4` now passes `fetch-depth: 0` (git-pr-release needs full history to diff branches).
- Ruby bumped from `3.1` to `3.3`.
- Dropped the old `publish-package-test` job — it depended on a `task build` / wasm-pack pipeline that no longer exists post-rewrite.

**`release-template.erb`**
- Restored verbatim, no changes (confirmed via diff against the historical `git show` output).

**`CLAUDE.md`**
- Extended the existing branch-naming note into an explicit prefix list/table (`feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `version/`), noting it drives `add-labels.yml` and that those labels categorize the `pr-release-beta.yml` release PR.

## Test plan

- [x] Both workflow YAMLs parsed successfully with `ruby -ryaml -e 'YAML.load_file(...)'`.
- [x] `release-template.erb` diffed byte-for-byte identical to the historical version.
- [ ] First real PR against `main` triggers `add-labels.yml` and applies the correct label.
- [ ] First push to `main` after merge triggers `pr-release-beta.yml` and opens/updates the beta release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)