### PR TITLE
feat(codegen): control flow — two-way, :if cascades, keyed :for

### DIFF
--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -1,19 +1,32 @@
 //! The JS emitter pass: turns a [`crate::ResolvedComponent`] into a runnable ES
 //! module that targets the runtime in `packages/lunas` (see
-//! `docs/output-design.md`).
+//! `docs/output-design.md` and `docs/for-diff-design.md`).
 //!
-//! Scope (Wave 1): plain text binds, attribute binds (incl. interpolated static
-//! attrs), and event listeners. Positional refs and runtime text anchors are
-//! emitted per §7–8. Control flow (`:if`/`:for`), two-way bindings, and child
-//! components are **not** wired yet — they are voided with a `/* TODO */` marker
-//! (and, for two-way, a diagnostic) so the module still compiles and runs.
+//! Scope (Wave 2): text binds, attribute binds, event listeners, two-way
+//! bindings (`::name`), `:if`/`:elseif`/`:else` cascades (`ifBlock`/`ifChain`),
+//! and keyed `:for` (`forBlock` in compiled html/wire mode: bulk `innerHTML`
+//! initial render + keyed diff updates). Control flow is emitted recursively,
+//! so nested combinations (`:if` in `:for`, `:for` in `:if`, …) work; each
+//! branch/item is its own *fragment* with its own static HTML string (hoisted
+//! at module scope), positional refs, anchors, and binds.
+//!
+//! Child components, `:for`+`:if` on the same element, and `:for` over a
+//! non-element body are not wired yet — they are voided with a comment (and a
+//! warning diagnostic where the author would otherwise be surprised) so the
+//! module still compiles and runs.
 //!
 //! The reactive model is compile-time adjacency dispatch (§4): each reactive
 //! variable becomes a box at a stable index; references to it are rewritten to
-//! `.v`; each dynamic part `bind(c, deps, …)`s with its precomputed dep indices.
+//! `.v`; each dynamic part `bind(c, deps, …)`s with its precomputed dep
+//! indices. Inside a `:for` item, expressions that read the loop bindings are
+//! registered as `bind(c, [], …)` so the item's patch path (`runScope`) can
+//! refresh them when the item's data cell changes.
 
-use lunas_parser::{Diagnostic, StaticValue, TemplateAttr, TemplateText, TextRange, TextSegment};
-use lunas_script::module_binding_references;
+use lunas_parser::{
+    Diagnostic, ForBlock, IfChain, StaticValue, Template, TemplateAttr, TemplateElement,
+    TemplateNode, TemplateText, TextRange, TextSegment,
+};
+use lunas_script::{module_binding_references, parse_for, ForKind};
 
 use crate::codegen::skeleton::{
     build_skeleton, DynamicElement, InsertPos, Skeleton, Slot, SlotContent,
@@ -22,9 +35,45 @@ use crate::model::{DynamicKind, ReactiveVar, ResolvedComponent};
 
 /// The root wrapper tag. The skeleton HTML is the wrapper's `innerHTML`, so all
 /// positional [`refs`](../../packages/lunas/src/dom.mjs) paths are `childNodes`
-/// indices from this element. A neutral `<div>` is used for every component in
-/// Wave 1 (single-root / multi-root distinction is a later optimization).
+/// indices from this element. A neutral `<div>` is used for every component
+/// (single-root / multi-root distinction is a later optimization).
 const ROOT_TAG: &str = "div";
+
+/// Hard cap on control-flow nesting; beyond it blocks are voided with a
+/// diagnostic instead of recursing (never-panic guarantee).
+const MAX_BLOCK_DEPTH: u32 = 32;
+
+/// Every runtime helper the emitter can reference by a bare name. Used to
+/// detect collisions with user bindings (a reactive var named `on` would
+/// shadow the `on` helper); a colliding helper is imported under an alias.
+const ALL_HELPERS: &[&str] = &[
+    "refs",
+    "on",
+    "bind",
+    "box",
+    "deepBox",
+    "anchorBefore",
+    "anchorBeforeSplit",
+    "anchorAppend",
+    "ifBlock",
+    "ifChain",
+    "forBlock",
+    "fromHTML",
+    // `component` is intentionally excluded: it is only referenced at module
+    // scope (the default export), where user bindings — emitted inside the
+    // setup closure — cannot shadow it.
+];
+
+/// A collision-proof local alias for a runtime helper whose canonical name is
+/// taken by a user binding. Prefixes with `$` (rare in hand-written state) and
+/// appends underscores until the name is unused.
+fn alias_name(helper: &str, reserved: &std::collections::HashSet<String>) -> String {
+    let mut name = format!("${helper}");
+    while reserved.contains(&name) {
+        name.push('_');
+    }
+    name
+}
 
 /// Compiles a `.lunas` source string into a runnable ES module.
 ///
@@ -57,7 +106,17 @@ fn emit_module(component: &ResolvedComponent, diags: &mut Vec<Diagnostic>) -> Op
     out.push('\n');
     out.push_str("const HTML = ");
     push_js_string(&mut out, &skeleton.html);
-    out.push_str(";\n\n");
+    out.push_str(";\n");
+    // Hoisted branch/item skeletons (one per :if branch / :for item template),
+    // defined once per module like HTML itself.
+    for (name, html) in &e.hoisted {
+        out.push_str("const ");
+        out.push_str(name);
+        out.push_str(" = ");
+        push_js_string(&mut out, html);
+        out.push_str(";\n");
+    }
+    out.push('\n');
     out.push_str("export default component(");
     push_js_string(&mut out, ROOT_TAG);
     out.push_str(", {}, HTML, (c, props) => {\n");
@@ -66,33 +125,165 @@ fn emit_module(component: &ResolvedComponent, diags: &mut Vec<Diagnostic>) -> Op
     Some(out)
 }
 
+/// The lexical context of one emitted fragment (the component root, an `:if`
+/// branch, or a `:for` item).
+struct Frag<'x> {
+    /// JS expression for the fragment's root node (`c.root`, or a scratch /
+    /// item root local like `r0`).
+    base: &'x str,
+    /// Loop-binding names in scope: they shadow same-named reactive variables
+    /// (no `.v` rewrite, no dep registration) and expressions reading them are
+    /// re-run by the enclosing item's patch path.
+    shadowed: &'x [String],
+    /// Indentation level (1 = the setup body).
+    indent: usize,
+    /// Control-flow nesting depth (for the recursion cap).
+    depth: u32,
+    /// How many leading path segments to strip: `:for` item fragments receive
+    /// the item ROOT node (not a scratch container), so the skeleton's `[0, …]`
+    /// paths become `[…]` relative to it.
+    strip: usize,
+}
+
 struct Emitter<'a> {
     component: &'a ResolvedComponent,
     /// Runtime helper names referenced by the emitted module, collected while
     /// generating so the import line stays minimal.
     used: std::collections::BTreeSet<&'static str>,
+    /// Local aliases for runtime helpers whose canonical name collides with a
+    /// user binding (e.g. a reactive var named `on` would shadow the `on`
+    /// helper). Maps the canonical helper name to the local name to import it
+    /// as and reference. Empty in the common no-collision case.
+    aliases: std::collections::BTreeMap<&'static str, String>,
+    /// Hoisted static HTML strings for control-flow fragments: (const name,
+    /// html), emitted at module scope in creation order.
+    hoisted: Vec<(String, String)>,
+    /// Text used for deep-mutation detection: the script plus one synthetic
+    /// assignment per two-way member/index lvalue (`::value="o.k"` deep-writes
+    /// `o`, so `o` needs a `deepBox` even if the script never mutates it).
+    deep_hint: String,
+    n_ref: usize,    // e{n}
+    n_text: usize,   // t{n}
+    n_anchor: usize, // a{n}
+    n_root: usize,   // r{n}
+    n_data: usize,   // d{n}
+    n_html: usize,   // HTML_{n}
 }
 
 impl<'a> Emitter<'a> {
     fn new(component: &'a ResolvedComponent) -> Self {
+        let script_text = component
+            .script
+            .as_ref()
+            .map(|s| s.source.text.as_str())
+            .unwrap_or("");
+        let mut deep_hint = String::from(script_text);
+        if let Some(template) = &component.template {
+            for lv in two_way_lvalues(template) {
+                // Only member/index writes imply deep mutation; a plain
+                // identifier lvalue is whole reassignment (a plain `box`).
+                if lv.contains('.') || lv.contains('[') {
+                    deep_hint.push('\n');
+                    deep_hint.push_str(&lv);
+                    deep_hint.push_str(" = 0;");
+                }
+            }
+        }
+        // Names that would shadow a runtime helper if imported bare: every
+        // top-level script binding plus every prop. A helper whose canonical
+        // name appears here is imported under a collision-proof alias instead.
+        let mut reserved: std::collections::HashSet<String> = std::collections::HashSet::new();
+        if let Some(script) = &component.script {
+            if let Ok(names) = lunas_script::declared_bindings(&script.source.text) {
+                reserved.extend(names);
+            }
+        }
+        for p in &component.props {
+            reserved.insert(p.name.clone());
+        }
+        let mut aliases = std::collections::BTreeMap::new();
+        for &h in ALL_HELPERS {
+            if reserved.contains(h) {
+                aliases.insert(h, alias_name(h, &reserved));
+            }
+        }
+
         Emitter {
             component,
             used: std::collections::BTreeSet::new(),
+            aliases,
+            hoisted: Vec::new(),
+            deep_hint,
+            n_ref: 0,
+            n_text: 0,
+            n_anchor: 0,
+            n_root: 0,
+            n_data: 0,
+            n_html: 0,
         }
     }
 
     /// `import { … } from "lunas";` covering every helper actually referenced.
+    /// A helper whose canonical name collides with a user binding is imported
+    /// under its alias (`on as _on$`).
     fn import_line(&self) -> String {
         // `component` is always used (the module's default export).
         let mut names: Vec<&str> = self.used.iter().copied().collect();
         if !names.contains(&"component") {
             names.insert(0, "component");
         }
-        format!("import {{ {} }} from \"lunas\";", names.join(", "))
+        let specs: Vec<String> = names
+            .iter()
+            .map(|&n| match self.aliases.get(n) {
+                Some(alias) => format!("{n} as {alias}"),
+                None => n.to_string(),
+            })
+            .collect();
+        format!("import {{ {} }} from \"lunas\";", specs.join(", "))
     }
 
     fn use_helper(&mut self, name: &'static str) {
         self.used.insert(name);
+    }
+
+    /// The local name to *reference* a helper by — its alias if the canonical
+    /// name collides with a user binding, else the canonical name.
+    fn helper(&self, name: &'static str) -> &str {
+        self.aliases.get(name).map(|s| s.as_str()).unwrap_or(name)
+    }
+
+    // --- name allocation ----------------------------------------------------
+
+    fn alloc_ref(&mut self) -> String {
+        let n = self.n_ref;
+        self.n_ref += 1;
+        format!("e{n}")
+    }
+    fn alloc_text(&mut self) -> String {
+        let n = self.n_text;
+        self.n_text += 1;
+        format!("t{n}")
+    }
+    fn alloc_anchor(&mut self) -> String {
+        let n = self.n_anchor;
+        self.n_anchor += 1;
+        format!("a{n}")
+    }
+    fn alloc_root(&mut self) -> String {
+        let n = self.n_root;
+        self.n_root += 1;
+        format!("r{n}")
+    }
+    fn alloc_data(&mut self) -> String {
+        let n = self.n_data;
+        self.n_data += 1;
+        format!("d{n}")
+    }
+    fn hoist_html(&mut self, html: String) -> String {
+        self.n_html += 1;
+        let name = format!("HTML_{}", self.n_html);
+        self.hoisted.push((name.clone(), html));
+        name
     }
 
     /// The body of the `setup` closure: props, boxes, refs, anchors, binds and
@@ -102,9 +293,14 @@ impl<'a> Emitter<'a> {
 
         self.emit_props(&mut b);
         self.emit_boxes(&mut b);
-        self.emit_refs(&mut b, &skeleton.dynamic_elements);
-        self.emit_text_slots(&mut b, &skeleton.slots, diags);
-        self.emit_attr_and_event_wiring(&mut b, &skeleton.dynamic_elements, diags);
+        let frag = Frag {
+            base: "c.root",
+            shadowed: &[],
+            indent: 1,
+            depth: 0,
+            strip: 0,
+        };
+        self.emit_fragment(&mut b, skeleton, &frag, diags);
 
         b
     }
@@ -142,11 +338,16 @@ impl<'a> Emitter<'a> {
             .unwrap_or("");
         // Rewrite the script body so reactive declarations become boxes and all
         // references become `.v`.
-        let rewritten = rewrite_script(script_text, &self.component.reactive_vars);
+        let rewritten = rewrite_script(
+            script_text,
+            &self.deep_hint,
+            &self.component.reactive_vars,
+            &self.aliases,
+        );
         let body = dedent(&rewritten);
         let body = body.trim();
         if !body.is_empty() {
-            for (kind, _) in reactive_box_kinds(script_text, &self.component.reactive_vars) {
+            for (kind, _) in reactive_box_kinds(&self.deep_hint, &self.component.reactive_vars) {
                 self.use_helper(kind);
             }
             for line in body.lines() {
@@ -157,100 +358,158 @@ impl<'a> Emitter<'a> {
         }
     }
 
+    // --- fragments ----------------------------------------------------------
+
+    /// Emits one fragment: refs, slots (text anchors + binds, control-flow
+    /// blocks — recursively), then attribute/event wiring, per §7 build order.
+    fn emit_fragment(
+        &mut self,
+        b: &mut String,
+        skeleton: &Skeleton,
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        let ref_names = self.emit_refs(b, &skeleton.dynamic_elements, frag);
+        self.emit_slots(b, &skeleton.slots, frag, diags);
+        self.emit_attr_and_event_wiring(b, &skeleton.dynamic_elements, &ref_names, frag, diags);
+    }
+
     // --- refs -------------------------------------------------------------
 
-    fn emit_refs(&mut self, b: &mut String, elems: &[DynamicElement]) {
+    /// Emits the positional-nav `refs(...)` destructuring for a fragment's
+    /// dynamic elements and returns the allocated local names (parallel to
+    /// `elems`).
+    fn emit_refs(&mut self, b: &mut String, elems: &[DynamicElement], frag: &Frag) -> Vec<String> {
         if elems.is_empty() {
-            return;
+            return Vec::new();
         }
         self.use_helper("refs");
-        b.push_str("  const [");
-        for (i, _) in elems.iter().enumerate() {
+        let refs_fn = self.helper("refs").to_string();
+        let names: Vec<String> = elems.iter().map(|_| self.alloc_ref()).collect();
+        push_indent(b, frag.indent);
+        b.push_str("const [");
+        for (i, name) in names.iter().enumerate() {
             if i > 0 {
                 b.push_str(", ");
             }
-            b.push_str(&ref_name(i));
+            b.push_str(name);
         }
-        b.push_str("] = refs(c.root, [");
+        b.push_str("] = ");
+        b.push_str(&refs_fn);
+        b.push('(');
+        b.push_str(frag.base);
+        b.push_str(", [");
         for (i, el) in elems.iter().enumerate() {
             if i > 0 {
                 b.push_str(", ");
             }
-            push_path(b, &el.path);
+            push_path(b, strip_path(&el.path, frag.strip));
         }
         b.push_str("]);\n");
+        names
     }
 
-    // --- text slots -> anchors + binds -----------------------------------
+    // --- slots --------------------------------------------------------------
 
-    fn emit_text_slots(&mut self, b: &mut String, slots: &[Slot], diags: &mut Vec<Diagnostic>) {
-        for (i, slot) in slots.iter().enumerate() {
+    fn emit_slots(
+        &mut self,
+        b: &mut String,
+        slots: &[Slot],
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        for slot in slots {
             match &slot.content {
-                SlotContent::Text(t) => self.emit_text_slot(b, i, t, &slot.pos),
-                SlotContent::If(_) | SlotContent::For(_) | SlotContent::Component(_) => {
-                    b.push_str("  /* TODO(wave2): ");
-                    b.push_str(slot_kind_name(&slot.content));
-                    b.push_str(" block not yet emitted */\n");
-                    let _ = diags; // no diagnostic: these are known deferrals
+                SlotContent::Text(t) => self.emit_text_slot(b, t, &slot.pos, frag),
+                SlotContent::If(chain) => self.emit_if_slot(b, chain, &slot.pos, frag, diags),
+                SlotContent::For(block) => self.emit_for_slot(b, block, &slot.pos, frag, diags),
+                SlotContent::Component(_) => {
+                    push_indent(b, frag.indent);
+                    b.push_str("/* TODO(components): child component not yet emitted */\n");
                 }
             }
         }
     }
 
-    fn emit_text_slot(&mut self, b: &mut String, i: usize, t: &TemplateText, pos: &InsertPos) {
-        let anchor = format!("t{i}");
-        self.emit_anchor(b, &anchor, pos);
+    // --- text slots -> anchors + binds -----------------------------------
 
-        let deps = self.text_run_deps(t);
-        let expr = self.text_run_expr(t);
+    fn emit_text_slot(&mut self, b: &mut String, t: &TemplateText, pos: &InsertPos, frag: &Frag) {
+        let anchor = self.alloc_text();
+        self.emit_anchor(b, &anchor, pos, frag);
 
-        if deps.is_empty() {
-            // Static-once: assign at build, no bind.
-            b.push_str("  ");
-            b.push_str(&anchor);
-            b.push_str(".data = ");
-            b.push_str(&expr);
-            b.push_str(";\n");
+        let deps = self.filter_deps(self.text_run_deps(t), frag.shadowed);
+        let expr = self.text_run_expr(t, frag.shadowed);
+        let coupled = t.segments.iter().any(|seg| match seg {
+            TextSegment::Interpolation(i) => reads_any(&i.expr, frag.shadowed),
+            TextSegment::Literal { .. } => false,
+        });
+
+        let stmt = format!("{anchor}.data = {expr};");
+        self.emit_update(b, frag, &deps, coupled, &stmt);
+    }
+
+    /// Emits `stmt` in the mode its dependencies demand: reactive deps →
+    /// `bind(c, deps, …)`; loop-data-coupled (inside a `:for` item) →
+    /// `bind(c, [], …)` so the item's patch path re-runs it; otherwise a bare
+    /// build-time statement.
+    fn emit_update(
+        &mut self,
+        b: &mut String,
+        frag: &Frag,
+        deps: &[u32],
+        item_coupled: bool,
+        stmt: &str,
+    ) {
+        push_indent(b, frag.indent);
+        if deps.is_empty() && !item_coupled {
+            b.push_str(stmt);
+            b.push('\n');
         } else {
             self.use_helper("bind");
-            b.push_str("  bind(c, ");
-            push_dep_list(b, &deps);
+            b.push_str(self.helper("bind"));
+            b.push_str("(c, ");
+            push_dep_list(b, deps);
             b.push_str(", () => { ");
-            b.push_str(&anchor);
-            b.push_str(".data = ");
-            b.push_str(&expr);
-            b.push_str("; });\n");
+            b.push_str(stmt);
+            b.push_str(" });\n");
         }
     }
 
-    /// Emits the anchor-creation statement for a text run, binding it to a
-    /// local const named `name`.
-    fn emit_anchor(&mut self, b: &mut String, name: &str, pos: &InsertPos) {
+    /// Emits the anchor-creation statement for a slot, binding it to a local
+    /// const named `name`.
+    fn emit_anchor(&mut self, b: &mut String, name: &str, pos: &InsertPos, frag: &Frag) {
+        push_indent(b, frag.indent);
         match pos {
             InsertPos::Before(path) => {
                 self.use_helper("anchorBefore");
-                b.push_str("  const ");
+                b.push_str("const ");
                 b.push_str(name);
-                b.push_str(" = anchorBefore(");
-                push_node_at(b, path);
+                b.push_str(" = ");
+                b.push_str(self.helper("anchorBefore"));
+                b.push('(');
+                push_node_at(b, frag.base, strip_path(path, frag.strip));
                 b.push_str(");\n");
             }
             InsertPos::BeforeSplit { path, utf16_offset } => {
                 self.use_helper("anchorBeforeSplit");
-                b.push_str("  const ");
+                b.push_str("const ");
                 b.push_str(name);
-                b.push_str(" = anchorBeforeSplit(");
-                push_node_at(b, path);
+                b.push_str(" = ");
+                b.push_str(self.helper("anchorBeforeSplit"));
+                b.push('(');
+                push_node_at(b, frag.base, strip_path(path, frag.strip));
                 b.push_str(", ");
                 b.push_str(&utf16_offset.to_string());
                 b.push_str(");\n");
             }
             InsertPos::Append(path) => {
                 self.use_helper("anchorAppend");
-                b.push_str("  const ");
+                b.push_str("const ");
                 b.push_str(name);
-                b.push_str(" = anchorAppend(");
-                push_node_at(b, path);
+                b.push_str(" = ");
+                b.push_str(self.helper("anchorAppend"));
+                b.push('(');
+                push_node_at(b, frag.base, strip_path(path, frag.strip));
                 b.push_str(");\n");
             }
         }
@@ -275,14 +534,18 @@ impl<'a> Emitter<'a> {
 
     /// A JS template literal that reproduces the whole text run, with reactive
     /// references rewritten to `.v`.
-    fn text_run_expr(&self, t: &TemplateText) -> String {
+    fn text_run_expr(&self, t: &TemplateText, shadowed: &[String]) -> String {
         let mut out = String::from("`");
         for seg in &t.segments {
             match seg {
                 TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut out, text),
                 TextSegment::Interpolation(interp) => {
                     out.push_str("${");
-                    out.push_str(&rewrite_expr(&interp.expr, &self.component.reactive_vars));
+                    out.push_str(&rewrite_expr(
+                        &interp.expr,
+                        &self.component.reactive_vars,
+                        shadowed,
+                    ));
                     out.push('}');
                 }
             }
@@ -291,16 +554,390 @@ impl<'a> Emitter<'a> {
         out
     }
 
+    // --- :if ------------------------------------------------------------------
+
+    fn emit_if_slot(
+        &mut self,
+        b: &mut String,
+        chain: &IfChain,
+        pos: &InsertPos,
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        if frag.depth >= MAX_BLOCK_DEPTH {
+            self.void_block(
+                b,
+                frag,
+                chain.range,
+                "control flow nested too deeply",
+                diags,
+            );
+            return;
+        }
+        // Every branch body must be an element (the parser guarantees this for
+        // plain cascades; a component body means child-component mounting,
+        // which is a later wave).
+        for branch in &chain.branches {
+            if !matches!(&*branch.body, TemplateNode::Element(_)) {
+                self.void_block(
+                    b,
+                    frag,
+                    branch.range,
+                    "`:if` on a component is not supported yet",
+                    diags,
+                );
+                return;
+            }
+        }
+
+        let anchor = self.alloc_anchor();
+        self.emit_anchor(b, &anchor, pos, frag);
+
+        // Union of every condition's deps drives the whole cascade.
+        let mut deps: Vec<u32> = Vec::new();
+        let mut conds: Vec<String> = Vec::new();
+        for branch in &chain.branches {
+            if let Some(cond) = &branch.condition {
+                if let Some(part) =
+                    self.find_dynamic(DynamicKind::IfCondition, &cond.text, cond.range)
+                {
+                    deps.extend(part.deps.indices().iter().copied());
+                }
+                conds.push(rewrite_expr(
+                    &cond.text,
+                    &self.component.reactive_vars,
+                    frag.shadowed,
+                ));
+            }
+        }
+        deps.sort_unstable();
+        deps.dedup();
+        let deps = self.filter_deps(deps, frag.shadowed);
+        let has_else = chain
+            .branches
+            .last()
+            .is_some_and(|br| br.condition.is_none());
+
+        if chain.branches.len() == 1 {
+            // Plain :if — the cheap single-block path.
+            self.use_helper("ifBlock");
+            push_indent(b, frag.indent);
+            b.push_str(self.helper("ifBlock"));
+            b.push_str("(c, ");
+            b.push_str(&anchor);
+            b.push_str(", ");
+            push_dep_list(b, &deps);
+            b.push_str(", () => (");
+            b.push_str(&conds[0]);
+            b.push_str("), () => {\n");
+            self.emit_block_fragment(b, &chain.branches[0].body, &anchor, frag, diags);
+            push_indent(b, frag.indent);
+            b.push_str("});\n");
+        } else {
+            // Cascade: one ifChain; which() maps conditions to a branch index
+            // (or -1 when no :else and nothing matched).
+            self.use_helper("ifChain");
+            push_indent(b, frag.indent);
+            b.push_str(self.helper("ifChain"));
+            b.push_str("(c, ");
+            b.push_str(&anchor);
+            b.push_str(", ");
+            push_dep_list(b, &deps);
+            b.push_str(", () => ");
+            for (i, cond) in conds.iter().enumerate() {
+                b.push('(');
+                b.push_str(cond);
+                b.push_str(") ? ");
+                b.push_str(&i.to_string());
+                b.push_str(" : ");
+            }
+            if has_else {
+                b.push_str(&conds.len().to_string());
+            } else {
+                b.push_str("-1");
+            }
+            b.push_str(", [\n");
+            for branch in &chain.branches {
+                push_indent(b, frag.indent + 1);
+                b.push_str("() => {\n");
+                let inner = Frag {
+                    indent: frag.indent + 1,
+                    ..*frag
+                };
+                self.emit_block_fragment(b, &branch.body, &anchor, &inner, diags);
+                push_indent(b, frag.indent + 1);
+                b.push_str("},\n");
+            }
+            push_indent(b, frag.indent);
+            b.push_str("]);\n");
+        }
+    }
+
+    /// Emits the body of a branch `make` closure: build the branch's own
+    /// skeleton detached (`fromHTML`), wire it recursively, return its root
+    /// node(s). `frag.indent` is the indent of the closure's braces.
+    fn emit_block_fragment(
+        &mut self,
+        b: &mut String,
+        body: &TemplateNode,
+        anchor: &str,
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        let tpl = Template {
+            nodes: vec![body.clone()],
+        };
+        let skel = build_skeleton(&tpl);
+        let multi_root = has_top_level_slot(&skel);
+        let html_name = self.hoist_html(skel.html.clone());
+        let root = self.alloc_root();
+        self.use_helper("fromHTML");
+        push_indent(b, frag.indent + 1);
+        b.push_str("const ");
+        b.push_str(&root);
+        b.push_str(" = ");
+        b.push_str(self.helper("fromHTML"));
+        b.push('(');
+        b.push_str(&html_name);
+        b.push_str(", ");
+        b.push_str(anchor);
+        b.push_str(");\n");
+        let inner = Frag {
+            base: &root,
+            shadowed: frag.shadowed,
+            indent: frag.indent + 1,
+            depth: frag.depth + 1,
+            strip: 0,
+        };
+        self.emit_fragment(b, &skel, &inner, diags);
+        push_indent(b, frag.indent + 1);
+        if multi_root {
+            // Top-level anchors travel with the branch as a node group.
+            b.push_str("return Array.from(");
+            b.push_str(&root);
+            b.push_str(".childNodes);\n");
+        } else {
+            b.push_str("return ");
+            b.push_str(&root);
+            b.push_str(".childNodes[0];\n");
+        }
+    }
+
+    // --- :for -------------------------------------------------------------------
+
+    fn emit_for_slot(
+        &mut self,
+        b: &mut String,
+        block: &ForBlock,
+        pos: &InsertPos,
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        if frag.depth >= MAX_BLOCK_DEPTH {
+            self.void_block(
+                b,
+                frag,
+                block.range,
+                "control flow nested too deeply",
+                diags,
+            );
+            return;
+        }
+        let Some(parsed) = parse_for(&block.header.text) else {
+            self.void_block(
+                b,
+                frag,
+                block.header.range,
+                "unrecognized `:for` header (expected e.g. `item of items`)",
+                diags,
+            );
+            return;
+        };
+        let body_el: &TemplateElement = match &*block.body {
+            TemplateNode::Element(e) => e,
+            TemplateNode::If(_) => {
+                self.void_block(
+                    b,
+                    frag,
+                    block.range,
+                    "`:if` on the same element as `:for` is not supported yet \
+                     (wrap the element in the `:if` instead)",
+                    diags,
+                );
+                return;
+            }
+            _ => {
+                self.void_block(
+                    b,
+                    frag,
+                    block.range,
+                    "`:for` on a component is not supported yet",
+                    diags,
+                );
+                return;
+            }
+        };
+
+        // The loop binding names shadow reactive vars inside the item.
+        let bindings = binding_names(&parsed.binding);
+        if bindings.is_empty() {
+            self.void_block(
+                b,
+                frag,
+                block.header.range,
+                "could not resolve the `:for` binding pattern",
+                diags,
+            );
+            return;
+        }
+        if bindings.iter().any(|n| is_generated_name(n)) {
+            self.void_block(
+                b,
+                frag,
+                block.header.range,
+                "`:for` binding name collides with a compiler-generated \
+                 identifier (e0/t0/a0/r0/d0 style); please rename it",
+                diags,
+            );
+            return;
+        }
+        let mut child_shadowed: Vec<String> = frag.shadowed.to_vec();
+        for n in &bindings {
+            if !child_shadowed.contains(n) {
+                child_shadowed.push(n.clone());
+            }
+        }
+
+        // Strip the `:key` bound attribute off the item root: it configures
+        // the reconciler and is never written to the DOM.
+        let mut item_el = body_el.clone();
+        let key_expr = take_key_attr(&mut item_el);
+
+        let anchor = self.alloc_anchor();
+        self.emit_anchor(b, &anchor, pos, frag);
+
+        // The iterable is evaluated in the ENCLOSING scope (outer shadowing).
+        let iterable = rewrite_expr(
+            &parsed.iterable,
+            &self.component.reactive_vars,
+            frag.shadowed,
+        );
+        let items_expr = match parsed.kind {
+            ForKind::Of => format!("Array.from(({iterable}) || [])"),
+            ForKind::In => format!("Object.keys(({iterable}) || {{}})"),
+        };
+        let deps = self.filter_deps(
+            self.find_dynamic_by(|p| {
+                p.kind == DynamicKind::ForIterable && p.expr == parsed.iterable
+            })
+            .map(|p| p.deps.indices().to_vec())
+            .unwrap_or_default(),
+            frag.shadowed,
+        );
+
+        // The item's own skeleton (single-root: the item element).
+        let tpl = Template {
+            nodes: vec![TemplateNode::Element(item_el)],
+        };
+        let skel = build_skeleton(&tpl);
+        let html_name = self.hoist_html(skel.html.clone());
+        let root = self.alloc_root();
+        let d_wire = self.alloc_data();
+        let d_patch = self.alloc_data();
+
+        self.use_helper("forBlock");
+        push_indent(b, frag.indent);
+        b.push_str(self.helper("forBlock"));
+        b.push_str("(c, ");
+        b.push_str(&anchor);
+        b.push_str(", ");
+        push_dep_list(b, &deps);
+        b.push_str(", () => ");
+        b.push_str(&items_expr);
+        b.push_str(", {\n");
+        push_indent(b, frag.indent + 1);
+        b.push_str("html: ");
+        b.push_str(&html_name);
+        b.push_str(",\n");
+        push_indent(b, frag.indent + 1);
+        b.push_str("wire: (");
+        b.push_str(&root);
+        b.push_str(", ");
+        b.push_str(&d_wire);
+        b.push_str(") => {\n");
+        push_indent(b, frag.indent + 2);
+        b.push_str("let ");
+        b.push_str(parsed.binding.trim());
+        b.push_str(" = ");
+        b.push_str(&d_wire);
+        b.push_str(";\n");
+        let inner = Frag {
+            base: &root,
+            shadowed: &child_shadowed,
+            indent: frag.indent + 2,
+            depth: frag.depth + 1,
+            strip: 1,
+        };
+        self.emit_fragment(b, &skel, &inner, diags);
+        push_indent(b, frag.indent + 2);
+        b.push_str("return (");
+        b.push_str(&d_patch);
+        b.push_str(") => { (");
+        b.push_str(parsed.binding.trim());
+        b.push_str(" = ");
+        b.push_str(&d_patch);
+        b.push_str("); };\n");
+        push_indent(b, frag.indent + 1);
+        b.push_str("},\n");
+        if let Some(key) = key_expr {
+            let d_key = self.alloc_data();
+            let key_js = rewrite_expr(&key, &self.component.reactive_vars, &child_shadowed);
+            push_indent(b, frag.indent + 1);
+            b.push_str("keyOf: (");
+            b.push_str(&d_key);
+            b.push_str(") => { const ");
+            b.push_str(parsed.binding.trim());
+            b.push_str(" = ");
+            b.push_str(&d_key);
+            b.push_str("; return (");
+            b.push_str(&key_js);
+            b.push_str("); },\n");
+        }
+        push_indent(b, frag.indent);
+        b.push_str("});\n");
+    }
+
+    /// Voids an unsupported block with a comment and a warning diagnostic. The
+    /// module still compiles and runs (never-panic, never-invalid-JS).
+    fn void_block(
+        &mut self,
+        b: &mut String,
+        frag: &Frag,
+        range: TextRange,
+        why: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        push_indent(b, frag.indent);
+        b.push_str("/* lunas: block skipped — ");
+        // Keep the comment safe: never allow a comment terminator through.
+        b.push_str(&why.replace("*/", "* /"));
+        b.push_str(" */\n");
+        diags.push(Diagnostic::warning(range, why.to_string()));
+    }
+
     // --- attribute / event wiring ----------------------------------------
 
     fn emit_attr_and_event_wiring(
         &mut self,
         b: &mut String,
         elems: &[DynamicElement],
+        ref_names: &[String],
+        frag: &Frag,
         diags: &mut Vec<Diagnostic>,
     ) {
+        let _ = diags;
         for (i, el) in elems.iter().enumerate() {
-            let name = ref_name(i);
+            let name = &ref_names[i];
             for attr in &el.attrs {
                 match attr {
                     TemplateAttr::Bound {
@@ -308,30 +945,24 @@ impl<'a> Emitter<'a> {
                         expr,
                         ..
                     } => {
-                        self.emit_bound_attr(b, &name, attr_name, &expr.text);
+                        self.emit_bound_attr(b, name, attr_name, &expr.text, frag);
                     }
                     TemplateAttr::Static {
                         name: attr_name,
                         value: Some(v),
                         ..
                     } if has_interpolation(v) => {
-                        self.emit_attr_text(b, &name, attr_name, v);
+                        self.emit_attr_text(b, name, attr_name, v, frag);
                     }
                     TemplateAttr::Event { event, handler, .. } => {
-                        self.emit_event(b, &name, event, &handler.text);
+                        self.emit_event(b, name, event, &handler.text, frag);
                     }
                     TemplateAttr::TwoWay {
                         name: attr_name,
-                        range,
+                        lvalue,
                         ..
                     } => {
-                        b.push_str("  /* TODO(wave2): two-way ::");
-                        b.push_str(attr_name);
-                        b.push_str(" not yet emitted */\n");
-                        diags.push(Diagnostic::warning(
-                            *range,
-                            format!("two-way binding ::{attr_name} is not yet emitted (Wave 2)"),
-                        ));
+                        self.emit_two_way(b, name, attr_name, &lvalue.text, frag);
                     }
                     TemplateAttr::Static { .. } => {}
                 }
@@ -339,34 +970,36 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    fn emit_bound_attr(&mut self, b: &mut String, node: &str, attr: &str, expr: &str) {
-        let deps = self.bound_attr_deps(attr, expr);
-        let value = rewrite_expr(expr, &self.component.reactive_vars);
+    fn emit_bound_attr(&mut self, b: &mut String, node: &str, attr: &str, expr: &str, frag: &Frag) {
+        let deps = self.filter_deps(self.bound_attr_deps(attr, expr), frag.shadowed);
+        let value = rewrite_expr(expr, &self.component.reactive_vars, frag.shadowed);
         let set = attr_set_statement(node, attr, &value);
-        if deps.is_empty() {
-            b.push_str("  ");
-            b.push_str(&set);
-            b.push('\n');
-        } else {
-            self.use_helper("bind");
-            b.push_str("  bind(c, ");
-            push_dep_list(b, &deps);
-            b.push_str(", () => { ");
-            b.push_str(&set);
-            b.push_str(" });\n");
-        }
+        self.emit_update(b, frag, &deps, reads_any(expr, frag.shadowed), &set);
     }
 
-    fn emit_attr_text(&mut self, b: &mut String, node: &str, attr: &str, value: &StaticValue) {
+    fn emit_attr_text(
+        &mut self,
+        b: &mut String,
+        node: &str,
+        attr: &str,
+        value: &StaticValue,
+        frag: &Frag,
+    ) {
         let mut deps = Vec::new();
+        let mut coupled = false;
         let mut lit = String::from("`");
         for seg in &value.segments {
             match seg {
                 TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut lit, text),
                 TextSegment::Interpolation(interp) => {
                     lit.push_str("${");
-                    lit.push_str(&rewrite_expr(&interp.expr, &self.component.reactive_vars));
+                    lit.push_str(&rewrite_expr(
+                        &interp.expr,
+                        &self.component.reactive_vars,
+                        frag.shadowed,
+                    ));
                     lit.push('}');
+                    coupled = coupled || reads_any(&interp.expr, frag.shadowed);
                     if let Some(part) = self.find_dynamic(
                         DynamicKind::AttributeText(attr.to_string()),
                         &interp.expr,
@@ -380,31 +1013,50 @@ impl<'a> Emitter<'a> {
         lit.push('`');
         deps.sort_unstable();
         deps.dedup();
+        let deps = self.filter_deps(deps, frag.shadowed);
 
         let set = attr_set_statement(node, attr, &lit);
-        if deps.is_empty() {
-            b.push_str("  ");
-            b.push_str(&set);
-            b.push('\n');
-        } else {
-            self.use_helper("bind");
-            b.push_str("  bind(c, ");
-            push_dep_list(b, &deps);
-            b.push_str(", () => { ");
-            b.push_str(&set);
-            b.push_str(" });\n");
-        }
+        self.emit_update(b, frag, &deps, coupled, &set);
     }
 
-    fn emit_event(&mut self, b: &mut String, node: &str, event: &str, handler: &str) {
+    fn emit_event(&mut self, b: &mut String, node: &str, event: &str, handler: &str, frag: &Frag) {
         self.use_helper("on");
-        let body = rewrite_expr(handler, &self.component.reactive_vars);
-        b.push_str("  on(");
+        let body = rewrite_expr(handler, &self.component.reactive_vars, frag.shadowed);
+        push_indent(b, frag.indent);
+        b.push_str(self.helper("on"));
+        b.push('(');
         b.push_str(node);
         b.push_str(", ");
         push_js_string(b, event);
         b.push_str(", () => { ");
         b.push_str(&body);
+        b.push_str("; });\n");
+    }
+
+    /// Two-way binding `::name="lvalue"` (§6): the read side is a normal bound
+    /// attribute of `lvalue`; the write side is an event listener assigning the
+    /// element state back into the lvalue. `::checked` listens on `change`
+    /// (checkbox/radio semantics); everything else on `input`.
+    fn emit_two_way(&mut self, b: &mut String, node: &str, attr: &str, lvalue: &str, frag: &Frag) {
+        // Read side: element reflects the lvalue.
+        let deps = self.filter_deps(self.two_way_deps(attr, lvalue), frag.shadowed);
+        let value = rewrite_expr(lvalue, &self.component.reactive_vars, frag.shadowed);
+        let set = attr_set_statement(node, attr, &value);
+        self.emit_update(b, frag, &deps, reads_any(lvalue, frag.shadowed), &set);
+
+        // Write side: element state flows back into the lvalue.
+        let (event, read) = two_way_read(node, attr);
+        self.use_helper("on");
+        push_indent(b, frag.indent);
+        b.push_str(self.helper("on"));
+        b.push('(');
+        b.push_str(node);
+        b.push_str(", ");
+        push_js_string(b, event);
+        b.push_str(", () => { ");
+        b.push_str(&value);
+        b.push_str(" = ");
+        b.push_str(&read);
         b.push_str("; });\n");
     }
 
@@ -416,6 +1068,31 @@ impl<'a> Emitter<'a> {
         })
         .map(|p| p.deps.indices().to_vec())
         .unwrap_or_default()
+    }
+
+    fn two_way_deps(&self, attr: &str, lvalue: &str) -> Vec<u32> {
+        self.find_dynamic_by(|p| {
+            matches!(&p.kind, DynamicKind::TwoWay(n) if n == attr) && p.expr == lvalue
+        })
+        .map(|p| p.deps.indices().to_vec())
+        .unwrap_or_default()
+    }
+
+    /// Drops dep indices whose reactive variable is shadowed by a loop binding
+    /// in the current fragment.
+    fn filter_deps(&self, mut deps: Vec<u32>, shadowed: &[String]) -> Vec<u32> {
+        if shadowed.is_empty() {
+            return deps;
+        }
+        deps.retain(|i| {
+            self.component
+                .reactive_vars
+                .iter()
+                .find(|v| v.index == *i)
+                .map(|v| !shadowed.contains(&v.name))
+                .unwrap_or(true)
+        });
+        deps
     }
 
     fn find_dynamic(
@@ -444,15 +1121,125 @@ impl<'a> Emitter<'a> {
     }
 }
 
+// --- template helpers ------------------------------------------------------
+
+/// Every two-way lvalue expression in the template (branch/item bodies
+/// included).
+fn two_way_lvalues(template: &Template) -> Vec<String> {
+    let mut out = Vec::new();
+    template.visit(&mut |node: &TemplateNode| {
+        let attrs = match node {
+            TemplateNode::Element(e) => &e.attrs,
+            TemplateNode::Component(c) => &c.props,
+            _ => return,
+        };
+        for attr in attrs {
+            if let TemplateAttr::TwoWay { lvalue, .. } = attr {
+                out.push(lvalue.text.clone());
+            }
+        }
+    });
+    out
+}
+
+/// Removes a `:key="expr"` bound attribute from a `:for` item root and returns
+/// the expression. The key configures the reconciler; it is not DOM state.
+fn take_key_attr(el: &mut TemplateElement) -> Option<String> {
+    let idx = el.attrs.iter().position(
+        |a| matches!(a, TemplateAttr::Bound { name, .. } if name.eq_ignore_ascii_case("key")),
+    )?;
+    match el.attrs.remove(idx) {
+        TemplateAttr::Bound { expr, .. } => Some(expr.text),
+        _ => None,
+    }
+}
+
+/// The identifier names bound by a `:for` binding pattern (`item`, `[i, v]`,
+/// `{a, b}`). Uses the scope-aware free-identifier scan: for a pattern text
+/// read as an expression, the free identifiers are exactly the bound names
+/// (default-value expressions may add extras; that only widens shadowing,
+/// which is safe).
+fn binding_names(pattern: &str) -> Vec<String> {
+    let p = pattern.trim();
+    if p.is_empty() {
+        return Vec::new();
+    }
+    // Object patterns parse as blocks when bare; parenthesize.
+    let as_expr = format!("({p})");
+    lunas_script::free_identifiers(&as_expr).unwrap_or_default()
+}
+
+/// Whether a user name would collide with the emitter's generated locals.
+fn is_generated_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('e' | 't' | 'a' | 'r' | 'd'))
+        && chars.as_str().chars().all(|c| c.is_ascii_digit())
+        && name.len() > 1
+}
+
+/// Whether `expr` reads any of the (loop-binding) `names`. Conservative: an
+/// unparseable expression is assumed to read them (extra re-runs are safe).
+fn reads_any(expr: &str, names: &[String]) -> bool {
+    if names.is_empty() {
+        return false;
+    }
+    match lunas_script::free_identifiers(expr) {
+        Ok(free) => free.iter().any(|n| names.contains(n)),
+        Err(_) => true,
+    }
+}
+
+/// Whether a fragment skeleton has slots inserted at its top level (the
+/// fragment root group then includes runtime anchors, so the whole child list
+/// must travel as the block handle).
+fn has_top_level_slot(skel: &Skeleton) -> bool {
+    skel.slots.iter().any(|s| match &s.pos {
+        InsertPos::Before(p) => p.len() <= 1,
+        InsertPos::BeforeSplit { path, .. } => path.len() <= 1,
+        InsertPos::Append(p) => p.is_empty(),
+    })
+}
+
+/// Drops the first `strip` segments of a positional path (used for `:for`
+/// items, whose wiring receives the item root rather than a container).
+fn strip_path(path: &[u32], strip: usize) -> &[u32] {
+    if path.len() >= strip {
+        &path[strip..]
+    } else {
+        &[]
+    }
+}
+
+// --- two-way write-back ------------------------------------------------------
+
+/// The (event, element-read expression) pair for a two-way binding's write-back
+/// listener.
+fn two_way_read(node: &str, attr: &str) -> (&'static str, String) {
+    if let Some(prop) = boolean_property(attr) {
+        // checkbox/radio style state commits on change
+        ("change", format!("{node}.{prop}"))
+    } else if idl_property(attr).is_some() {
+        ("input", format!("{node}.value"))
+    } else if attr
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+    {
+        ("input", format!("{node}.{attr}"))
+    } else {
+        ("input", format!("{node}.getAttribute(\"{attr}\")"))
+    }
+}
+
 // --- reactive box selection & script rewriting ---------------------------
 
 /// The box helper each reactive var should use, in declaration order: `deepBox`
-/// if the script deeply mutates the var (member/index write or a mutating array
-/// method), else `box`.
-fn reactive_box_kinds(script_text: &str, vars: &[ReactiveVar]) -> Vec<(&'static str, u32)> {
+/// if the component deeply mutates the var (member/index write or a mutating
+/// array method in the script, or a two-way member lvalue), else `box`.
+/// `hint` is the script text plus synthetic template-derived writes.
+fn reactive_box_kinds(hint: &str, vars: &[ReactiveVar]) -> Vec<(&'static str, u32)> {
     vars.iter()
         .map(|v| {
-            let kind = if is_deeply_mutated(script_text, &v.name) {
+            let kind = if is_deeply_mutated(hint, &v.name) {
                 "deepBox"
             } else {
                 "box"
@@ -464,9 +1251,9 @@ fn reactive_box_kinds(script_text: &str, vars: &[ReactiveVar]) -> Vec<(&'static 
 
 /// Textual heuristic for deep mutation of `name`: a member/index assignment
 /// (`name.x =`, `name[i] =`, `name.x++`) or a mutating array method call
-/// (`name.push(`, …). Conservative and dependency-free — Wave 1 has no
-/// AST-level deep-mutation analysis. On a false negative the var would use a
-/// plain `box`, which still reacts to whole reassignment.
+/// (`name.push(`, …). Conservative and dependency-free — there is no AST-level
+/// deep-mutation analysis yet. On a false negative the var would use a plain
+/// `box`, which still reacts to whole reassignment.
 fn is_deeply_mutated(script: &str, name: &str) -> bool {
     const MUTATORS: &[&str] = &[
         "push",
@@ -568,11 +1355,18 @@ fn skip_ident(s: &str) -> Option<&str> {
 /// Rewrites the whole script body: reactive `let/const/var name = init`
 /// declarations become `const name = box|deepBox(c, i, init)`, and every
 /// reference to a reactive variable becomes `name.v`. Uses scope-aware
-/// [`module_binding_references`] so shadowed uses are left alone.
-fn rewrite_script(script: &str, vars: &[ReactiveVar]) -> String {
+/// [`module_binding_references`] so shadowed uses are left alone. `hint` is
+/// the deep-mutation detection text (script + template-derived writes).
+fn rewrite_script(
+    script: &str,
+    hint: &str,
+    vars: &[ReactiveVar],
+    aliases: &std::collections::BTreeMap<&'static str, String>,
+) -> String {
     if vars.is_empty() {
         return script.to_string();
     }
+    let box_name = |k: &'static str| aliases.get(k).map(|s| s.as_str()).unwrap_or(k);
     let reactive: std::collections::HashMap<&str, &ReactiveVar> =
         vars.iter().map(|v| (v.name.as_str(), v)).collect();
 
@@ -596,7 +1390,7 @@ fn rewrite_script(script: &str, vars: &[ReactiveVar]) -> String {
         if d.declarators_in_stmt != 1 {
             continue;
         }
-        let kind = if is_deeply_mutated(script, &d.name) {
+        let kind = if is_deeply_mutated(hint, &d.name) {
             "deepBox"
         } else {
             "box"
@@ -605,8 +1399,14 @@ fn rewrite_script(script: &str, vars: &[ReactiveVar]) -> String {
             .init_range
             .and_then(|ir| ir.slice(script))
             .unwrap_or("undefined");
-        let init = rewrite_expr(init_raw, vars);
-        let text = format!("const {} = {}(c, {}, {})", d.name, kind, var.index, init);
+        let init = rewrite_expr(init_raw, vars, &[]);
+        let text = format!(
+            "const {} = {}(c, {}, {})",
+            d.name,
+            box_name(kind),
+            var.index,
+            init
+        );
         edits.push((d.stmt_range.start().raw(), d.stmt_range.end().raw(), text));
         decl_ranges.push(d.stmt_range);
     }
@@ -652,12 +1452,20 @@ fn apply_edits(src: &str, mut edits: Vec<(u32, u32, String)>) -> String {
 
 /// Rewrites a standalone JS expression so reactive references become `name.v`.
 /// Uses scope-aware [`free_identifiers_with_spans`] so shadowed locals (e.g. an
-/// arrow parameter of the same name) are left alone.
-fn rewrite_expr(expr: &str, vars: &[ReactiveVar]) -> String {
+/// arrow parameter of the same name) are left alone. `shadowed` names (loop
+/// bindings of enclosing `:for` items) are excluded from rewriting.
+fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String {
     if vars.is_empty() {
         return expr.trim().to_string();
     }
-    let reactive: std::collections::HashSet<&str> = vars.iter().map(|v| v.name.as_str()).collect();
+    let reactive: std::collections::HashSet<&str> = vars
+        .iter()
+        .map(|v| v.name.as_str())
+        .filter(|n| !shadowed.iter().any(|s| s == n))
+        .collect();
+    if reactive.is_empty() {
+        return expr.trim().to_string();
+    }
     let spans = match lunas_script::free_identifiers_with_spans(expr) {
         Ok(s) => s,
         Err(_) => return expr.trim().to_string(),
@@ -710,10 +1518,6 @@ fn idl_property(attr: &str) -> Option<&'static str> {
 
 // --- small emit utilities ------------------------------------------------
 
-fn ref_name(i: usize) -> String {
-    format!("e{i}")
-}
-
 /// Strips the common leading whitespace shared by all non-blank lines, so a
 /// script block written with source indentation re-emits cleanly.
 fn dedent(s: &str) -> String {
@@ -735,25 +1539,22 @@ fn dedent(s: &str) -> String {
         .join("\n")
 }
 
-fn slot_kind_name(c: &SlotContent) -> &'static str {
-    match c {
-        SlotContent::Text(_) => "text",
-        SlotContent::If(_) => "if",
-        SlotContent::For(_) => "for",
-        SlotContent::Component(_) => "component",
-    }
-}
-
 fn has_interpolation(v: &StaticValue) -> bool {
     v.segments
         .iter()
         .any(|s| matches!(s, TextSegment::Interpolation(_)))
 }
 
-/// Emits `n.childNodes[i]…` navigation from `c.root` for a positional path.
-/// `[]` is the root itself.
-fn push_node_at(b: &mut String, path: &[u32]) {
-    b.push_str("c.root");
+fn push_indent(b: &mut String, level: usize) {
+    for _ in 0..level {
+        b.push_str("  ");
+    }
+}
+
+/// Emits `base.childNodes[i]…` navigation for a positional path. `[]` is the
+/// base itself.
+fn push_node_at(b: &mut String, base: &str, path: &[u32]) {
+    b.push_str(base);
     for i in path {
         b.push_str(".childNodes[");
         b.push_str(&i.to_string());

--- a/crates/lunas_compiler/src/lib.rs
+++ b/crates/lunas_compiler/src/lib.rs
@@ -59,8 +59,16 @@ pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
         })
         .collect();
 
+    // A two-way binding (`::name="lvalue"`) writes back into its target, so the
+    // lvalue's root binding is mutated even if the script never assigns it.
+    let template_mutated = file
+        .html
+        .as_ref()
+        .map(|h| two_way_mutation_roots(&h.template))
+        .unwrap_or_default();
+
     let reactive_vars = match &file.script {
-        Some(script) => resolve_reactive_vars(script, &mut diags),
+        Some(script) => resolve_reactive_vars(script, &template_mutated, &mut diags),
         None => Vec::new(),
     };
 
@@ -92,10 +100,58 @@ pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
     (component, diags)
 }
 
+/// The root identifiers written by two-way bindings anywhere in the template
+/// (including inside `:if` branches and `:for` bodies). `::value="name"` writes
+/// `name`; `::value="o.k"` deep-writes `o`.
+fn two_way_mutation_roots(template: &lunas_parser::Template) -> HashSet<String> {
+    use lunas_parser::{TemplateAttr, TemplateNode};
+    let mut roots = HashSet::new();
+    template.visit(&mut |node: &TemplateNode| {
+        let attrs = match node {
+            TemplateNode::Element(e) => &e.attrs,
+            TemplateNode::Component(c) => &c.props,
+            _ => return,
+        };
+        for attr in attrs {
+            if let TemplateAttr::TwoWay { lvalue, .. } = attr {
+                if let Some(root) = leading_identifier(&lvalue.text) {
+                    roots.insert(root.to_string());
+                }
+            }
+        }
+    });
+    roots
+}
+
+/// The identifier an expression starts with (`o.k` → `o`), or `None` if it
+/// does not start with one.
+fn leading_identifier(expr: &str) -> Option<&str> {
+    let s = expr.trim_start();
+    let mut end = 0;
+    for (i, ch) in s.char_indices() {
+        let ok = if i == 0 {
+            ch.is_alphabetic() || ch == '_' || ch == '$'
+        } else {
+            ch.is_alphanumeric() || ch == '_' || ch == '$'
+        };
+        if !ok {
+            break;
+        }
+        end = i + ch.len_utf8();
+    }
+    if end == 0 {
+        None
+    } else {
+        Some(&s[..end])
+    }
+}
+
 /// Determines which top-level bindings are reactive (declared *and* mutated
-/// somewhere) and numbers them in declaration order.
+/// somewhere) and numbers them in declaration order. `extra_mutated` carries
+/// mutations visible only in the template (two-way binding write-backs).
 fn resolve_reactive_vars(
     script: &lunas_parser::ScriptBlock,
+    extra_mutated: &HashSet<String>,
     diags: &mut Vec<Diagnostic>,
 ) -> Vec<ReactiveVar> {
     let text = &script.source.text;
@@ -122,6 +178,7 @@ fn resolve_reactive_vars(
     if let Ok(top_level) = assigned_identifiers(text) {
         mutated.extend(top_level);
     }
+    mutated.extend(extra_mutated.iter().cloned());
 
     let decl_spans = declared_bindings_with_spans(text).unwrap_or_default();
     let span_of = |name: &str| {

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -139,26 +139,207 @@ fn deep_mutation_uses_deepbox() {
 }
 
 #[test]
-fn two_way_binding_is_voided_with_diagnostic() {
+fn two_way_binding_emits_property_and_write_back() {
+    // `::value` binds the property (read side) *and* an input listener that
+    // writes the element's value back into the lvalue (write side).
     let (js, diags) = compile(
         "html:\n    <input ::value=\"name\">\nscript:\n    let name = \"a\"\n    function f(){ name = \"b\" }\n",
     );
-    let js = js.expect("module still emitted");
-    assert!(js.contains("/* TODO(wave2): two-way ::value"), "{js}");
     assert!(
-        diags
-            .iter()
-            .any(|d| !d.is_error() && d.message.contains("two-way")),
-        "a non-fatal diagnostic is reported: {diags:?}"
+        !diags.iter().any(|d| d.is_error()),
+        "no error diags: {diags:?}"
+    );
+    let js = js.expect("module emitted");
+    assert!(
+        js.contains("bind(c, [0], () => { e0.value = name.v; });"),
+        "read side binds the value property: {js}"
+    );
+    assert!(
+        js.contains("on(e0, \"input\", () => { name.v = e0.value; });"),
+        "write side listens on input and writes back: {js}"
     );
 }
 
 #[test]
-fn if_slot_voided_gracefully() {
-    let js = emit("html:\n    <div><span :if=\"c\">y</span></div>\nscript:\n    let c = true\n    function t(){ c = false }\n");
-    assert!(js.contains("/* TODO(wave2): if block"), "{js}");
-    // Still a valid module.
-    assert!(js.starts_with("import { component"), "{js}");
+fn two_way_checked_uses_change_event() {
+    // `::checked` reflects a boolean property and commits on `change`
+    // (checkbox/radio semantics), not `input`.
+    let js = emit(
+        "html:\n    <input type=\"checkbox\" ::checked=\"done\">\nscript:\n    let done = false\n    function f(){ done = true }\n",
+    );
+    assert!(
+        js.contains("e0.checked = !!(done.v);"),
+        "read side sets checked truthiness: {js}"
+    );
+    assert!(
+        js.contains("on(e0, \"change\", () => { done.v = e0.checked; });"),
+        "write side listens on change: {js}"
+    );
+}
+
+#[test]
+fn plain_if_emits_ifblock() {
+    let js = emit(
+        "html:\n    <div><span :if=\"show\">y</span></div>\nscript:\n    let show = true\n    function t(){ show = false }\n",
+    );
+    // The branch skeleton is hoisted and built by its own fromHTML when shown.
+    assert!(js.contains("const HTML_1 = \"<span>y</span>\";"), "{js}");
+    assert!(
+        js.contains("const a0 = anchorAppend(c.root.childNodes[0]);"),
+        "{js}"
+    );
+    assert!(
+        js.contains("ifBlock(c, a0, [0], () => (show.v), () => {"),
+        "single :if uses the cheap ifBlock path: {js}"
+    );
+    assert!(js.contains("fromHTML(HTML_1, a0)"), "{js}");
+}
+
+#[test]
+fn if_elseif_else_emits_ifchain() {
+    let js = emit(
+        "html:\n    <div><p :if=\"n > 0\">pos ${n}</p><p :elseif=\"n < 0\">neg</p><p :else>zero</p></div>\nscript:\n    let n = 0\n    function set(x){ n = x }\n",
+    );
+    // A cascade compiles to one ifChain with a which() index selector and a
+    // parallel array of branch builders.
+    assert!(
+        js.contains("ifChain(c, a0, [0], () => (n.v > 0) ? 0 : (n.v < 0) ? 1 : 2, ["),
+        "which() maps conditions to a branch index, :else = last: {js}"
+    );
+    // Each branch has its own hoisted skeleton; the first is dynamic.
+    assert!(js.contains("const HTML_1 = \"<p></p>\";"), "{js}");
+    assert!(js.contains("const HTML_2 = \"<p>neg</p>\";"), "{js}");
+    assert!(js.contains("const HTML_3 = \"<p>zero</p>\";"), "{js}");
+    assert!(
+        js.contains("bind(c, [0], () => { t0.data = `pos ${n.v}`; });"),
+        "nested bind inside a branch works: {js}"
+    );
+}
+
+#[test]
+fn if_without_else_selects_minus_one() {
+    let js = emit(
+        "html:\n    <div><p :if=\"a\">x</p><p :elseif=\"b\">y</p></div>\nscript:\n    let a = true\n    let b = false\n    function f(){ a = false }\n",
+    );
+    assert!(
+        js.contains("? 1 : -1, ["),
+        "no :else -> which() returns -1 (no branch): {js}"
+    );
+}
+
+#[test]
+fn keyed_for_emits_forblock_with_keyof() {
+    let js = emit(
+        "html:\n    <ul><li :for=\"item of items\" :key=\"item.id\" @click=\"del(item.id)\">${item.label}</li></ul>\nscript:\n    let items = [{id:1,label:\"a\"}]\n    function del(id){ items = items.filter((x) => x.id !== id) }\n",
+    );
+    // The item skeleton is hoisted; the loop binding shadows reactive vars
+    // (so `item.label` is NOT rewritten to `.v`).
+    assert!(js.contains("const HTML_1 = \"<li></li>\";"), "{js}");
+    assert!(
+        js.contains("forBlock(c, a0, [0], () => Array.from((items.v) || []), {"),
+        "iterable evaluated in the outer scope, reactive on items: {js}"
+    );
+    assert!(js.contains("html: HTML_1,"), "{js}");
+    assert!(
+        js.contains("wire: (r0, d0) => {"),
+        "compiled html/wire mode: {js}"
+    );
+    assert!(
+        js.contains("let item = d0;"),
+        "item bound from the data cell: {js}"
+    );
+    assert!(
+        js.contains("bind(c, [], () => { t0.data = `${item.label}`; });"),
+        "item-local text bind (empty deps, refreshed by runScope): {js}"
+    );
+    assert!(
+        js.contains("on(e0, \"click\", () => { del(item.id); });"),
+        "per-item listener closes over the item binding: {js}"
+    );
+    assert!(
+        js.contains("keyOf: (d2) => { const item = d2; return (item.id); },"),
+        ":key becomes keyOf, :key attr stripped from the DOM: {js}"
+    );
+    // The stripped :key must not appear as a DOM attribute.
+    assert!(
+        !js.contains("setAttribute(\"key\""),
+        "key is not a DOM attr: {js}"
+    );
+}
+
+#[test]
+fn if_in_for_reacts_and_nests() {
+    // Nested :if inside a :for item: the array is deep-mutated (push), so it is
+    // a reactive deepBox and the forBlock depends on it; the nested ifBlock is
+    // wired inside the item and refreshed via the item scope.
+    let js = emit(
+        "html:\n    <ul><li :for=\"item of items\" :key=\"item.id\"><em :if=\"item.done\">done</em>${item.label}</li></ul>\nscript:\n    let items = []\n    function add(){ items.push({id:1,label:\"a\",done:false}) }\n",
+    );
+    assert!(
+        js.contains("deepBox(c, 0, [])"),
+        "array push -> deepBox: {js}"
+    );
+    assert!(
+        js.contains("forBlock(c, a0, [0], () => Array.from((items.v) || []), {"),
+        "for reacts to the reactive array: {js}"
+    );
+    assert!(
+        js.contains("ifBlock(c, a1, [], () => (item.done), () => {"),
+        "nested :if wired inside the item, keyed on the loop binding: {js}"
+    );
+}
+
+#[test]
+fn for_in_if_reacts_and_nests() {
+    let js = emit(
+        "html:\n    <div :if=\"show\"><p :for=\"t of tags\">${t}</p></div>\nscript:\n    let show = true\n    let tags = [\"x\"]\n    function toggle(){ show = !show }\n    function addTag(){ tags.push(\"y\") }\n",
+    );
+    assert!(js.contains("box(c, 0, true)"), "show boxed: {js}");
+    assert!(js.contains("deepBox(c, 1, [\"x\"])"), "tags deepBox: {js}");
+    assert!(
+        js.contains("ifBlock(c, a0, [0], () => (show.v), () => {"),
+        "outer :if reacts to show: {js}"
+    );
+    assert!(
+        js.contains("forBlock(c, a1, [1], () => Array.from((tags.v) || []), {"),
+        "inner :for reacts to tags, nested inside the branch: {js}"
+    );
+}
+
+#[test]
+fn helper_name_collision_is_aliased() {
+    // A reactive var named `on` would shadow the `on` runtime helper. The
+    // emitter imports the helper under an alias and references the alias, so
+    // the user binding and the helper coexist.
+    let js = emit(
+        "html:\n    <button @click=\"flip()\" :if=\"on\">x</button>\nscript:\n    let on = false\n    function flip(){ on = !on }\n",
+    );
+    assert!(
+        js.contains("on as $on"),
+        "helper imported under alias: {js}"
+    );
+    assert!(
+        js.contains("const on = box(c, 0, false)"),
+        "user binding kept: {js}"
+    );
+    assert!(
+        js.contains("$on(e0, \"click\""),
+        "helper referenced by alias: {js}"
+    );
+    // The bare `on(` call form must not appear (would call the box).
+    assert!(!js.contains(" on(e0"), "no bare on() call: {js}");
+}
+
+#[test]
+fn box_helper_collision_is_aliased() {
+    // A binding literally named `box` collides with the box constructor helper.
+    let js =
+        emit("html:\n    <p>${box}</p>\nscript:\n    let box = 0\n    function f(){ box = 1 }\n");
+    assert!(js.contains("box as $box"), "box helper aliased: {js}");
+    assert!(
+        js.contains("const box = $box(c, 0, 0)"),
+        "user `box` boxed via alias: {js}"
+    );
 }
 
 #[test]
@@ -187,5 +368,50 @@ fn malformed_inputs_do_not_panic() {
     ];
     for case in cases {
         let (_js, _diags) = compile(case);
+    }
+}
+
+/// Fuzz: arbitrary nestings of `:if`/`:for` (plus a couple of adversarial
+/// leaves) must never panic and must never produce error diagnostics — deep or
+/// otherwise-unsupported nesting is voided with a *warning*, never a crash.
+#[test]
+fn arbitrary_control_flow_nesting_never_panics() {
+    // A small grammar of nested control-flow fragments, expanded to increasing
+    // depths. Leaves include a two-way bind and an interpolation so wiring runs
+    // inside every level.
+    fn leaf(depth: usize) -> String {
+        match depth % 3 {
+            0 => "<span>${x}</span>".to_string(),
+            1 => "<input ::value=\"x\">".to_string(),
+            _ => "<b :if=\"x\">${x}</b>".to_string(),
+        }
+    }
+    fn wrap_if(inner: &str) -> String {
+        format!("<div :if=\"x\">{inner}</div>")
+    }
+    fn wrap_for(inner: &str) -> String {
+        format!("<div :for=\"x of xs\" :key=\"x\">{inner}</div>")
+    }
+
+    let script =
+        "\nscript:\n    let x = 0\n    let xs = []\n    function f(){ x = 1; xs.push(x) }\n";
+    for depth in 0..40usize {
+        let mut body = leaf(depth);
+        for i in 0..depth {
+            body = if i % 2 == 0 {
+                wrap_if(&body)
+            } else {
+                wrap_for(&body)
+            };
+        }
+        let source = format!("html:\n    {body}{script}");
+        let (js, diags) = compile(&source);
+        assert!(
+            !diags.iter().any(|d| d.is_error()),
+            "depth {depth}: unexpected error diagnostic: {diags:?}"
+        );
+        // Whatever is emitted must at least be a module (or None when there is
+        // nothing to emit); never a panic — reaching here is the assertion.
+        let _ = js;
     }
 }

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -151,3 +151,134 @@ fn mixed_text_anchor_updates_in_place() {
     let out = run_component("mixed", source, driver);
     assert!(out.contains("INITIAL:a=1 b=2!"), "mixed render: {out}");
 }
+
+#[test]
+fn two_way_input_writes_back_to_state() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // `::value` binds the property from state AND writes back on input. A text
+    // node mirrors the state so we can see the write-back land.
+    let source = "html:\n\
+        \x20   <div><input ::value=\"name\"><span>${name}</span></div>\n\
+        script:\n\
+        \x20   let name = \"a\"\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const input = root.childNodes[0].childNodes[0];\n\
+        const span = root.childNodes[0].childNodes[1];\n\
+        console.log('INITIAL:' + input.value + '/' + span.innerHTMLString());\n\
+        input.value = 'zed';\n\
+        input.dispatch('input');\n\
+        await tick();\n\
+        console.log('AFTER:' + span.innerHTMLString());\n";
+
+    let out = run_component("twoway", source, driver);
+    assert!(out.contains("INITIAL:a/a"), "initial reflects state: {out}");
+    assert!(
+        out.contains("AFTER:zed"),
+        "input write-back updates state and dependent text: {out}"
+    );
+}
+
+#[test]
+fn if_toggles_branch_on_event() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    let source = "html:\n\
+        \x20   <div><button @click=\"toggle()\">t</button><span :if=\"on\">HERE</span></div>\n\
+        script:\n\
+        \x20   let on = false\n\
+        \x20   function toggle(){ on = !on }\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const box = root.childNodes[0];\n\
+        const btn = box.childNodes[0];\n\
+        console.log('INITIAL:' + box.innerHTMLString());\n\
+        btn.dispatch('click');\n\
+        await tick();\n\
+        console.log('SHOWN:' + box.innerHTMLString());\n\
+        btn.dispatch('click');\n\
+        await tick();\n\
+        console.log('HIDDEN:' + box.innerHTMLString());\n";
+
+    let out = run_component("iftoggle", source, driver);
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("INITIAL:") && !l.contains("HERE")),
+        "initially hidden: {out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("SHOWN:") && l.contains("<span>HERE</span>")),
+        "branch built and inserted on toggle: {out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("HIDDEN:") && !l.contains("HERE")),
+        "branch removed on toggle back: {out}"
+    );
+}
+
+#[test]
+fn for_initial_push_splice_and_reorder() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Keyed :for over a deeply-mutated array. Mutations are driven through
+    // button click handlers (the only way to reach setup-local state from the
+    // driver): .push/.splice and a whole-array reassignment (reorder) all mark
+    // the list reactive; the keyed reconciler preserves node identity for
+    // surviving keys across a reorder.
+    let source = "html:\n\
+        \x20   <div>\n\
+        \x20     <button @click=\"push3()\">p</button>\n\
+        \x20     <button @click=\"drop2()\">d</button>\n\
+        \x20     <button @click=\"reorder()\">r</button>\n\
+        \x20     <ul><li :for=\"item of items\" :key=\"item.id\">${item.label}</li></ul>\n\
+        \x20   </div>\n\
+        script:\n\
+        \x20   let items = [{id:1,label:\"a\"},{id:2,label:\"b\"}]\n\
+        \x20   function push3(){ items.push({id:3,label:\"c\"}) }\n\
+        \x20   function drop2(){ items.splice(1, 1) }\n\
+        \x20   function reorder(){ items = [items[1], items[0]] }\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const [pBtn, dBtn, rBtn, ul] = div.childNodes;\n\
+        const lis = () => ul.childNodes.filter(n => n.tag === 'li');\n\
+        const labels = () => lis().map(n => n.innerHTMLString()).join(',');\n\
+        console.log('INITIAL:' + labels());\n\
+        const [firstA, firstB] = lis();\n\
+        pBtn.dispatch('click'); await tick();\n\
+        console.log('PUSH:' + labels());\n\
+        dBtn.dispatch('click'); await tick();\n\
+        console.log('SPLICE:' + labels());\n\
+        rBtn.dispatch('click'); await tick();\n\
+        const after = lis();\n\
+        console.log('REORDER:' + labels());\n\
+        console.log('IDENTITY:' + (after[after.length-1] === firstA));\n";
+
+    let out = run_component("forkeyed", source, driver);
+    assert!(out.contains("INITIAL:a,b"), "initial bulk render: {out}");
+    assert!(out.contains("PUSH:a,b,c"), "push appends: {out}");
+    assert!(
+        out.contains("SPLICE:a,c"),
+        "splice removes the middle: {out}"
+    );
+    assert!(
+        out.contains("REORDER:c,a"),
+        "reorder reflects new order: {out}"
+    );
+    assert!(
+        out.contains("IDENTITY:true"),
+        "surviving key keeps its DOM node across a reorder: {out}"
+    );
+}

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -4,9 +4,9 @@
 
 use swc_common::{sync::Lrc, FileName, SourceMap};
 use swc_ecma_ast::{
-    ArrayPat, AssignExpr, AssignTarget, AssignTargetPat, Decl, Expr, Ident, ImportSpecifier,
-    ModuleDecl, ModuleItem, ObjectPat, ObjectPatProp, Pat, SimpleAssignTarget, Stmt, UpdateExpr,
-    VarDecl,
+    ArrayPat, AssignExpr, AssignTarget, AssignTargetPat, CallExpr, Callee, Decl, Expr, Ident,
+    ImportSpecifier, MemberProp, ModuleDecl, ModuleItem, ObjectPat, ObjectPatProp, Pat,
+    SimpleAssignTarget, Stmt, UpdateExpr, VarDecl,
 };
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 use swc_ecma_visit::{Visit, VisitWith};
@@ -613,6 +613,50 @@ impl Visit for AssignCollector {
         }
         n.arg.visit_with(self);
     }
+
+    fn visit_call_expr(&mut self, n: &CallExpr) {
+        // A mutating method call on a binding deep-mutates it: `items.push(x)`,
+        // `list.splice(…)`, `set.add(…)`, `map.clear()`, … all change the value
+        // the binding holds even though nothing is assigned. Report the root
+        // object so the binding is treated as reactive (and later boxed with a
+        // `deepBox`). Only *known* mutators count — a `.filter()`/`.map()` is
+        // non-mutating and must not spuriously mark the binding.
+        if let Callee::Expr(callee) = &n.callee {
+            if let Expr::Member(m) = &**callee {
+                if let MemberProp::Ident(method) = &m.prop {
+                    if is_mutating_method(&method.sym) {
+                        if let Some(id) = root_ident(&m.obj) {
+                            self.names.push(id.sym.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        // Still recurse: arguments (and the callee object) may contain further
+        // assignments / mutations.
+        n.visit_children_with(self);
+    }
+}
+
+/// Array / collection methods that mutate the receiver in place. A call to one
+/// of these on a binding is a deep mutation of that binding.
+fn is_mutating_method(name: &str) -> bool {
+    matches!(
+        name,
+        "push"
+            | "pop"
+            | "shift"
+            | "unshift"
+            | "splice"
+            | "sort"
+            | "reverse"
+            | "fill"
+            | "copyWithin"
+            | "set"
+            | "add"
+            | "delete"
+            | "clear"
+    )
 }
 
 impl AssignCollector {

--- a/crates/lunas_script/tests/analysis.rs
+++ b/crates/lunas_script/tests/analysis.rs
@@ -272,6 +272,43 @@ fn function_mutations_ignores_locals_but_keeps_outer() {
 }
 
 #[test]
+fn function_mutations_detects_array_mutators() {
+    // In-place array/collection mutation deep-mutates the binding even though
+    // nothing is assigned, so the receiver's root is reported.
+    let muts =
+        function_mutations("function f(){ items.push(1); q.splice(0, 1); s.add(2); m.clear() }")
+            .unwrap();
+    assert_eq!(muts[0].0, "f");
+    for name in ["items", "q", "s", "m"] {
+        assert!(
+            muts[0].1.contains(&name.to_string()),
+            "{name} mutated: {muts:?}"
+        );
+    }
+}
+
+#[test]
+fn function_mutations_ignores_non_mutating_methods() {
+    // filter/map/slice return a new value; they do not mutate the receiver, so
+    // a binding read only through them is not reported as mutated.
+    let muts =
+        function_mutations("function f(){ const x = items.filter(a => a).map(b => b) }").unwrap();
+    assert_eq!(muts[0].0, "f");
+    assert!(
+        !muts[0].1.contains(&"items".to_string()),
+        "non-mutating chain must not mark items: {muts:?}"
+    );
+}
+
+#[test]
+fn function_mutations_member_receiver_reports_root() {
+    // `state.list.push(x)` mutates `state`.
+    let muts = function_mutations("function f(){ state.list.push(1) }").unwrap();
+    assert_eq!(muts[0].0, "f");
+    assert!(muts[0].1.contains(&"state".to_string()), "{muts:?}");
+}
+
+#[test]
 fn function_mutations_on_real_fixture() {
     // counter-game's functions and what they mutate.
     let path = format!(

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -4,32 +4,60 @@
 // Every block collects the binds created inside its content into a scope
 // (core.mjs beginScope/endScope) and drops that scope when the content is
 // removed, so removed content never receives updates and never leaks.
+//
+// Scope homing: a block remembers the scope that was open when it was CREATED
+// (its "home" — e.g. the enclosing :for item's scope) and opens its content
+// scopes under that home, even when the content is (re)built later from a
+// flush where no scope is open. This keeps the scope tree congruent with the
+// block tree, so dropping an item's scope recursively drops the binds of any
+// nested :if/:for content alive inside it (for-diff-design.md §5, §6).
 
-import { bind, unbind, beginScope, endScope, dropScope } from "./core.mjs";
-import { createForState, seedForState, reconcile } from "./for_diff.mjs";
+import {
+  bind,
+  unbind,
+  beginScope,
+  endScope,
+  dropScope,
+  runScope,
+} from "./core.mjs";
+import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
 
 const toNodes = (h) => (Array.isArray(h) ? h : [h]);
 const firstNode = (h) => (Array.isArray(h) ? h[0] : h);
+
+// Run `fn` inside a fresh scope parented to `home` (not to whatever scope
+// happens to be open), restoring the previous open scope afterwards.
+// Returns { result, scope }.
+function inScopeAt(c, home, fn) {
+  const prev = c.scope;
+  c.scope = home;
+  const scope = beginScope(c);
+  let result;
+  try {
+    result = fn();
+  } finally {
+    endScope(c);
+    c.scope = prev;
+  }
+  return { result, scope };
+}
 
 // ifBlock(c, anchor, deps, cond, make)
 // `make()` returns a node (single-root branch) or an array of nodes
 // (multi-root branch — the compiler knows which and emits accordingly).
 // The branch is inserted before the permanent anchor when cond() becomes
 // truthy and removed (with scope teardown) when it becomes falsy.
-// Returns a handle with destroy() for whole-block teardown.
+// Returns a handle with update() (re-evaluate now; used by :for item patching)
+// and destroy() for whole-block teardown.
 export function ifBlock(c, anchor, deps, cond, make) {
+  const home = c.scope;
   let nodes = null;
   let scope = null;
 
   const insert = () => {
-    scope = beginScope(c);
-    let h;
-    try {
-      h = make();
-    } finally {
-      endScope(c);
-    }
-    nodes = toNodes(h);
+    const r = inScopeAt(c, home, make);
+    scope = r.scope;
+    nodes = toNodes(r.result);
     const p = anchor.parentNode;
     for (const n of nodes) p.insertBefore(n, anchor);
   };
@@ -40,14 +68,16 @@ export function ifBlock(c, anchor, deps, cond, make) {
     scope = null;
   };
 
-  const s = bind(c, deps, () => {
+  const run = () => {
     const want = !!cond();
     if (want === (nodes !== null)) return;
     if (want) insert();
     else removeAll();
-  });
+  };
+  const s = bind(c, deps, run);
 
   return {
+    update: run,
     destroy() {
       unbind(c, s);
       if (nodes !== null) removeAll();
@@ -55,20 +85,81 @@ export function ifBlock(c, anchor, deps, cond, make) {
   };
 }
 
+// ifChain(c, anchor, deps, which, makes)
+// One :if/:elseif/:else cascade at a single permanent anchor. `which()`
+// returns the index of the branch that should be shown (compiled from the
+// cascade's conditions), or -1 for "no branch" (a cascade without :else whose
+// conditions are all false). Exactly one branch is alive at a time; switching
+// tears the old branch's scope down and builds the new one via its own make.
+// Returns a handle with update() and destroy(), like ifBlock.
+export function ifChain(c, anchor, deps, which, makes) {
+  const home = c.scope;
+  let cur = -1;
+  let nodes = null;
+  let scope = null;
+
+  const removeAll = () => {
+    for (const n of nodes) n.remove();
+    nodes = null;
+    dropScope(c, scope);
+    scope = null;
+  };
+
+  const run = () => {
+    const idx = which();
+    if (idx === cur) return;
+    if (nodes !== null) removeAll();
+    cur = idx;
+    if (idx >= 0) {
+      const r = inScopeAt(c, home, makes[idx]);
+      scope = r.scope;
+      nodes = toNodes(r.result);
+      const p = anchor.parentNode;
+      for (const n of nodes) p.insertBefore(n, anchor);
+    }
+  };
+  const s = bind(c, deps, run);
+
+  return {
+    update: run,
+    destroy() {
+      unbind(c, s);
+      if (nodes !== null) removeAll();
+      cur = -1;
+    },
+  };
+}
+
 // forBlock(c, anchor, deps, items, opts)
 //   items — closure returning the current array (read lazily at flush time)
-//   opts.make(itemData, key)   — build one item; returns node or node array
+//
+// Item construction — one of two modes (the compiler picks one per site):
+//   opts.make(itemData, key, index)  — build one item; returns node or array.
+//   opts.html + opts.wire            — compiled mode (output-design.md §8):
+//     opts.html                — the item's static skeleton HTML (one string,
+//                                single-root). The INITIAL render concatenates
+//                                it N times into ONE bulk innerHTML parse; on
+//                                updates a new item parses its own copy.
+//     opts.wire(root, d, i)    — wire one item's dynamics against its root
+//                                node (binds, listeners, nested blocks). May
+//                                return a patch closure `(d, i) => …` that
+//                                updates the item's data cell; after it runs,
+//                                the item's whole scope is re-run (runScope)
+//                                so every item-local bind — including nested
+//                                block binds — sees the new data.
+//
 //   opts.keyOf(itemData, i)    — compiled :key (optional; see design doc §3)
-//   opts.patch(handle, data)   — update an existing item's scope (optional)
+//   opts.patch(handle, d, i)   — extra user patch hook (optional)
 //   opts.onWarn(msg)           — duplicate-key warning hook (optional)
-//   opts.seed                  — { keys, handles, data } from a bulk
-//                                innerHTML initial render (optional); when
-//                                present the initial reconcile is skipped
-//                                because the items are already mounted.
-// Updates go through the keyed LIS reconciler; innerHTML is never used here.
-// Returns a handle with destroy().
+//   opts.seed                  — { keys, handles, data } from an external
+//                                initial render (optional); when present the
+//                                initial reconcile is skipped.
+// Updates go through the keyed LIS reconciler; innerHTML is never used on
+// update. Returns a handle with update() and destroy().
 export function forBlock(c, anchor, deps, items, opts) {
+  const home = c.scope;
   const scopes = new Map(); // handle -> scope
+  const patches = new Map(); // handle -> patch closure from opts.wire
 
   const host = {
     insertBefore(h, ref) {
@@ -83,25 +174,40 @@ export function forBlock(c, anchor, deps, items, opts) {
         dropScope(c, sc);
         scopes.delete(h);
       }
+      patches.delete(h);
     },
   };
 
-  const makeItem = (itemData, key) => {
-    const sc = beginScope(c);
-    let h;
-    try {
-      h = opts.make(itemData, key);
-    } finally {
-      endScope(c);
-    }
-    scopes.set(h, sc);
-    return h;
+  const compiled = opts.html != null && opts.wire;
+
+  // Build one item in compiled mode: parse its own skeleton copy, wire it.
+  const buildOne = (d, i) => {
+    const scr = anchor.ownerDocument.createElement("div");
+    scr.innerHTML = opts.html;
+    const root = scr.childNodes[0];
+    const p = opts.wire(root, d, i);
+    if (p) patches.set(root, p);
+    return root;
+  };
+
+  const makeItem = (d, key, i) => {
+    const r = inScopeAt(c, home, () =>
+      compiled ? buildOne(d, i) : opts.make(d, key, i)
+    );
+    scopes.set(r.result, r.scope);
+    return r.result;
   };
 
   const state = createForState();
   const ropts = {
     keyOf: opts.keyOf,
-    patchItem: opts.patch,
+    patchItem(h, d, i) {
+      const p = patches.get(h);
+      if (p) p(d, i);
+      const sc = scopes.get(h);
+      if (sc) runScope(c, sc);
+      if (opts.patch) opts.patch(h, d, i);
+    },
     onWarn: opts.onWarn,
   };
 
@@ -109,18 +215,46 @@ export function forBlock(c, anchor, deps, items, opts) {
   if (opts.seed) {
     seedForState(state, opts.seed.keys, opts.seed.handles, opts.seed.data);
     seeded = true;
+  } else if (compiled) {
+    // Bulk initial render (design doc §2a): ONE innerHTML parse of every
+    // item's skeleton concatenated, then per-item wiring, then seed the
+    // reconciler. No later update ever re-runs this.
+    const arr = items();
+    const n = arr.length;
+    if (n > 0) {
+      const scr = anchor.ownerDocument.createElement("div");
+      let html = "";
+      for (let i = 0; i < n; i++) html += opts.html;
+      scr.innerHTML = html;
+      // Snapshot roots before moving anything (childNodes is live).
+      const nodes = new Array(n);
+      for (let i = 0; i < n; i++) nodes[i] = scr.childNodes[i];
+      const kx = extractKeys(arr, opts.keyOf || ((d) => d), opts.onWarn);
+      const p = anchor.parentNode;
+      for (let i = 0; i < n; i++) {
+        const root = nodes[i];
+        const r = inScopeAt(c, home, () => opts.wire(root, arr[i], i));
+        if (r.result) patches.set(root, r.result);
+        scopes.set(root, r.scope);
+        p.insertBefore(root, anchor);
+      }
+      seedForState(state, kx.keys, nodes, arr);
+    }
+    seeded = true;
   }
 
+  const run = () => reconcile(state, host, items(), makeItem, ropts);
   const s = bind(c, deps, () => {
     if (seeded) {
-      // bulk initial render already mounted the items; skip the first run
+      // the initial render already mounted the items; skip the first run
       seeded = false;
       return;
     }
-    reconcile(state, host, items(), makeItem, ropts);
+    run();
   });
 
   return {
+    update: run,
     destroy() {
       unbind(c, s);
       reconcile(state, host, [], makeItem, ropts); // removes all + drops scopes

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -106,6 +106,23 @@ export function endScope(c) {
   c.scope = c.scope ? c.scope.parent : null;
 }
 
+// runScope(c, scope) — re-run every live bind registered in `scope` and its
+// child scopes (nested blocks' content). Used by forBlock's patch path: after
+// an item's data cell is updated, re-running the item's scope refreshes every
+// item-local bind — including nested ifBlock/forBlock binds, which re-evaluate
+// their condition/reconcile with the fresh data (for-diff-design.md §6).
+// Scopes dropped mid-walk are safe: dropScope empties their arrays and marks
+// their records dead, so they no-op here.
+export function runScope(c, scope) {
+  // Snapshot first: a sub may create child scopes (a branch shown by this very
+  // walk) whose binds already ran at creation, or drop existing ones (their
+  // arrays are emptied by dropScope, so recursing into them is a no-op).
+  const subs = scope.subs.slice();
+  const children = scope.children.slice();
+  for (const s of subs) if (s.alive) s.fn();
+  for (const ch of children) runScope(c, ch);
+}
+
 export function dropScope(c, scope) {
   for (const s of scope.subs) unbind(c, s);
   for (const ch of scope.children) {

--- a/packages/lunas/src/dom.mjs
+++ b/packages/lunas/src/dom.mjs
@@ -28,6 +28,21 @@ export const refs = (root, paths) =>
 
 export const on = (el, ev, fn) => el.addEventListener(ev, fn);
 
+// fromHTML(html, near) — parse a static block skeleton (an :if branch, a :for
+// item, …) into a detached scratch element via one bulk innerHTML, exactly like
+// the component root build (§8: branches are built by their own innerHTML when
+// shown). `near` is any node used to reach the owner document, so blocks built
+// inside a detached component still resolve a document (and tests can pass a
+// fake-DOM node).
+export function fromHTML(html, near) {
+  const doc =
+    (near && near.ownerDocument) ||
+    (typeof document !== "undefined" ? document : null);
+  const el = doc.createElement("div");
+  el.innerHTML = html;
+  return el;
+}
+
 // --- anchors -----------------------------------------------------------------
 // Anchors are permanent EMPTY TEXT NODES created at wiring time (never
 // comments — comments knock Blink off the fast-path parser; see

--- a/packages/lunas/src/for_diff.mjs
+++ b/packages/lunas/src/for_diff.mjs
@@ -25,12 +25,12 @@
 //   host.remove(node)
 //       Detach `node` from the parent.
 //
-//   makeItem(itemData, key) -> node
+//   makeItem(itemData, key, index) -> node
 //       Build the DOM (or handle) for a new item and return its host node.
 //       In the runtime this parses the item's own innerHTML branch, wires its
 //       binds, and returns the single-root node or a multi-root handle.
 //
-//   patchItem(node, itemData)  [optional]
+//   patchItem(node, itemData, index)  [optional]
 //       Update an existing item's reactive scope with new data (same key,
 //       possibly new value/index). No-op if omitted.
 //
@@ -78,8 +78,10 @@ const NADA = -1;
 // only loses the "reuse by identity" optimization. A warning is surfaced via
 // the optional `onWarn` hook.
 //
-// Returns { keys, duped }.
-function extractKeys(items, keyOf, onWarn) {
+// Returns { keys, duped }. Exported so the runtime's bulk initial render
+// (blocks.mjs forBlock, html/wire mode) seeds the reconciler state with exactly
+// the same key semantics — including the duplicate-key index fallback.
+export function extractKeys(items, keyOf, onWarn) {
   const n = items.length;
   const keys = new Array(n);
   const seen = new Map(); // key -> first index, for the warning
@@ -169,7 +171,7 @@ export function reconcile(state, host, items, makeItem, opts) {
     // Everything is new. Append in order (refNode = null => before anchor).
     const nodes = new Array(newLen);
     for (let i = 0; i < newLen; i++) {
-      const node = makeItem(items[i], newKeys[i]);
+      const node = makeItem(items[i], newKeys[i], i);
       host.insertBefore(node, null);
       nodes[i] = node;
     }
@@ -186,7 +188,7 @@ export function reconcile(state, host, items, makeItem, opts) {
     start < minLen &&
     sameKey(effOldKeys[start], newKeys[start])
   ) {
-    if (patchItem) patchItem(oldNodes[start], items[start]);
+    if (patchItem) patchItem(oldNodes[start], items[start], start);
     start++;
   }
 
@@ -198,7 +200,7 @@ export function reconcile(state, host, items, makeItem, opts) {
     newEnd >= start &&
     sameKey(effOldKeys[oldEnd], newKeys[newEnd])
   ) {
-    if (patchItem) patchItem(oldNodes[oldEnd], items[newEnd]);
+    if (patchItem) patchItem(oldNodes[oldEnd], items[newEnd], newEnd);
     oldEnd--;
     newEnd--;
   }
@@ -217,7 +219,7 @@ export function reconcile(state, host, items, makeItem, opts) {
     const refNode =
       newEnd + 1 < newLen ? resultNodes[newEnd + 1] : null;
     for (let i = start; i <= newEnd; i++) {
-      const node = makeItem(items[i], newKeys[i]);
+      const node = makeItem(items[i], newKeys[i], i);
       host.insertBefore(node, refNode);
       resultNodes[i] = node;
     }
@@ -260,7 +262,7 @@ export function reconcile(state, host, items, makeItem, opts) {
       newToOld[rel] = oi;
       oldUsed[oi - start] = true;
       resultNodes[ni] = oldNodes[oi];
-      if (patchItem) patchItem(oldNodes[oi], items[ni]);
+      if (patchItem) patchItem(oldNodes[oi], items[ni], ni);
       patched++;
     }
   }
@@ -289,7 +291,7 @@ export function reconcile(state, host, items, makeItem, opts) {
 
     if (newToOld[rel] === NADA) {
       // new key -> create + insert
-      const node = makeItem(items[ni], k);
+      const node = makeItem(items[ni], k, ni);
       host.insertBefore(node, refNode);
       resultNodes[ni] = node;
     } else if (lisPtr >= 0 && lis[lisPtr] === rel) {

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -13,6 +13,7 @@ export {
   beginScope,
   endScope,
   dropScope,
+  runScope,
 } from "./core.mjs";
 
 export { box, deepBox, shared } from "./boxes.mjs";
@@ -27,17 +28,19 @@ export {
   component,
   refs,
   on,
+  fromHTML,
   anchorBefore,
   anchorBeforeSplit,
   anchorAppend,
 } from "./dom.mjs";
 
-export { ifBlock, forBlock, mountChild } from "./blocks.mjs";
+export { ifBlock, ifChain, forBlock, mountChild } from "./blocks.mjs";
 
 export {
   createForState,
   seedForState,
   reconcile,
+  extractKeys,
   longestIncreasingSubsequence,
 } from "./for_diff.mjs";
 

--- a/packages/lunas/test/blocks-compiled.test.mjs
+++ b/packages/lunas/test/blocks-compiled.test.mjs
@@ -1,0 +1,238 @@
+// blocks-compiled.test.mjs — the compiled control-flow surface the code
+// generator targets: forBlock's html/wire mode (bulk innerHTML initial render,
+// per-item wiring, patch-through-runScope) and fromHTML branch building.
+// Uses the dom-shim (innerHTML-capable), the same fake DOM the compiled-output
+// exec tests run against.
+// Run: node packages/lunas/test/blocks-compiled.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind, markVar } from "../src/core.mjs";
+import { box, deepBox } from "../src/boxes.mjs";
+import { fromHTML, anchorAppend } from "../src/dom.mjs";
+import { ifBlock, forBlock } from "../src/blocks.mjs";
+
+installDom();
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+const shape = (parent) =>
+  parent.childNodes
+    .map((n) =>
+      n.kind === "text" ? (n.data === "" ? "|" : n.data) : "<" + n.tag + ">"
+    )
+    .join(" ");
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- fromHTML ------------------------------------------------------------------
+
+await test("fromHTML parses a branch skeleton into a detached scratch element", () => {
+  const near = document.createTextNode("");
+  const r = fromHTML('<p class="a">hi</p><span></span>', near);
+  assert.strictEqual(r.childNodes.length, 2);
+  assert.strictEqual(r.childNodes[0].tag, "p");
+  assert.strictEqual(r.childNodes[0].getAttribute("class"), "a");
+  assert.strictEqual(r.childNodes[1].tag, "span");
+  assert.strictEqual(r.parentNode, null, "detached");
+});
+
+// --- forBlock compiled mode ------------------------------------------------------
+
+await test("forBlock html/wire: bulk initial render + per-item wiring", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  const list = deepBox(c, 0, [
+    { id: 1, txt: "one" },
+    { id: 2, txt: "two" },
+  ]);
+  let wires = 0;
+  forBlock(c, anchor, [0], () => Array.from(list.v), {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      wires++;
+      let d = d0;
+      const t = document.createTextNode("");
+      root.appendChild(t);
+      bind(c, [], () => {
+        t.data = d.txt;
+      });
+      return (nd) => {
+        d = nd;
+      };
+    },
+    keyOf: (d) => d.id,
+  });
+  assert.strictEqual(wires, 2, "each item wired once");
+  assert.strictEqual(parent.childNodes.length, 3, "2 items + anchor");
+  assert.strictEqual(parent.childNodes[0].outerHTML, "<li>one</li>");
+  assert.strictEqual(parent.childNodes[1].outerHTML, "<li>two</li>");
+});
+
+await test("forBlock html/wire: push appends, reorder moves same nodes, patch refreshes data", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  const list = deepBox(c, 0, [
+    { id: 1, txt: "a" },
+    { id: 2, txt: "b" },
+  ]);
+  forBlock(c, anchor, [0], () => Array.from(list.v), {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      let d = d0;
+      const t = document.createTextNode("");
+      root.appendChild(t);
+      bind(c, [], () => {
+        t.data = d.txt;
+      });
+      return (nd) => {
+        d = nd;
+      };
+    },
+    keyOf: (d) => d.id,
+  });
+  const [n1, n2] = [parent.childNodes[0], parent.childNodes[1]];
+
+  list.v.push({ id: 3, txt: "c" });
+  await tick();
+  assert.strictEqual(parent.childNodes.length, 4);
+  assert.strictEqual(parent.childNodes[0], n1, "no rebuild on append");
+  assert.strictEqual(parent.childNodes[2].outerHTML, "<li>c</li>");
+
+  list.v.reverse();
+  await tick();
+  assert.strictEqual(parent.childNodes[0].outerHTML, "<li>c</li>");
+  assert.strictEqual(parent.childNodes[1], n2, "same node object moved");
+  assert.strictEqual(parent.childNodes[2], n1, "same node object moved");
+
+  // patch: same key, new data — node reused, text refreshed via runScope
+  list.v[2] = { id: 1, txt: "A!" };
+  await tick();
+  assert.strictEqual(parent.childNodes[2], n1, "patched in place");
+  assert.strictEqual(parent.childNodes[2].outerHTML, "<li>A!</li>");
+});
+
+await test("forBlock html/wire: removed item's binds are dead; empty <-> filled", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  const hi = box(c, 1, "!");
+  let arr = ["a", "b"];
+  const runs = { a: 0, b: 0 };
+  forBlock(c, anchor, [0], () => arr.slice(), {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      const key = d0;
+      const t = document.createTextNode("");
+      root.appendChild(t);
+      bind(c, [1], () => {
+        runs[key]++;
+        t.data = key + hi.v;
+      });
+    },
+    keyOf: (d) => d,
+  });
+  assert.deepStrictEqual(runs, { a: 1, b: 1 });
+  arr = ["a"];
+  markVar(c, 0);
+  await tick();
+  hi.v = "!!";
+  await tick();
+  assert.strictEqual(runs.b, 1, "removed item's bind unregistered");
+  arr = [];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(shape(parent), "|");
+  arr = ["b"];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(parent.childNodes[0].outerHTML, "<li>b!!</li>");
+});
+
+await test("forBlock html/wire: nested ifBlock re-evaluates on patch and dies with its item", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  let arr = [{ id: 1, on: false }];
+  let innerBinds = 0;
+  const flag = box(c, 1, "*");
+  forBlock(c, anchor, [0], () => arr.slice(), {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      let d = d0;
+      const a = anchorAppend(root);
+      ifBlock(c, a, [], () => d.on, () => {
+        const el = document.createElement("em");
+        bind(c, [1], () => {
+          innerBinds++;
+          el.setAttribute("data-x", flag.v);
+        });
+        return el;
+      });
+      return (nd) => {
+        d = nd;
+      };
+    },
+    keyOf: (d) => d.id,
+  });
+  assert.strictEqual(parent.childNodes[0].childNodes.length, 1, "just the if anchor");
+
+  // patch with on=true — runScope re-runs the nested ifBlock's bind
+  arr = [{ id: 1, on: true }];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(parent.childNodes[0].childNodes[0].tag, "em", "branch shown after patch");
+  assert.strictEqual(innerBinds, 1);
+
+  // removing the item drops the nested branch's binds (scope homing)
+  arr = [];
+  markVar(c, 0);
+  await tick();
+  flag.v = "**";
+  await tick();
+  assert.strictEqual(innerBinds, 1, "nested branch bind dead after item removal");
+});
+
+await test("forBlock html/wire: duplicate keys warn and fall back to index keys", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  const warnings = [];
+  forBlock(c, anchor, [0], () => ["x", "x"], {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      root.appendChild(document.createTextNode(d0));
+    },
+    keyOf: (d) => d,
+    onWarn: (m) => warnings.push(m),
+  });
+  assert.strictEqual(parent.childNodes.length, 3, "both items rendered");
+  assert.strictEqual(warnings.length, 1, "one duplicate-key warning");
+});
+
+await test("forBlock update() forces a reconcile (used by outer patch paths)", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  let arr = ["a"];
+  const blk = forBlock(c, anchor, [], () => arr.slice(), {
+    html: "<li></li>",
+    wire: (root, d0) => {
+      root.appendChild(document.createTextNode(d0));
+    },
+    keyOf: (d) => d,
+  });
+  assert.strictEqual(parent.childNodes.length, 2);
+  arr = ["a", "b"];
+  blk.update(); // no dep fired; forced refresh
+  assert.strictEqual(parent.childNodes.length, 3);
+  assert.strictEqual(parent.childNodes[1].outerHTML, "<li>b</li>");
+});
+
+console.log("blocks-compiled.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/blocks.test.mjs
+++ b/packages/lunas/test/blocks.test.mjs
@@ -3,7 +3,14 @@
 // Run: node packages/lunas/test/blocks.test.mjs
 
 import assert from "node:assert";
-import { createContext, bind, markVar } from "../src/core.mjs";
+import {
+  createContext,
+  bind,
+  markVar,
+  beginScope,
+  endScope,
+  dropScope,
+} from "../src/core.mjs";
 import { box, deepBox } from "../src/boxes.mjs";
 import {
   anchorBefore,
@@ -11,7 +18,7 @@ import {
   anchorAppend,
   on,
 } from "../src/dom.mjs";
-import { ifBlock, forBlock, mountChild } from "../src/blocks.mjs";
+import { ifBlock, ifChain, forBlock, mountChild } from "../src/blocks.mjs";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -201,6 +208,132 @@ await test("ifBlock teardown: inner binds dropped on hide; destroy() unbinds all
   assert.strictEqual(innerRuns, 3, "nothing runs after destroy");
 });
 
+// --- ifChain -------------------------------------------------------------------
+
+await test("ifChain switches branches; -1 shows none", async () => {
+  const c = createContext(null);
+  const parent = fakeDoc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const n = box(c, 0, 1);
+  const makes = { pos: 0, neg: 0 };
+  ifChain(
+    c,
+    anchor,
+    [0],
+    () => (n.v > 0 ? 0 : n.v < 0 ? 1 : -1),
+    [
+      () => {
+        makes.pos++;
+        return fakeDoc.createElement("pos");
+      },
+      () => {
+        makes.neg++;
+        return fakeDoc.createElement("neg");
+      },
+    ]
+  );
+  assert.strictEqual(shape(parent), "<pos> |", "initial branch 0");
+  n.v = -5;
+  await tick();
+  assert.strictEqual(shape(parent), "<neg> |", "switched to branch 1");
+  n.v = 0;
+  await tick();
+  assert.strictEqual(shape(parent), "|", "no branch for -1");
+  n.v = 3;
+  await tick();
+  assert.strictEqual(shape(parent), "<pos> |");
+  assert.deepStrictEqual(makes, { pos: 2, neg: 1 }, "branches rebuilt per show");
+});
+
+await test("ifChain: same branch stays put; switch tears the old scope down", async () => {
+  const c = createContext(null);
+  const parent = fakeDoc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const n = box(c, 0, 1);
+  const label = box(c, 1, "x");
+  let innerRuns = 0;
+  ifChain(
+    c,
+    anchor,
+    [0],
+    () => (n.v > 0 ? 0 : 1),
+    [
+      () => {
+        const el = fakeDoc.createElement("a");
+        bind(c, [1], () => {
+          innerRuns++;
+          el.data = label.v;
+        });
+        return el;
+      },
+      () => fakeDoc.createElement("b"),
+    ]
+  );
+  const el0 = parent.childNodes[0];
+  n.v = 2; // same branch index -> nothing happens
+  await tick();
+  assert.strictEqual(parent.childNodes[0], el0, "same branch: node kept");
+  assert.strictEqual(innerRuns, 1);
+  n.v = -1; // switch to branch 1
+  await tick();
+  label.v = "y";
+  await tick();
+  assert.strictEqual(innerRuns, 1, "old branch's bind dropped on switch");
+});
+
+await test("ifChain destroy() removes content and unbinds", async () => {
+  const c = createContext(null);
+  const parent = fakeDoc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const n = box(c, 0, 0);
+  const blk = ifChain(c, anchor, [0], () => (n.v > 0 ? 0 : -1), [
+    () => fakeDoc.createElement("x"),
+  ]);
+  n.v = 1;
+  await tick();
+  assert.strictEqual(shape(parent), "<x> |");
+  blk.destroy();
+  assert.strictEqual(shape(parent), "|");
+  n.v = 2;
+  await tick();
+  assert.strictEqual(shape(parent), "|", "dead after destroy");
+});
+
+// --- scope homing --------------------------------------------------------------
+
+await test("ifBlock content built on a later flush still parents to the creation scope", async () => {
+  const c = createContext(null);
+  const parent = fakeDoc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const show = box(c, 0, false);
+  const label = box(c, 1, "x");
+  let innerRuns = 0;
+
+  // Simulate a :for item: the block is created inside an item scope.
+  const home = beginScope(c);
+  ifBlock(c, anchor, [0], () => show.v, () => {
+    const el = fakeDoc.createElement("span");
+    bind(c, [1], () => {
+      innerRuns++;
+      el.data = label.v;
+    });
+    return el;
+  });
+  endScope(c);
+
+  show.v = true; // content is built during a flush (no scope open)
+  await tick();
+  assert.strictEqual(innerRuns, 1);
+
+  // Dropping the "item" scope must tear down the branch content's binds even
+  // though the branch was built later, outside the scope bracket.
+  dropScope(c, home);
+  label.v = "y";
+  show.v = false;
+  await tick();
+  assert.strictEqual(innerRuns, 1, "branch bind dropped with the home scope");
+});
+
 // --- forBlock ------------------------------------------------------------------
 
 await test("forBlock initial render + reorder reuses nodes via reconciler", async () => {
@@ -298,9 +431,11 @@ await test("forBlock item scope teardown: removed item's binds are dead", async 
   arr = ["a"]; // remove b
   markVar(c, 0);
   await tick();
+  // reconcile patched the kept item "a" (its scope re-ran once: a -> 3)
+  assert.deepStrictEqual(runsPerKey, { a: 3, b: 2 }, "kept item patched once");
   hi.v = "!!!";
   await tick();
-  assert.deepStrictEqual(runsPerKey, { a: 3, b: 2 }, "b's bind unregistered");
+  assert.deepStrictEqual(runsPerKey, { a: 4, b: 2 }, "b's bind unregistered");
 });
 
 await test("forBlock destroy() removes items and unbinds everything", async () => {

--- a/packages/lunas/test/dom-shim.mjs
+++ b/packages/lunas/test/dom-shim.mjs
@@ -22,6 +22,10 @@ class FakeNode {
     this._props = {}; // IDL properties set via `el.value = …` etc.
   }
   insertBefore(n, ref) {
+    if (ref !== null && ref !== undefined && ref.parentNode !== this) {
+      // Real-DOM semantics: a reference node that is not a child is an error.
+      throw new Error("insertBefore: refNode is not a child");
+    }
     if (n.parentNode) n.parentNode._drop(n);
     const at =
       ref === null || ref === undefined

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -45,9 +45,9 @@ tree:
         - { id: cg-text, title: "Reactive text binds", status: done }
         - { id: cg-attrs, title: "Attribute binds incl. static interpolation", status: done }
         - { id: cg-events, title: "Event listeners", status: done }
-        - { id: cg-two-way, title: "Two-way bindings", status: in_progress }
-        - { id: cg-if, title: "Conditional rendering (:if/:elseif/:else)", status: in_progress }
-        - { id: cg-for, title: "List rendering (keyed :for)", status: in_progress }
+        - { id: cg-two-way, title: "Two-way bindings", status: done }
+        - { id: cg-if, title: "Conditional rendering (:if/:elseif/:else)", status: done }
+        - { id: cg-for, title: "List rendering (keyed :for)", status: done }
         - { id: cg-components, title: "Child component mounting", status: todo }
         - { id: cg-inputs, title: "@input props handling", status: todo }
         - { id: cg-e2e, title: "End-to-end snapshot + browser smoke tests", status: todo }


### PR DESCRIPTION
## What

Completes the code generator for Wave-2 control flow (roadmap **cg-two-way**, **cg-if**, **cg-for**), plus the runtime support it targets.

- **Two-way `::name`** — property bind (read side) + write-back listener (write side). `::checked` commits on `change`; everything else on `input`. A two-way *member* lvalue (`::value="o.k"`) marks its root a `deepBox` and reactive; `resolve()` scans the whole template (incl. `:if` branches / `:for` bodies) for two-way mutation roots.
- **`:if` / `:elseif` / `:else`** — a plain `:if` compiles to the cheap `ifBlock`; a cascade to one `ifChain` with a `which()` index selector and a parallel array of branch builders. Each branch is its own hoisted static skeleton, built by `fromHTML` when shown, wired recursively (nested binds/events/refs work).
- **Keyed `:for`** — `forBlock` in compiled `html`/`wire` mode: hoisted item skeleton, bulk-`innerHTML` initial render, per-item wiring + per-item reactive scope, loop bindings shadow reactive vars (no `.v` rewrite; refreshed via `runScope` on the item's patch path), `:key` → `keyOf` (stripped from the DOM), LIS keyed diff on update.
- **Nesting** — `:if`-in-`:for` and `:for`-in-`:if` wire and react correctly. Depth is capped (`MAX_BLOCK_DEPTH`) and voided with a *warning* diagnostic beyond it — never a panic. The `compile()` API and never-panic guarantee are preserved.

## Why

The previous handoff snapshot had the emitter ~90% there but (a) left two stale "voided" tests asserting the old behavior, and (b) had an unfinished analysis change: `items.push()` inside a handler was **not** detected as a mutation, so `:for` over a pushed array (and nested control flow reading it) never became reactive. Two supporting fixes landed:

- `feat(script)`: `AssignCollector` now treats in-place array/collection mutators (`push`/`splice`/`add`/`clear`/…) as deep mutations of the receiver's root, while excluding non-mutating chains (`filter`/`map`). This is what makes the nested cases actually react.
- Robustness: a user binding whose name collides with a runtime helper (e.g. a reactive var named `on`) previously shadowed the helper and produced a broken module. Colliding helpers are now imported under a `$`-prefixed alias and referenced by it.

## Test evidence

- **Emit snapshots** (`codegen_emit.rs`): two-way `value`/`checked`, `if`/`elseif`/`else`, `:if` without `:else` (→ `-1`), keyed `:for` with `keyOf`, `:if`-in-`:for`, `:for`-in-`:if`, helper-collision aliasing, and a never-panic fuzz over arbitrary `:if`/`:for` nesting (depth 0–40).
- **Node exec tests** (`codegen_exec.rs`, dom-shim): input → state → dependent-text write-back; `:if` toggle via a click event (branch built/inserted, then removed); keyed `:for` initial render + push/splice/reorder asserting DOM order **and** node identity for a surviving key across a reorder.
- **Analysis unit tests** (`lunas_script`): mutating-method detection, non-mutating-method exclusion, member-receiver root reporting.
- Runtime suite (`packages/lunas/test/run-all.mjs`) green.

Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, and the node runtime suite all pass.

roadmap.yml: `cg-two-way` / `cg-if` / `cg-for` flipped to `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)