### PR TITLE
feat(runtime): async components + suspense boundaries

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -236,6 +236,26 @@ export function routerLink(el, router, path, opts) { /* click -> preventDefault 
 //   const a = anchorBefore(placeholder);
 //   routerOutlet(c, a, appRouter);               // <router-outlet/>
 //   routerLink(linkEl, appRouter, "/users/1");   // <a :href="/users/1">
+
+// --- async / lazy components + suspense boundaries ---
+export function asyncComponent(loader, opts) { /* wrap `() => import("./Heavy.mjs")`
+                                                  into a child factory; resolves default
+                                                  export or bare factory, caches after
+                                                  first load (later mounts sync); opts
+                                                  { loading?, error?, delay=200, timeout? }
+                                                  — Vue-style: loading only after `delay`,
+                                                  error on reject/timeout */ }
+export function mountAsyncChild(c, before, AsyncChild, props) { /* mountChild contract; threads
+                                                                   c so the child registers with
+                                                                   the nearest suspense boundary;
+                                                                   unmount() cancels in-flight loads */ }
+export function suspenseBlock(c, anchor, content, fallback) { /* boundary at a text anchor: builds
+                                                                 content (async kids start loading),
+                                                                 shows fallback until every async dep
+                                                                 registered via c._suspense settles,
+                                                                 then reveals content (batched via
+                                                                 afterFlush — no flash on sync subtrees);
+                                                                 nested boundaries own their subtree */ }
 ```
 
 No signal-tracking stack, no VDOM, no per-node effect objects.

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -95,6 +95,9 @@ main repo for the calling contract.
 | `historyAdapter(win)` | `lunas/router` | Default History-API adapter (pushState/replaceState/popstate). |
 | `routerOutlet(c, anchor, router, opts)` | `lunas/router` | Mount the matched route's component at an anchor, swapping on navigation; params passed as props. |
 | `routerLink(el, router, path, opts)` | `lunas/router` | Wire an element's click to a client-side navigation (preventDefault + push). |
+| `asyncComponent(loader, opts?)` | `lunas/async` | Wrap a lazy module loader (`() => import(...)`) into a mountable child factory; resolves default export or bare factory, caches after first load, optional `loading`/`error`/`delay`/`timeout`. |
+| `mountAsyncChild(c, anchor, factory, props?)` | `lunas/async` | Mount an async component at an anchor (mountChild contract + suspense registration); `unmount()` cancels any in-flight load. |
+| `suspenseBlock(c, anchor, contentFactory, fallbackFactory?)` | `lunas/async` | Async boundary at an anchor: shows `fallback` while any async child under it is pending, reveals `content` once all resolve (batched, no flash); nested boundaries are independent. |
 
 ## Testing
 

--- a/packages/lunas/package.json
+++ b/packages/lunas/package.json
@@ -70,6 +70,10 @@
       "types": "./types/router.d.ts",
       "import": "./src/router.mjs"
     },
+    "./async": {
+      "types": "./types/async.d.ts",
+      "import": "./src/async.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/lunas/src/async.mjs
+++ b/packages/lunas/src/async.mjs
@@ -1,0 +1,408 @@
+// async.mjs — async / lazy components + suspense boundaries.
+// See output-design.md §5 (runtime API) and §7 (mount lifecycle).
+//
+// Two cooperating primitives, dependency-free (ES2015 + Promise), tree-shakeable:
+//
+//   asyncComponent(loader, opts) — turn a `() => import("./Heavy.mjs")` loader
+//     into a mountable child factory. Resolves the module (default export or
+//     direct factory), caches after first load (later mounts are synchronous),
+//     and shows Vue-style loading/error components with a `delay`/`timeout`.
+//
+//   suspenseBlock(c, anchor, contentFactory, fallbackFactory) — a boundary at a
+//     text anchor. It shows `fallback` while any async component under it is
+//     pending, then reveals `content` once every pending dep resolves.
+//
+// ── Boundary-registration mechanism ────────────────────────────────────────
+// A suspense boundary publishes itself on the component context as `c._suspense`
+// for the duration of its content build. `asyncComponent`, when mounted, reads
+// the *current* `c._suspense` and — if present — registers with it: it bumps the
+// boundary's pending counter while the module loads and settles it (found / miss)
+// once resolved or rejected. Nested boundaries save the enclosing `c._suspense`,
+// install themselves, build their content, then restore the parent — so an inner
+// boundary owns exactly its own subtree and never leaks pending counts upward.
+// This reuses the existing context object; core.mjs / blocks.mjs are untouched.
+//
+// ── Unmount safety ─────────────────────────────────────────────────────────
+// Every async mount owns a live token ({ alive: true }). Unmount flips it false;
+// a loader that settles afterwards writes no DOM and settles no boundary. Boundary
+// swaps run through afterFlush so sync-resolved loads never flash the fallback.
+
+import { afterFlush } from "./core.mjs";
+import { mountChild } from "./blocks.mjs";
+
+// unwrap(mod) — accept an ES module namespace ({ default }), a bare factory, or
+// a `{ default }` wrapper object, and return the child-component factory.
+function unwrap(mod) {
+  if (mod && typeof mod === "object" && "default" in mod) return mod.default;
+  return mod;
+}
+
+// asyncComponent(loader, opts) — returns a childFactory usable with mountChild.
+//
+//   loader : () => Promise<Module|Factory> | Module | Factory
+//   opts   : {
+//     loading? : childFactory shown while pending (only after `delay` ms),
+//     error?   : childFactory shown on rejection / timeout,
+//     delay?   : ms to wait before showing `loading` (default 200; avoids flash),
+//     timeout? : ms after which a still-pending load is treated as an error,
+//   }
+//
+// The returned factory obeys the mountChild contract: called with `props`, it
+// returns a root Node immediately (a placeholder anchor + optional loading UI),
+// and swaps in the resolved component when the module lands. Once resolved, the
+// module is cached, so subsequent mounts build synchronously with no placeholder.
+export function asyncComponent(loader, opts) {
+  opts = opts || {};
+  const delay = opts.delay == null ? 200 : opts.delay;
+  const timeout = opts.timeout;
+  const loadingFactory = opts.loading || null;
+  const errorFactory = opts.error || null;
+
+  // Per-wrapper cache: `resolved` holds the settled child factory; `promise`
+  // dedupes concurrent in-flight loads so N mounts share one import().
+  let resolved = null;
+  let promise = null;
+
+  const load = () => {
+    if (resolved) return Promise.resolve(resolved);
+    if (promise) return promise;
+    let out;
+    try {
+      out = loader();
+    } catch (e) {
+      return Promise.reject(e);
+    }
+    // A synchronous (already-imported / factory) loader still normalizes to a
+    // promise so the mount path has one shape.
+    promise = Promise.resolve(out).then(
+      (mod) => {
+        resolved = unwrap(mod);
+        promise = null;
+        return resolved;
+      },
+      (err) => {
+        promise = null;
+        throw err;
+      }
+    );
+    return promise;
+  };
+
+  // The returned factory is invoked as `factory(props)` by mountChild (no
+  // `this`). The component context is threaded onto `mountAsync._c` by
+  // mountAsyncChild right before the call, so the factory can reach
+  // `c._suspense` and afterFlush without a `this`-binding contract.
+  const mountAsync = function (props) {
+    const c = mountAsync._c || null;
+    const boundary = c ? c._suspense : null;
+    return buildAsyncRoot(c, boundary, props, {
+      load,
+      resolved: () => resolved,
+      delay,
+      timeout,
+      loadingFactory,
+      errorFactory,
+    });
+  };
+  mountAsync._c = null;
+  return mountAsync;
+}
+
+// buildAsyncRoot — construct the mountable root for one async mount. Returns a
+// Node synchronously (placeholder anchor); swaps children in as the load settles.
+//
+// The root is a permanent empty text node acting as its own anchor; resolved /
+// loading / error content is inserted before it and removed on the next swap.
+// This keeps a single stable node in the parent's child list (mountChild inserts
+// `root`), so unmount()/removal is a single node.remove() on the placeholder plus
+// teardown of whatever child is currently shown.
+function buildAsyncRoot(c, boundary, props, cfg) {
+  const anchor = makeAnchor(c);
+  const token = { alive: true };
+  let shown = null; // { root, unmount } | null — the currently-mounted child
+
+  // If we have a live suspense boundary, register the pending dep now (before
+  // any async work) so a synchronously-resolvable child still counts until it
+  // actually mounts — the boundary settles it in `finish`.
+  const settled = { done: false };
+  if (boundary) boundary.enter();
+  const settleBoundary = () => {
+    if (boundary && !settled.done) {
+      settled.done = true;
+      boundary.leave();
+    }
+  };
+
+  // The anchor is inserted into the parent by mountChild AFTER this function
+  // returns, so a synchronous insert here would hit a detached anchor. Buffer
+  // any node whose insert races the attach and drain it in `_asyncAttached`
+  // (called by mountAsyncChild right after the anchor lands).
+  let queued = null;
+  const insert = (childRoot) => {
+    if (anchor.parentNode) anchor.parentNode.insertBefore(childRoot, anchor);
+    else (queued || (queued = [])).push(childRoot);
+  };
+  const clear = () => {
+    if (shown) {
+      shown.unmount();
+      shown = null;
+    }
+  };
+  const swapTo = (factory) => {
+    if (!token.alive) return;
+    clear();
+    const root = factory(props);
+    insert(root);
+    shown = { root, unmount: () => root.remove() };
+  };
+
+  const cached = cfg.resolved();
+  if (cached) {
+    // Cache hit: mount synchronously, no placeholder, no flash.
+    swapTo(cached);
+    settleBoundary();
+  } else {
+    // Cold load. Optionally show `loading` after `delay` ms (0 → immediately).
+    let delayTimer = null;
+    let timeoutTimer = null;
+
+    const showLoading = () => {
+      if (!token.alive || shown) return;
+      if (cfg.loadingFactory) swapTo(cfg.loadingFactory);
+    };
+    const showError = (err) => {
+      if (!token.alive) return;
+      if (cfg.errorFactory) {
+        clear();
+        const root = cfg.errorFactory(Object.assign({ error: err }, props));
+        insert(root);
+        shown = { root, unmount: () => root.remove() };
+      }
+    };
+
+    if (cfg.loadingFactory) {
+      if (cfg.delay <= 0) showLoading();
+      else delayTimer = setTimeout(showLoading, cfg.delay);
+    }
+    if (cfg.timeout != null) {
+      timeoutTimer = setTimeout(() => {
+        // Still pending when the timeout fires → treat as an error. `_timedOut`
+        // makes the later load resolution a no-op (no late swap-in).
+        if (token.alive && !cfg.resolved()) {
+          token._timedOut = true;
+          showError(new Error("async component: load timed out"));
+          settleBoundary();
+        }
+      }, cfg.timeout);
+    }
+
+    const clearTimers = () => {
+      if (delayTimer) clearTimeout(delayTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      delayTimer = timeoutTimer = null;
+    };
+
+    cfg.load().then(
+      (factory) => {
+        clearTimers();
+        if (!token.alive || token._timedOut) return; // unmounted / already errored
+        // Reveal on the flush boundary so a fast (micro-tick) resolve that races
+        // a batched update lands with no flicker.
+        const reveal = () => {
+          if (!token.alive || token._timedOut) return;
+          swapTo(factory);
+          settleBoundary();
+        };
+        if (c) afterFlush(c, reveal);
+        else reveal();
+      },
+      (err) => {
+        clearTimers();
+        if (!token.alive) return;
+        showError(err);
+        settleBoundary();
+      }
+    );
+  }
+
+  // Drain buffered synchronous inserts once the anchor is attached. Called by
+  // mountAsyncChild immediately after the anchor lands in the parent.
+  anchor._asyncAttached = () => {
+    if (queued) {
+      const q = queued;
+      queued = null;
+      for (const n of q) anchor.parentNode.insertBefore(n, anchor);
+    }
+  };
+  // Expose an unmount hook on the anchor so a mounting parent (or suspense
+  // content teardown) can drop this subtree and cancel pending work.
+  anchor._asyncUnmount = () => {
+    token.alive = false;
+    clear();
+    queued = null;
+    settleBoundary();
+    anchor.remove();
+  };
+  return anchor;
+}
+
+// makeAnchor(c) — a permanent empty text node used as the async root's anchor.
+// Resolves a document from the context root (works off-DOM / in tests).
+function makeAnchor(c) {
+  const doc =
+    (c && c.root && c.root.ownerDocument) ||
+    (typeof document !== "undefined" ? document : null);
+  return doc.createTextNode("");
+}
+
+// mountAsyncChild(c, anchor, asyncFactory, props) — the mount entry codegen uses
+// for an async component. Identical contract to mountChild, but threads the
+// component context `c` into the async factory (so it can reach `c._suspense`
+// and afterFlush) and returns an unmount that cancels in-flight loads.
+export function mountAsyncChild(c, anchor, asyncFactory, props) {
+  // Thread the context onto the factory for this mount. Async factories read
+  // `_c` at call time; setting it right before the call keeps the closure clean
+  // and avoids a `this`-binding contract through mountChild.
+  asyncFactory._c = c;
+  const m = mountChild(c, anchor, asyncFactory, props);
+  asyncFactory._c = null;
+  const root = m.root;
+  // The async root (an anchor text node) is now attached; drain any synchronous
+  // content (cache hit / delay-0 loading) that was buffered during the build.
+  if (root._asyncAttached) root._asyncAttached();
+  return {
+    root,
+    unmount() {
+      if (root._asyncUnmount) root._asyncUnmount();
+      else m.unmount();
+    },
+  };
+}
+
+// suspenseBlock(c, anchor, contentFactory, fallbackFactory)
+//
+// A boundary anchored at a text node. It builds `content` immediately (so async
+// children under it begin loading), but keeps it hidden and shows `fallback`
+// while any registered async dep is pending. When the pending counter reaches
+// zero the fallback is torn down and the content revealed — batched via
+// afterFlush so a fully-synchronous subtree never flashes the fallback.
+//
+//   contentFactory(c)  — returns a Node (or Node[]); async children inside it
+//                        register with this boundary via `c._suspense`.
+//   fallbackFactory()  — returns a Node (or Node[]) shown while pending.
+//
+// Nested boundaries: contentFactory runs with `c._suspense` pointing at THIS
+// boundary; an inner suspenseBlock saves/restores that pointer, so async deps
+// register with their nearest boundary only.
+export function suspenseBlock(c, anchor, contentFactory, fallbackFactory) {
+  const toNodes = (h) => (h == null ? [] : Array.isArray(h) ? h : [h]);
+  const parent = anchor.parentNode;
+
+  let pending = 0;
+  let done = false;
+  let alive = true;
+  let revealScheduled = false;
+
+  let contentNodes = null; // built once, held (detached) until revealed
+  let fallbackNodes = null;
+
+  const removeNodes = (list) => {
+    if (list) for (const n of list) if (n.parentNode) n.remove();
+  };
+  const insertNodes = (list) => {
+    if (list) for (const n of list) parent.insertBefore(n, anchor);
+  };
+
+  const reveal = () => {
+    if (!alive || !done) return;
+    removeNodes(fallbackNodes);
+    fallbackNodes = null;
+    insertNodes(contentNodes);
+  };
+
+  const maybeSettle = () => {
+    if (pending === 0 && !done) {
+      done = true;
+      if (revealScheduled) return;
+      revealScheduled = true;
+      // Batch the swap so a synchronous subtree (pending hit 0 during build)
+      // reveals content directly without ever painting the fallback.
+      afterFlush(c, () => {
+        revealScheduled = false;
+        reveal();
+      });
+    }
+  };
+
+  const boundary = {
+    enter() {
+      pending++;
+    },
+    leave() {
+      if (pending > 0) pending--;
+      maybeSettle();
+    },
+  };
+
+  // Install this boundary as the nearest one for the content build, saving any
+  // enclosing boundary so nested suspense restores correctly.
+  const prev = c._suspense;
+  c._suspense = boundary;
+  let built;
+  try {
+    built = contentFactory(c);
+  } finally {
+    c._suspense = prev;
+  }
+  contentNodes = toNodes(built);
+
+  // Decide the initial paint after the content build settled its synchronous
+  // deps. If nothing was pending, content is already `done`; reveal directly
+  // (no fallback ever mounts). Otherwise mount the fallback now.
+  if (done) {
+    insertNodes(contentNodes);
+  } else if (pending > 0) {
+    fallbackNodes = toNodes(fallbackFactory ? fallbackFactory() : null);
+    insertNodes(fallbackNodes);
+  } else {
+    // No async deps registered at all: reveal content immediately.
+    done = true;
+    insertNodes(contentNodes);
+  }
+
+  return {
+    // Whether the boundary has revealed its content (settled). Useful for tests.
+    isSettled() {
+      return done;
+    },
+    destroy() {
+      alive = false;
+      // Cancel any pending async children in the (possibly still-hidden) content
+      // by removing their anchors — each async root's `_asyncUnmount` flips its
+      // token so late loads write nothing.
+      cancelAsync(contentNodes);
+      removeNodes(fallbackNodes);
+      removeNodes(contentNodes);
+      contentNodes = fallbackNodes = null;
+      c._suspense = prev;
+    },
+  };
+}
+
+// cancelAsync(nodes) — best-effort cancel of async-component roots in a subtree
+// list. Async roots are the anchor text nodes carrying `_asyncUnmount`; walking
+// the parent list is enough because mountAsyncChild inserts each async root as a
+// sibling before the content anchor. We also scan descendants defensively.
+function cancelAsync(nodes) {
+  if (!nodes) return;
+  for (const n of nodes) {
+    if (n && n._asyncUnmount) n._asyncUnmount();
+    // Content built from an async child may itself hold nested async anchors as
+    // sibling text nodes; a shallow descendant scan covers the common shapes.
+    if (n && n.childNodes) {
+      for (const ch of n.childNodes.slice ? n.childNodes.slice() : n.childNodes) {
+        if (ch && ch._asyncUnmount) ch._asyncUnmount();
+      }
+    }
+  }
+}

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -53,3 +53,5 @@ export {
   routerOutlet,
   routerLink,
 } from "./router.mjs";
+
+export { asyncComponent, mountAsyncChild, suspenseBlock } from "./async.mjs";

--- a/packages/lunas/test/async.test.mjs
+++ b/packages/lunas/test/async.test.mjs
@@ -1,0 +1,339 @@
+// async.test.mjs — asyncComponent + suspenseBlock against the fake DOM.
+// Run: node packages/lunas/test/async.test.mjs
+//
+// Timing is exercised with controllable deferred promises (resolve when we say)
+// and real short timers for delay/timeout semantics. `tick()` drains the
+// microtask + flush queue; `after(ms)` waits past a real timer.
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import {
+  asyncComponent,
+  mountAsyncChild,
+  suspenseBlock,
+} from "../src/async.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const after = (ms) => new Promise((r) => setTimeout(r, ms + 5));
+
+// A deferred: a promise plus its resolve/reject, so tests control settle timing.
+function defer() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// A trivial child factory producing <tag>text</tag>.
+const leaf = (tag, text) => () => {
+  const el = document.createElement(tag);
+  if (text != null) el.appendChild(document.createTextNode(text));
+  return el;
+};
+
+// Build a host: a container element with a trailing anchor to mount into.
+function host() {
+  const c = createContext(document.createElement("div"));
+  const container = c.root;
+  const anchor = anchorAppend(container);
+  return { c, container, anchor };
+}
+
+// Serialize a container's children (skips empty-text anchors).
+function html(container) {
+  return container.childNodes
+    .filter((n) => !(n.kind === "text" && n.data === ""))
+    .map((n) => n.outerHTML)
+    .join("");
+}
+
+test("loader resolves → mounts the component", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise);
+  mountAsyncChild(c, anchor, factory, {});
+  assert.equal(html(container), ""); // nothing yet
+  d.resolve(leaf("span", "hi"));
+  await tick();
+  assert.equal(html(container), "<span>hi</span>");
+});
+
+test("default export is unwrapped", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise);
+  mountAsyncChild(c, anchor, factory, {});
+  d.resolve({ default: leaf("b", "def") }); // ES module shape
+  await tick();
+  assert.equal(html(container), "<b>def</b>");
+});
+
+test("cache: second mount is synchronous", async () => {
+  const { c, container, anchor } = host();
+  let loads = 0;
+  const d = defer();
+  const factory = asyncComponent(() => {
+    loads++;
+    return d.promise;
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  d.resolve(leaf("i", "x"));
+  await tick();
+  assert.equal(html(container), "<i>x</i>");
+  assert.equal(loads, 1);
+
+  // Second mount at a fresh anchor: resolves synchronously from cache.
+  const h2 = host();
+  mountAsyncChild(h2.c, h2.anchor, factory, {});
+  assert.equal(html(h2.container), "<i>x</i>"); // no await → already there
+  assert.equal(loads, 1); // loader not called again
+});
+
+test("delay: loading not shown before delay, shown after", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    loading: leaf("p", "loading"),
+    delay: 40,
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  await tick();
+  assert.equal(html(container), ""); // before delay: no loading (avoid flash)
+  await after(45);
+  assert.equal(html(container), "<p>loading</p>"); // after delay
+  d.resolve(leaf("span", "done"));
+  await tick();
+  assert.equal(html(container), "<span>done</span>");
+});
+
+test("delay: fast resolve never shows loading", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    loading: leaf("p", "loading"),
+    delay: 40,
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  d.resolve(leaf("span", "fast"));
+  await tick();
+  assert.equal(html(container), "<span>fast</span>");
+  await after(45); // delay timer should have been cleared
+  assert.equal(html(container), "<span>fast</span>");
+});
+
+test("error component shown on rejection", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    error: leaf("em", "err"),
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  d.reject(new Error("boom"));
+  await tick();
+  assert.equal(html(container), "<em>err</em>");
+});
+
+test("timeout → error component", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    error: leaf("em", "timed-out"),
+    timeout: 30,
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  await after(35);
+  assert.equal(html(container), "<em>timed-out</em>");
+  // A late resolve must not swap the error out.
+  d.resolve(leaf("span", "late"));
+  await tick();
+  assert.equal(html(container), "<em>timed-out</em>");
+});
+
+test("suspense: fallback → content when the single async dep resolves", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const child = asyncComponent(() => d.promise);
+
+  suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const a = anchorAppend(wrap);
+      mountAsyncChild(cc, a, child, {});
+      return wrap;
+    },
+    leaf("div", "fallback")
+  );
+
+  assert.equal(html(container), "<div>fallback</div>"); // pending → fallback
+  d.resolve(leaf("span", "content"));
+  await tick();
+  assert.equal(html(container), "<section><span>content</span></section>");
+});
+
+test("suspense: counter waits for BOTH async children", async () => {
+  const { c, container, anchor } = host();
+  const d1 = defer();
+  const d2 = defer();
+  const a1 = asyncComponent(() => d1.promise);
+  const a2 = asyncComponent(() => d2.promise);
+
+  const s = suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const an1 = anchorAppend(wrap);
+      mountAsyncChild(cc, an1, a1, {});
+      const an2 = anchorAppend(wrap);
+      mountAsyncChild(cc, an2, a2, {});
+      return wrap;
+    },
+    leaf("div", "wait")
+  );
+
+  assert.equal(html(container), "<div>wait</div>");
+  d1.resolve(leaf("b", "one"));
+  await tick();
+  assert.equal(s.isSettled(), false); // one still pending
+  assert.equal(html(container), "<div>wait</div>");
+  d2.resolve(leaf("i", "two"));
+  await tick();
+  assert.equal(s.isSettled(), true);
+  assert.equal(html(container), "<section><b>one</b><i>two</i></section>");
+});
+
+test("suspense: sync-resolved subtree never flashes fallback", async () => {
+  const { c, container, anchor } = host();
+  const child = asyncComponent(() => leaf("span", "sync")); // already a factory
+
+  suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const a = anchorAppend(wrap);
+      mountAsyncChild(cc, a, child, {});
+      return wrap;
+    },
+    leaf("div", "fallback")
+  );
+
+  // pending was bumped then settled during build; content reveals on afterFlush
+  // without the fallback ever entering the DOM.
+  await tick();
+  assert.equal(html(container), "<section><span>sync</span></section>");
+});
+
+test("suspense: content with no async deps reveals immediately", async () => {
+  const { c, container, anchor } = host();
+  const s = suspenseBlock(
+    c,
+    anchor,
+    () => leaf("main", "static")(),
+    leaf("div", "fallback")
+  );
+  assert.equal(s.isSettled(), true);
+  assert.equal(html(container), "<main>static</main>");
+});
+
+test("nested boundaries settle independently", async () => {
+  const { c, container, anchor } = host();
+  const dOuter = defer();
+  const dInner = defer();
+  const outerChild = asyncComponent(() => dOuter.promise);
+  const innerChild = asyncComponent(() => dInner.promise);
+
+  suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      // outer async dep
+      const ao = anchorAppend(wrap);
+      mountAsyncChild(cc, ao, outerChild, {});
+      // inner boundary with its own async dep + fallback
+      const innerAnchor = anchorAppend(wrap);
+      suspenseBlock(
+        cc,
+        innerAnchor,
+        (ic) => {
+          const iwrap = document.createElement("article");
+          const ia = anchorAppend(iwrap);
+          mountAsyncChild(ic, ia, innerChild, {});
+          return iwrap;
+        },
+        leaf("small", "inner-fallback")
+      );
+      return wrap;
+    },
+    leaf("div", "outer-fallback")
+  );
+
+  assert.equal(html(container), "<div>outer-fallback</div>");
+
+  // Resolve inner first: outer boundary is still pending on outerChild, so the
+  // outer fallback stays. The inner boundary settled but its content is inside
+  // the still-hidden outer content.
+  dInner.resolve(leaf("span", "inner-done"));
+  await tick();
+  assert.equal(html(container), "<div>outer-fallback</div>");
+
+  // Now resolve outer: outer content (which contains the already-revealed inner
+  // article) is shown.
+  dOuter.resolve(leaf("b", "outer-done"));
+  await tick();
+  assert.equal(
+    html(container),
+    "<section><b>outer-done</b><article><span>inner-done</span></article></section>"
+  );
+});
+
+test("unmount while pending writes nothing", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    loading: leaf("p", "loading"),
+    delay: 0,
+  });
+  const m = mountAsyncChild(c, anchor, factory, {});
+  await tick();
+  assert.equal(html(container), "<p>loading</p>"); // delay 0 → loading now
+  m.unmount();
+  assert.equal(html(container), ""); // gone
+  d.resolve(leaf("span", "late"));
+  await tick();
+  await after(5);
+  assert.equal(html(container), ""); // late resolve must not write DOM
+});
+
+test("destroy suspense while pending cancels async children", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const child = asyncComponent(() => d.promise);
+  const s = suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const a = anchorAppend(wrap);
+      mountAsyncChild(cc, a, child, {});
+      return wrap;
+    },
+    leaf("div", "fallback")
+  );
+  assert.equal(html(container), "<div>fallback</div>");
+  s.destroy();
+  assert.equal(html(container), "");
+  d.resolve(leaf("span", "late"));
+  await tick();
+  assert.equal(html(container), ""); // nothing written after destroy
+});

--- a/packages/lunas/types/async.d.ts
+++ b/packages/lunas/types/async.d.ts
@@ -1,0 +1,75 @@
+// async.d.ts — types for src/async.mjs
+// Async / lazy components + suspense boundaries.
+
+import type { Context } from "./core.js";
+import type { ChildFactory, MountedChild } from "./blocks.js";
+
+/** An imported module, an `{ default }` ES-module namespace, or a bare factory. */
+export type AsyncModule<P = Record<string, unknown>> =
+  | ChildFactory<P>
+  | { default: ChildFactory<P> };
+
+/** A loader for a lazy component: `() => import("./Heavy.mjs")` or similar. */
+export type AsyncLoader<P = Record<string, unknown>> = () =>
+  | Promise<AsyncModule<P>>
+  | AsyncModule<P>;
+
+/** Options for {@link asyncComponent}. */
+export interface AsyncComponentOptions<P = Record<string, unknown>> {
+  /** Component shown while pending — only after `delay` ms, to avoid a flash. */
+  loading?: ChildFactory<P>;
+  /** Component shown on load rejection or timeout. Receives `{ error }` in props. */
+  error?: ChildFactory<P & { error?: unknown }>;
+  /** Milliseconds to wait before showing `loading` (default 200). */
+  delay?: number;
+  /** Milliseconds after which a still-pending load is treated as an error. */
+  timeout?: number;
+}
+
+/**
+ * asyncComponent(loader, opts) — wrap a lazy module loader into a mountable
+ * child factory. The module is resolved on first mount (default export or bare
+ * factory both accepted) and cached, so later mounts build synchronously.
+ * Mount it with {@link mountAsyncChild} (threads the context for suspense).
+ */
+export function asyncComponent<P = Record<string, unknown>>(
+  loader: AsyncLoader<P>,
+  opts?: AsyncComponentOptions<P>
+): ChildFactory<P>;
+
+/**
+ * mountAsyncChild(c, anchor, asyncFactory, props) — mount an async component
+ * factory (from {@link asyncComponent}) at a text anchor. Same contract as
+ * `mountChild`, but threads the component context so the async component can
+ * register with the nearest {@link suspenseBlock}; its `unmount()` cancels any
+ * in-flight load so a late resolution writes no DOM.
+ */
+export function mountAsyncChild<P = Record<string, unknown>>(
+  c: Context,
+  anchor: Node,
+  asyncFactory: ChildFactory<P>,
+  props?: P
+): MountedChild;
+
+/** Handle returned by {@link suspenseBlock}. */
+export interface SuspenseHandle {
+  /** Whether the boundary has revealed its content (all async deps settled). */
+  isSettled(): boolean;
+  /** Tear the boundary down, cancelling any pending async children. */
+  destroy(): void;
+}
+
+/**
+ * suspenseBlock(c, anchor, contentFactory, fallbackFactory) — a boundary at a
+ * text anchor. It builds the content immediately (so async children begin
+ * loading) but shows `fallback` until every async dep registered under it
+ * resolves, then reveals the content (batched via afterFlush — a fully
+ * synchronous subtree never flashes the fallback). Nested boundaries handle
+ * their own subtree; each async child registers with its nearest boundary.
+ */
+export function suspenseBlock(
+  c: Context,
+  anchor: Node,
+  contentFactory: (c: Context) => Node | Node[],
+  fallbackFactory?: () => Node | Node[]
+): SuspenseHandle;

--- a/packages/lunas/types/index.d.ts
+++ b/packages/lunas/types/index.d.ts
@@ -81,3 +81,12 @@ export {
 export type { Store, StoreField, Unsubscribe } from "./store.js";
 
 export { createStore, useStore, derivedStore } from "./store.js";
+
+export type {
+  AsyncModule,
+  AsyncLoader,
+  AsyncComponentOptions,
+  SuspenseHandle,
+} from "./async.js";
+
+export { asyncComponent, mountAsyncChild, suspenseBlock } from "./async.js";

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -94,7 +94,7 @@ tree:
         - { id: c-emits, title: "Events / emits (child → parent)", status: todo }
         - { id: c-lifecycle, title: "Lifecycle hooks (mount/update/destroy)", status: todo }
         - { id: c-provide, title: "Provide / inject (DI)", status: todo }
-        - { id: c-async, title: "Async / lazy components", status: todo }
+        - { id: c-async, title: "Async / lazy components", status: done }
         - { id: c-transition, title: "Transitions & animations", status: todo }
         - { id: c-keepalive, title: "Keep-alive (component caching)", status: todo }
     - id: app
@@ -104,7 +104,7 @@ tree:
         - { id: a-router, title: "Router runtime (matching, history, outlet, guards)", status: done }
         - { id: a-ssr, title: "SSR + client hydration", status: deferred }
         - { id: a-css, title: "Scoped CSS (lunas_css)", status: done }
-        - { id: a-suspense, title: "Suspense / async boundaries", status: todo }
+        - { id: a-suspense, title: "Suspense / async boundaries", status: done }
         - { id: a-store, title: "Global state / stores", status: done }
     - id: tooling
       title: Tooling


### PR DESCRIPTION
## What

Adds `packages/lunas/src/async.mjs` — one module, two cooperating primitives for lazy components and async boundaries (roadmap `c-async`, `a-suspense`).

- **`asyncComponent(loader, opts)`** — wraps `() => import("./Heavy.mjs")`-style loaders into a `mountChild`-compatible child factory. Unwraps `default`-export **or** bare-factory modules, caches after the first load (subsequent mounts are synchronous), and supports Vue-style `{ loading, error, delay = 200, timeout }` semantics: `loading` shows only after `delay` ms (no flash), `error` on rejection or timeout.
- **`suspenseBlock(c, anchor, contentFactory, fallbackFactory)`** — a boundary at a text anchor. It builds the content immediately (so async children begin loading), shows `fallback` while any async dep under it is pending, and reveals content once every dep settles — batched via `afterFlush`, so a fully synchronous subtree never flashes the fallback. Nested boundaries own their own subtree.
- **`mountAsyncChild(c, anchor, factory, props)`** — the mount entry codegen uses for an async component. Same contract as `mountChild`, but threads the component context (for suspense registration + `afterFlush`) and cancels in-flight loads on `unmount()`.

## Why

Completes the async/lazy-component and suspense roadmap items, giving codegen a runtime target that treats async components identically to sync ones.

## Boundary-registration mechanism

A suspense boundary publishes itself on the component context as `c._suspense` for the duration of its content build. Async children read the *current* `c._suspense` at mount and, if present, `enter()`/`leave()` its pending counter. Nested boundaries save/restore the enclosing `c._suspense`, so an inner boundary owns exactly its own subtree. This reuses the existing context object — **no changes to `core.mjs` or `blocks.mjs`.**

**Unmount safety:** each async mount owns a live token; `unmount()` (and `suspenseBlock.destroy()`) flips it, so a loader settling afterwards writes no DOM and settles no boundary. Timers are cleared on settle/unmount.

## Tests

`packages/lunas/test/async.test.mjs` — 14 tests, all green via `node test/run-all.mjs` (11 test files pass; treeshake check clean; `types/async.d.ts` strict-typechecks): loader resolve → mount, default-export unwrap, cache (2nd mount sync), delay semantics (loading not shown before delay; fast resolve never shows loading), error on reject, timeout → error, suspense fallback → content, counter waits for BOTH children, sync subtree no-flash, no-async immediate reveal, nested boundaries independent, unmount-while-pending writes nothing, destroy-while-pending cancels children.

Also: `./async` package export, index + `index.d.ts` re-exports, README rows, output-design.md §5 block. Flips roadmap `c-async` and `a-suspense` to `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)