### PR TITLE
feat(codegen): child component mounting + @input props

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -168,6 +168,10 @@ export function box(c, i, v) {               // reassign-only var at reactive in
   return { get v() { return v; }, set v(x) { if (x !== v) { v = x; markVar(c, i); } } };
 }
 export function deepBox(c, i, v) { /* Proxy wrapping arrays/objects; markVar(c,i) on mutation */ }
+export function prop(c, name, i, raw, def, deep) { /* adopt an @input prop as a reactive box at index
+                                                      i; seed from raw (getter or value) or def;
+                                                      register under c._props[name] for the parent's
+                                                      mountChild.setProp bridge (§6) */ }
 
 // --- derived values, watchers, batching (compile-time deps, no auto-tracking) ---
 export function computed(c, i, deps, fn) { /* lazy derived value at index i reading `deps`;
@@ -197,7 +201,10 @@ export const on = (el, ev, fn) => el.addEventListener(ev, fn);
 // --- control flow (anchors are runtime text nodes) ---
 export function ifBlock(c, before, deps, cond, make) { /* insert/remove make() at a text anchor */ }
 export function forBlock(c, into, deps, items, make) { /* keyed list at a text anchor */ }
-export function mountChild(c, before, Child, props) { /* Child(props) inserted at a text anchor */ }
+export function mountChild(c, before, Child, props) { /* Child(props) inserted at a text anchor;
+                                                          returns { root, ctx, setProp(name,value),
+                                                          unmount() } — setProp drives a reactive
+                                                          prop box in the child (§6) */ }
 
 // --- module-level stores (state outside any component; §4's "shared" concept
 //     generalized to N components importing the same module, instead of one
@@ -254,8 +261,54 @@ No signal-tracking stack, no VDOM, no per-node effect objects.
 | static `class="a ${x}"` | text nodes / attr set; interpolations become `bind`s |
 | `:if` / `:elseif` / `:else` | one `ifBlock` chain per cascade, anchored; branch built by its own `innerHTML` when shown |
 | `:for="n of items"` | `forBlock`; **initial render = one `innerHTML` of the concatenated items**, updates = keyed diff |
-| `<Child :p="e"/>` | `mountChild` at an anchor; `p` passed as a getter so the child can `bind` to it |
-| `@input name:type = v` | `props.name ?? v` at the top of `setup` |
+| `<Child :p="e"/>` | `mountChild(c, anchor, Child, { p: () => e, static: "x" })` at an anchor; reactive props are getters, static props are values (see below) |
+| `@input name:type = v` | `const name = prop(c, "name", i, props.name, v)` at the top of `setup` — every prop is a reactive box (see below) |
+
+### Child components & props (concretized)
+
+`@input` props are **reactive**: a parent can change a prop after init, so a
+child's template reads of a prop must re-run. The generator numbers each prop as
+a reactive variable (after the script's reactive vars) and adopts it with the
+`prop` helper:
+
+```js
+const name = prop(c, "name", i, props.name, defaultExpr /*, deep */);
+```
+
+`prop` seeds the box from `props.name` (calling it if the parent passed a getter,
+else using the value), or from `defaultExpr` when the prop is omitted. It
+registers the box under its name in `c._props` so a parent can drive it. The
+optional `deep` flag selects a `deepBox` when the child deeply mutates the prop
+locally.
+
+The **parent** mounts a child and drives its reactive props:
+
+```js
+const a0 = anchorBefore(hostNode.childNodes[k]);
+const ch0 = mountChild(c, a0, Child, { p: () => e, static: "x" });
+bind(c, [deps of e], () => ch0.setProp("p", e));   // one per reactive prop
+```
+
+- **Reactive props** (`:p="e"`, or a static value with an interpolation) are
+  passed as **getters** in the initial object (so the child seeds correctly at
+  construction) *and* driven by a parent-side `bind` that calls
+  `ch0.setProp("p", e)` on the expression's compile-time deps. The bind's initial
+  run re-seeds the same value (the box no-ops on an equal write). Inside a `:for`
+  item the driving bind is item-coupled (`bind(c, [], …)`), so `runScope`
+  refreshes it when the item's data changes.
+- **Static props** (`static="x"`, valueless `flag` → `true`) are plain values in
+  the initial object; no driving bind is emitted.
+- `mountChild` returns `{ root, ctx, setProp(name, value), unmount() }`.
+  `setProp` writes `child._props[name].v`, which marks the **child** dirty and
+  flushes the child. The two contexts are independent: a child event marks only
+  the child, a parent prop push marks only the child — parent and child never
+  cross-contaminate reactive state.
+
+Child modules are imported from the `@use` table: `import Child from "path"`
+with the path written verbatim (extension handling is the module resolver's
+job — the compiler does not rewrite it). Only components actually used in the
+template are imported; a colliding tag name (e.g. a component literally named
+`bind`) is imported under a `$`-suffixed alias.
 
 ---
 

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -23,8 +23,8 @@
 //! refresh them when the item's data cell changes.
 
 use lunas_parser::{
-    Diagnostic, ForBlock, IfChain, StaticValue, Template, TemplateAttr, TemplateElement,
-    TemplateNode, TemplateText, TextRange, TextSegment,
+    ComponentUse, Diagnostic, ForBlock, IfChain, StaticValue, Template, TemplateAttr,
+    TemplateElement, TemplateNode, TemplateText, TextRange, TextSegment,
 };
 use lunas_script::{module_binding_references, parse_for, ForKind};
 
@@ -52,6 +52,7 @@ const ALL_HELPERS: &[&str] = &[
     "bind",
     "box",
     "deepBox",
+    "prop",
     "anchorBefore",
     "anchorBeforeSplit",
     "anchorAppend",
@@ -59,6 +60,7 @@ const ALL_HELPERS: &[&str] = &[
     "ifChain",
     "forBlock",
     "fromHTML",
+    "mountChild",
     // `component` is intentionally excluded: it is only referenced at module
     // scope (the default export), where user bindings — emitted inside the
     // setup closure — cannot shadow it.
@@ -103,6 +105,15 @@ fn emit_module(component: &ResolvedComponent, diags: &mut Vec<Diagnostic>) -> Op
     let mut out = String::new();
     out.push_str(&e.import_line());
     out.push('\n');
+    // Child-component imports from the `@use` table (path as written). Emitted
+    // in tag-name order after the runtime import, before the module body.
+    for (local, path) in e.child_imports.values() {
+        out.push_str("import ");
+        out.push_str(local);
+        out.push_str(" from ");
+        push_js_string(&mut out, path);
+        out.push_str(";\n");
+    }
     out.push('\n');
     out.push_str("const HTML = ");
     push_js_string(&mut out, &skeleton.html);
@@ -158,6 +169,10 @@ struct Emitter<'a> {
     /// Hoisted static HTML strings for control-flow fragments: (const name,
     /// html), emitted at module scope in creation order.
     hoisted: Vec<(String, String)>,
+    /// Child-component imports referenced in the template: component tag name
+    /// (as written) -> (local import identifier, module path as written in
+    /// `@use`). Emitted as `import Local from "path";` at module scope.
+    child_imports: std::collections::BTreeMap<String, (String, String)>,
     /// Text used for deep-mutation detection: the script plus one synthetic
     /// assignment per two-way member/index lvalue (`::value="o.k"` deep-writes
     /// `o`, so `o` needs a `deepBox` even if the script never mutates it).
@@ -168,6 +183,7 @@ struct Emitter<'a> {
     n_root: usize,   // r{n}
     n_data: usize,   // d{n}
     n_html: usize,   // HTML_{n}
+    n_child: usize,  // c{n} (child-component instance handle)
 }
 
 impl<'a> Emitter<'a> {
@@ -208,11 +224,42 @@ impl<'a> Emitter<'a> {
             }
         }
 
+        // Child-component imports: only for `@use` entries whose tag is actually
+        // used in the template (avoids dead imports). Each gets a collision-proof
+        // local identifier — its own name unless that collides with a helper
+        // import, a user binding, or a generated local.
+        let used_component_tags = component
+            .template
+            .as_ref()
+            .map(component_tags_in_template)
+            .unwrap_or_default();
+        let mut import_reserved: std::collections::HashSet<String> = reserved.clone();
+        for a in aliases.values() {
+            import_reserved.insert(a.clone());
+        }
+        for &h in ALL_HELPERS {
+            import_reserved.insert(h.to_string());
+        }
+        import_reserved.insert("component".to_string());
+        let mut child_imports = std::collections::BTreeMap::new();
+        for u in &component.imports {
+            if !used_component_tags.contains(&u.component_name) {
+                continue;
+            }
+            if child_imports.contains_key(&u.component_name) {
+                continue;
+            }
+            let local = child_local_name(&u.component_name, &import_reserved);
+            import_reserved.insert(local.clone());
+            child_imports.insert(u.component_name.clone(), (local, u.path.clone()));
+        }
+
         Emitter {
             component,
             used: std::collections::BTreeSet::new(),
             aliases,
             hoisted: Vec::new(),
+            child_imports,
             deep_hint,
             n_ref: 0,
             n_text: 0,
@@ -220,6 +267,7 @@ impl<'a> Emitter<'a> {
             n_root: 0,
             n_data: 0,
             n_html: 0,
+            n_child: 0,
         }
     }
 
@@ -279,6 +327,11 @@ impl<'a> Emitter<'a> {
         self.n_data += 1;
         format!("d{n}")
     }
+    fn alloc_child(&mut self) -> String {
+        let n = self.n_child;
+        self.n_child += 1;
+        format!("ch{n}")
+    }
     fn hoist_html(&mut self, html: String) -> String {
         self.n_html += 1;
         let name = format!("HTML_{}", self.n_html);
@@ -309,19 +362,52 @@ impl<'a> Emitter<'a> {
 
     fn emit_props(&mut self, b: &mut String) {
         for p in &self.component.props {
-            // `@input name = default` -> `let name = props.name ?? default;`
-            // Reactive props are still boxed below; the plain `let` seeds them.
-            b.push_str("  let ");
+            // Every `@input` prop is reactive (a parent can change it), so it is
+            // adopted as a reactive box at its index via the `prop` helper and
+            // referenced through `.v` everywhere. The parent seeds it (a getter
+            // for a reactive prop, a plain value for a static prop) and drives
+            // later changes via the mountChild handle's setProp — which writes
+            // this box, re-running the child's own binds (output-design.md §6).
+            let index = self
+                .component
+                .reactive_index(&p.name)
+                .expect("every @input prop is numbered as a reactive var");
+            let deep = is_deeply_mutated(&self.deep_hint, &p.name);
+            self.use_helper("prop");
+            let prop_fn = self.helper("prop").to_string();
+            let name = self.rewrite_binding_name(&p.name);
+            b.push_str("  const ");
+            b.push_str(&name);
+            b.push_str(" = ");
+            b.push_str(&prop_fn);
+            b.push_str("(c, ");
+            push_js_string(b, &p.name);
+            b.push_str(", ");
+            b.push_str(&index.to_string());
+            b.push_str(", props.");
             b.push_str(&p.name);
-            b.push_str(" = props.");
-            b.push_str(&p.name);
-            if let Some(d) = &p.default_value {
-                b.push_str(" ?? (");
-                b.push_str(d.trim());
-                b.push(')');
+            b.push_str(", ");
+            match &p.default_value {
+                Some(d) => {
+                    b.push('(');
+                    b.push_str(&rewrite_expr(d.trim(), &self.component.reactive_vars, &[]));
+                    b.push(')');
+                }
+                None => b.push_str("undefined"),
             }
-            b.push_str(";\n");
+            if deep {
+                b.push_str(", true");
+            }
+            b.push_str(");\n");
         }
+    }
+
+    /// The local name a reactive binding is emitted under. A prop whose name
+    /// collides with a runtime helper would, when boxed as `const name = …`,
+    /// need no alias (only *helper* references are aliased); the binding keeps
+    /// its own name. This exists as a single point in case that changes.
+    fn rewrite_binding_name(&self, name: &str) -> String {
+        name.to_string()
     }
 
     // --- boxes ------------------------------------------------------------
@@ -347,8 +433,24 @@ impl<'a> Emitter<'a> {
         let body = dedent(&rewritten);
         let body = body.trim();
         if !body.is_empty() {
-            for (kind, _) in reactive_box_kinds(&self.deep_hint, &self.component.reactive_vars) {
-                self.use_helper(kind);
+            // Import a box helper only for reactive vars actually DECLARED in the
+            // script (props are boxed by the `prop` helper, not here, so they
+            // must not pull in an unused `box`/`deepBox` import).
+            let declared: std::collections::HashSet<String> =
+                lunas_script::declared_bindings(script_text)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect();
+            for (kind, index) in reactive_box_kinds(&self.deep_hint, &self.component.reactive_vars)
+            {
+                if self
+                    .component
+                    .reactive_vars
+                    .iter()
+                    .any(|v| v.index == index && declared.contains(&v.name))
+                {
+                    self.use_helper(kind);
+                }
             }
             for line in body.lines() {
                 b.push_str("  ");
@@ -423,9 +525,8 @@ impl<'a> Emitter<'a> {
                 SlotContent::Text(t) => self.emit_text_slot(b, t, &slot.pos, frag),
                 SlotContent::If(chain) => self.emit_if_slot(b, chain, &slot.pos, frag, diags),
                 SlotContent::For(block) => self.emit_for_slot(b, block, &slot.pos, frag, diags),
-                SlotContent::Component(_) => {
-                    push_indent(b, frag.indent);
-                    b.push_str("/* TODO(components): child component not yet emitted */\n");
+                SlotContent::Component(comp) => {
+                    self.emit_component_slot(b, comp, &slot.pos, frag, diags)
                 }
             }
         }
@@ -513,6 +614,200 @@ impl<'a> Emitter<'a> {
                 b.push_str(");\n");
             }
         }
+    }
+
+    // --- child components -------------------------------------------------
+
+    /// Emits a child-component mount at a text anchor (output-design.md §6):
+    /// an anchor, `mountChild(c, anchor, Child, initialProps)`, and one parent
+    /// `bind` per reactive prop that drives the child via `setProp`. Reactive
+    /// props seed the child through getters in the initial object and stay live
+    /// through the binds; static props pass as plain values. The two contexts
+    /// are independent — pushing a prop marks the child dirty, never the parent.
+    fn emit_component_slot(
+        &mut self,
+        b: &mut String,
+        comp: &ComponentUse,
+        pos: &InsertPos,
+        frag: &Frag,
+        diags: &mut Vec<Diagnostic>,
+    ) {
+        // Resolve the child factory local. An unknown tag (not in the `@use`
+        // table) is voided: nothing to mount.
+        let Some((local, _)) = self.child_imports.get(&comp.name).cloned() else {
+            self.void_block(
+                b,
+                frag,
+                comp.open_tag_range,
+                "child component tag has no matching `@use` import",
+                diags,
+            );
+            return;
+        };
+
+        // Classify each prop into an initial-object entry and (for reactive
+        // props) a driving bind. `reactive` collects (prop_name, expr, deps).
+        struct ReactiveProp {
+            name: String,
+            expr: String,
+            deps: Vec<u32>,
+            /// Reads an enclosing `:for` loop binding: no reactive deps of its
+            /// own, but the item's patch path (`runScope`) must re-run it.
+            coupled: bool,
+        }
+        // Initial props object members: `name: <value-or-getter>`.
+        let mut members: Vec<String> = Vec::new();
+        let mut reactive: Vec<ReactiveProp> = Vec::new();
+
+        for attr in &comp.props {
+            match attr {
+                TemplateAttr::Bound { name, expr, .. } => {
+                    let deps =
+                        self.filter_deps(self.bound_attr_deps(name, &expr.text), frag.shadowed);
+                    let value =
+                        rewrite_expr(&expr.text, &self.component.reactive_vars, frag.shadowed);
+                    // Pass a getter so the child seeds from the current value;
+                    // a bind keeps it live if it has deps (or is item-coupled).
+                    members.push(format!("{}: () => ({})", prop_key(name), value));
+                    let coupled = reads_any(&expr.text, frag.shadowed);
+                    if !deps.is_empty() || coupled {
+                        reactive.push(ReactiveProp {
+                            name: name.clone(),
+                            expr: value,
+                            deps,
+                            coupled,
+                        });
+                    }
+                }
+                TemplateAttr::Static {
+                    name,
+                    value: Some(v),
+                    ..
+                } if has_interpolation(v) => {
+                    // `prop="a ${x}"` — an interpolated string prop.
+                    let (lit, deps, coupled) = self.attr_text_value(name, v, frag);
+                    members.push(format!("{}: () => ({})", prop_key(name), lit));
+                    if !deps.is_empty() || coupled {
+                        reactive.push(ReactiveProp {
+                            name: name.clone(),
+                            expr: lit,
+                            deps,
+                            coupled,
+                        });
+                    }
+                }
+                TemplateAttr::Static { name, value, .. } => {
+                    let val = match value {
+                        Some(v) => {
+                            let mut s = String::from("`");
+                            for seg in &v.segments {
+                                if let TextSegment::Literal { text, .. } = seg {
+                                    push_template_literal_chunk(&mut s, text);
+                                }
+                            }
+                            s.push('`');
+                            s
+                        }
+                        // Valueless attr `<Child flag/>` -> boolean true.
+                        None => "true".to_string(),
+                    };
+                    members.push(format!("{}: {}", prop_key(name), val));
+                }
+                TemplateAttr::TwoWay { name, .. } => {
+                    self.void_block(
+                        b,
+                        frag,
+                        comp.open_tag_range,
+                        &format!("two-way binding `::{name}` on a component is not supported yet"),
+                        diags,
+                    );
+                }
+                TemplateAttr::Event { event, .. } => {
+                    self.void_block(
+                        b,
+                        frag,
+                        comp.open_tag_range,
+                        &format!("component event binding `@{event}` is not supported yet"),
+                        diags,
+                    );
+                }
+            }
+        }
+
+        let anchor = self.alloc_anchor();
+        self.emit_anchor(b, &anchor, pos, frag);
+
+        let handle = self.alloc_child();
+        self.use_helper("mountChild");
+        push_indent(b, frag.indent);
+        b.push_str("const ");
+        b.push_str(&handle);
+        b.push_str(" = ");
+        b.push_str(self.helper("mountChild"));
+        b.push_str("(c, ");
+        b.push_str(&anchor);
+        b.push_str(", ");
+        b.push_str(&local);
+        b.push_str(", {");
+        for (i, m) in members.iter().enumerate() {
+            if i > 0 {
+                b.push(',');
+            }
+            b.push(' ');
+            b.push_str(m);
+        }
+        if !members.is_empty() {
+            b.push(' ');
+        }
+        b.push_str("});\n");
+
+        // Drive each reactive prop from the parent. The bind's initial run seeds
+        // the same value (a box no-ops on equal), later parent changes flow in.
+        for rp in &reactive {
+            let stmt = format!("{handle}.setProp({}, {});", js_string(&rp.name), rp.expr);
+            self.emit_update(b, frag, &rp.deps, rp.coupled, &stmt);
+        }
+    }
+
+    /// Builds the template-literal value, deps, and item-coupling flag for an
+    /// interpolated static attribute/prop value (`a ${x} b`). Shared by element
+    /// attribute-text wiring and component string-prop wiring.
+    fn attr_text_value(
+        &self,
+        attr: &str,
+        value: &StaticValue,
+        frag: &Frag,
+    ) -> (String, Vec<u32>, bool) {
+        let mut deps = Vec::new();
+        let mut coupled = false;
+        let mut lit = String::from("`");
+        for seg in &value.segments {
+            match seg {
+                TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut lit, text),
+                TextSegment::Interpolation(interp) => {
+                    lit.push_str("${");
+                    lit.push_str(&rewrite_expr(
+                        &interp.expr,
+                        &self.component.reactive_vars,
+                        frag.shadowed,
+                    ));
+                    lit.push('}');
+                    coupled = coupled || reads_any(&interp.expr, frag.shadowed);
+                    if let Some(part) = self.find_dynamic(
+                        DynamicKind::AttributeText(attr.to_string()),
+                        &interp.expr,
+                        interp.expr_range,
+                    ) {
+                        deps.extend(part.deps.indices().iter().copied());
+                    }
+                }
+            }
+        }
+        lit.push('`');
+        deps.sort_unstable();
+        deps.dedup();
+        let deps = self.filter_deps(deps, frag.shadowed);
+        (lit, deps, coupled)
     }
 
     /// The combined dependency indices of every interpolation in a text run.
@@ -985,36 +1280,7 @@ impl<'a> Emitter<'a> {
         value: &StaticValue,
         frag: &Frag,
     ) {
-        let mut deps = Vec::new();
-        let mut coupled = false;
-        let mut lit = String::from("`");
-        for seg in &value.segments {
-            match seg {
-                TextSegment::Literal { text, .. } => push_template_literal_chunk(&mut lit, text),
-                TextSegment::Interpolation(interp) => {
-                    lit.push_str("${");
-                    lit.push_str(&rewrite_expr(
-                        &interp.expr,
-                        &self.component.reactive_vars,
-                        frag.shadowed,
-                    ));
-                    lit.push('}');
-                    coupled = coupled || reads_any(&interp.expr, frag.shadowed);
-                    if let Some(part) = self.find_dynamic(
-                        DynamicKind::AttributeText(attr.to_string()),
-                        &interp.expr,
-                        interp.expr_range,
-                    ) {
-                        deps.extend(part.deps.indices().iter().copied());
-                    }
-                }
-            }
-        }
-        lit.push('`');
-        deps.sort_unstable();
-        deps.dedup();
-        let deps = self.filter_deps(deps, frag.shadowed);
-
+        let (lit, deps, coupled) = self.attr_text_value(attr, value, frag);
         let set = attr_set_statement(node, attr, &lit);
         self.emit_update(b, frag, &deps, coupled, &set);
     }
@@ -1122,6 +1388,31 @@ impl<'a> Emitter<'a> {
 }
 
 // --- template helpers ------------------------------------------------------
+
+/// The set of component tag names actually used anywhere in the template
+/// (branch/item bodies included). Drives which `@use` imports are emitted.
+fn component_tags_in_template(template: &Template) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    template.visit(&mut |node: &TemplateNode| {
+        if let TemplateNode::Component(c) = node {
+            out.insert(c.name.clone());
+        }
+    });
+    out
+}
+
+/// A collision-proof local import identifier for a child component. Its own tag
+/// name when free; otherwise `<Name>$`, adding underscores until unused.
+fn child_local_name(tag: &str, reserved: &std::collections::HashSet<String>) -> String {
+    if !reserved.contains(tag) && !is_generated_name(tag) {
+        return tag.to_string();
+    }
+    let mut name = format!("{tag}$");
+    while reserved.contains(&name) {
+        name.push('_');
+    }
+    name
+}
 
 /// Every two-way lvalue expression in the template (branch/item bodies
 /// included).
@@ -1584,6 +1875,27 @@ fn push_dep_list(b: &mut String, deps: &[u32]) {
         b.push_str(&d.to_string());
     }
     b.push(']');
+}
+
+/// A double-quoted JS string literal for `s`.
+fn js_string(s: &str) -> String {
+    let mut out = String::new();
+    push_js_string(&mut out, s);
+    out
+}
+
+/// A JS object-literal key for a prop name: the bare name if it is a valid
+/// identifier, else a quoted string key (an attribute name like `data-x` is not
+/// a valid bare key).
+fn prop_key(name: &str) -> String {
+    let mut chars = name.chars();
+    let ok = matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$');
+    if ok {
+        name.to_string()
+    } else {
+        js_string(name)
+    }
 }
 
 /// Emits `s` as a double-quoted JS string literal.

--- a/crates/lunas_compiler/src/lib.rs
+++ b/crates/lunas_compiler/src/lib.rs
@@ -42,7 +42,7 @@ pub use model::{Deps, DynamicKind, DynamicPart, ReactiveVar, ResolvedComponent, 
 pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
     let (file, mut diags) = parse(source);
 
-    let props = file
+    let props: Vec<lunas_parser::PropInput> = file
         .directives
         .iter()
         .filter_map(|d| match d {
@@ -67,10 +67,28 @@ pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
         .map(|h| two_way_mutation_roots(&h.template))
         .unwrap_or_default();
 
-    let reactive_vars = match &file.script {
+    let mut reactive_vars = match &file.script {
         Some(script) => resolve_reactive_vars(script, &template_mutated, &mut diags),
         None => Vec::new(),
     };
+
+    // `@input` props are reactive too: a parent can change a prop after init,
+    // so the child's template reads of it must re-run. Each prop that is not
+    // already a reactive script binding gets its own index appended after the
+    // script vars (output-design.md §6). Numbering stays stable: script vars
+    // first (in declaration order), then props (in `@input` order).
+    let mut next_index = reactive_vars.len() as u32;
+    for p in &props {
+        if reactive_vars.iter().any(|v| v.name == p.name) {
+            continue;
+        }
+        reactive_vars.push(ReactiveVar {
+            name: p.name.clone(),
+            index: next_index,
+            decl_range: Some(p.range),
+        });
+        next_index += 1;
+    }
 
     // Annotate every dynamic template expression with the reactive variables it
     // reads, and every handler with what it writes.

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -114,10 +114,29 @@ fn event_listener() {
 
 #[test]
 fn props_seeded_from_input() {
+    // Every `@input` prop is reactive: adopted as a `prop` box at its index
+    // (props numbered after script vars) so the child's template reads react
+    // when a parent pushes a new value. The default seeds it when the parent
+    // omits the prop.
     let js = emit(
         "@input start:number = 0\nhtml:\n    <p>${start}</p>\nscript:\n    let count = start\n    function f(){ count = 1 }\n",
     );
-    assert!(js.contains("let start = props.start ?? (0);"), "{js}");
+    // `count` is reactive var 0 (script, declared first); `start` is 1 (prop).
+    assert!(
+        js.contains("const start = prop(c, \"start\", 1, props.start, (0));"),
+        "prop adopted as a reactive box with its default: {js}"
+    );
+    // The template read of the prop is now a reactive bind on the prop index.
+    assert!(
+        js.contains("bind(c, [1], () => { t0.data = `${start.v}`; });"),
+        "prop read is reactive: {js}"
+    );
+    // Script that reads the prop sees it through the box.
+    assert!(
+        js.contains("const count = box(c, 0, start.v)"),
+        "script read of the prop rewritten through the box: {js}"
+    );
+    assert!(js.contains(", prop }"), "prop helper imported: {js}");
 }
 
 #[test]
@@ -342,6 +361,157 @@ fn box_helper_collision_is_aliased() {
     );
 }
 
+// --- child components -----------------------------------------------------
+
+#[test]
+fn simple_child_mounts_at_anchor() {
+    // A childless static child: import from the `@use` table, anchor, mount.
+    let js = emit("@use Child from \"./Child.lunas\"\nhtml:\n    <div><Child/></div>\n");
+    assert!(
+        js.contains("import Child from \"./Child.lunas\";"),
+        "child module imported from @use, path as written: {js}"
+    );
+    assert!(
+        js.contains("const a0 = anchorAppend(c.root.childNodes[0]);"),
+        "anchor created inside the host element: {js}"
+    );
+    assert!(
+        js.contains("const ch0 = mountChild(c, a0, Child, {});"),
+        "mounted with an empty props object: {js}"
+    );
+}
+
+#[test]
+fn child_reactive_and_static_props() {
+    // Reactive prop -> getter seed + driving bind on its deps; static prop ->
+    // plain value in the initial object (no bind).
+    let js = emit(
+        "@use Card from \"./Card.lunas\"\nhtml:\n    <div><Card :count=\"n\" title=\"hi\"/></div>\nscript:\n    let n = 0\n    function inc(){ n++ }\n",
+    );
+    assert!(js.contains("import Card from \"./Card.lunas\";"), "{js}");
+    assert!(
+        js.contains("mountChild(c, a0, Card, { count: () => (n.v), title: `hi` });"),
+        "reactive prop is a getter, static prop is a value: {js}"
+    );
+    assert!(
+        js.contains("bind(c, [0], () => { ch0.setProp(\"count\", n.v); });"),
+        "parent drives the reactive prop through setProp on its deps: {js}"
+    );
+    // A static-only prop must NOT get a driving bind.
+    assert!(
+        !js.contains("setProp(\"title\""),
+        "static prop is not driven: {js}"
+    );
+}
+
+#[test]
+fn child_boolean_and_interpolated_props() {
+    // Valueless prop -> boolean true; interpolated string prop -> reactive
+    // template-literal getter + driving bind.
+    let js = emit(
+        "@use B from \"./B.lunas\"\nhtml:\n    <div><B flag greeting=\"hi ${name}\"/></div>\nscript:\n    let name = \"x\"\n    function f(){ name = \"y\" }\n",
+    );
+    assert!(js.contains("flag: true"), "valueless prop -> true: {js}");
+    assert!(
+        js.contains("greeting: () => (`hi ${name.v}`)"),
+        "interpolated string prop seeds via a template-literal getter: {js}"
+    );
+    assert!(
+        js.contains("ch0.setProp(\"greeting\", `hi ${name.v}`);"),
+        "interpolated prop driven on its deps: {js}"
+    );
+}
+
+#[test]
+fn child_in_if_branch() {
+    // A child inside an `:if` branch is wired inside the branch fragment,
+    // recursively; the import is still emitted.
+    let js = emit(
+        "@use Panel from \"./Panel.lunas\"\nhtml:\n    <div :if=\"show\"><Panel :v=\"n\"/></div>\nscript:\n    let show = true\n    let n = 0\n    function f(){ show = false; n++ }\n",
+    );
+    assert!(js.contains("import Panel from \"./Panel.lunas\";"), "{js}");
+    assert!(
+        js.contains("ifBlock(c, a0, [0], () => (show.v), () => {"),
+        "outer :if: {js}"
+    );
+    assert!(
+        js.contains("mountChild(c, a1, Panel, { v: () => (n.v) });"),
+        "child mounted inside the branch fragment: {js}"
+    );
+    // `n` is reactive var 1 (after `show`); the driving bind uses that index.
+    assert!(
+        js.contains("bind(c, [1], () => { ch0.setProp(\"v\", n.v); });"),
+        "driving bind uses the prop-source dep index: {js}"
+    );
+}
+
+#[test]
+fn child_in_for_item() {
+    // A child inside a `:for` item: the loop binding shadows reactive vars, so
+    // the prop getter reads the item binding directly (no `.v`), and the
+    // driving bind is item-coupled (empty deps, refreshed by runScope).
+    let js = emit(
+        "@use Row from \"./Row.lunas\"\nhtml:\n    <ul><li :for=\"item of items\" :key=\"item.id\"><Row :data=\"item\"/></li></ul>\nscript:\n    let items = []\n    function add(){ items.push({id:1}) }\n",
+    );
+    assert!(js.contains("import Row from \"./Row.lunas\";"), "{js}");
+    assert!(
+        js.contains("mountChild(c, a1, Row, { data: () => (item) });"),
+        "prop getter reads the loop binding (not rewritten to .v): {js}"
+    );
+    assert!(
+        js.contains("bind(c, [], () => { ch0.setProp(\"data\", item); });"),
+        "item-coupled driving bind (empty deps, item scope refreshes it): {js}"
+    );
+}
+
+#[test]
+fn multiple_children_and_dedup_imports() {
+    // Two uses of the same child + one of another: each import appears once,
+    // one handle per instance.
+    let js = emit(
+        "@use A from \"./A.lunas\"\n@use Bee from \"./Bee.lunas\"\nhtml:\n    <div><A/><Bee/><A/></div>\n",
+    );
+    assert_eq!(
+        js.matches("import A from \"./A.lunas\";").count(),
+        1,
+        "duplicate child imported once: {js}"
+    );
+    assert!(js.contains("import Bee from \"./Bee.lunas\";"), "{js}");
+    assert!(js.contains("const ch0 = mountChild(c, a0, A, {});"), "{js}");
+    assert!(
+        js.contains("const ch1 = mountChild(c, a1, Bee, {});"),
+        "{js}"
+    );
+    assert!(js.contains("const ch2 = mountChild(c, a2, A, {});"), "{js}");
+}
+
+#[test]
+fn unused_use_import_is_not_emitted() {
+    // A declared-but-unused `@use` produces no dead import.
+    let js = emit("@use Unused from \"./Unused.lunas\"\nhtml:\n    <p>hi</p>\n");
+    assert!(
+        !js.contains("import Unused"),
+        "unused @use is not imported: {js}"
+    );
+}
+
+#[test]
+fn child_import_name_collision_is_aliased() {
+    // A component tag that collides with a runtime helper name is imported
+    // under an alias, and the mount references the alias.
+    let js = emit(
+        "@use bind from \"./bind.lunas\"\nhtml:\n    <div><bind :v=\"n\"/></div>\nscript:\n    let n = 0\n    function f(){ n++ }\n",
+    );
+    assert!(
+        js.contains("import bind$ from \"./bind.lunas\";"),
+        "colliding child import aliased: {js}"
+    );
+    assert!(
+        js.contains("mountChild(c, a0, bind$, {"),
+        "mount references the aliased local: {js}"
+    );
+}
+
 #[test]
 fn no_template_emits_nothing() {
     let (js, diags) = compile("script:\n    let x = 0\n");
@@ -365,6 +535,10 @@ fn malformed_inputs_do_not_panic() {
         "html:\n    <div :x=\"{ a }\"></div>\nscript:\n    let a = 0\n    function f(){ a = 1 }",
         "html:\n    <p>a ${x} b ${y} c</p>\nscript:\n    let x=0\n    let y=0\n    function f(){ x=1; y=2 }",
         "html:\n    <input ::value=\"o.k\">\nscript:\n    let o = {}\n    function f(){ o.k = 1 }",
+        // Child components with adversarial / unsupported props.
+        "@use X from \"./X.lunas\"\nhtml:\n    <X :p=\"a.(\" ::two=\"b\" @go=\"h()\" q=\"${z}\"/>\nscript:\n    let a=0\n    let b=0\n    let z=0",
+        "@use X from \"./X.lunas\"\nhtml:\n    <X/>",
+        "html:\n    <Undeclared :p=\"x\"/>\nscript:\n    let x = 0",
     ];
     for case in cases {
         let (_js, _diags) = compile(case);
@@ -380,10 +554,14 @@ fn arbitrary_control_flow_nesting_never_panics() {
     // depths. Leaves include a two-way bind and an interpolation so wiring runs
     // inside every level.
     fn leaf(depth: usize) -> String {
-        match depth % 3 {
+        // Include a child component with a reactive prop, a static prop, and a
+        // valueless prop at some leaves so component wiring runs at arbitrary
+        // depth inside :if/:for.
+        match depth % 4 {
             0 => "<span>${x}</span>".to_string(),
             1 => "<input ::value=\"x\">".to_string(),
-            _ => "<b :if=\"x\">${x}</b>".to_string(),
+            2 => "<Kid :v=\"x\" tag=\"t\" flag/>".to_string(),
+            _ => "<b :if=\"x\">${x}<Kid :v=\"x\"/></b>".to_string(),
         }
     }
     fn wrap_if(inner: &str) -> String {
@@ -404,7 +582,7 @@ fn arbitrary_control_flow_nesting_never_panics() {
                 wrap_for(&body)
             };
         }
-        let source = format!("html:\n    {body}{script}");
+        let source = format!("@use Kid from \"./Kid.lunas\"\nhtml:\n    {body}{script}");
         let (js, diags) = compile(&source);
         assert!(
             !diags.iter().any(|d| d.is_error()),

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -77,6 +77,70 @@ fn run_component(name: &str, source: &str, driver_body: &str) -> String {
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
+/// Compiles a parent + child pair (two `.lunas` sources) into two ES modules,
+/// wires the parent's `@use` import (`child_use_path`, the path as written in
+/// the parent's `@use`) to the generated child module, and runs the driver.
+/// Both modules' `from "lunas"` imports are rewritten to the runtime index so
+/// node resolves them without a package install.
+fn run_parent_child(
+    name: &str,
+    parent_src: &str,
+    child_src: &str,
+    child_use_path: &str,
+    driver_body: &str,
+) -> String {
+    let root = repo_root();
+    let test_dir = root.join("packages/lunas");
+
+    let compile = |src: &str| {
+        let (js, diags) = lunas_compiler::compile(src);
+        assert!(
+            !diags.iter().any(|d| d.is_error()),
+            "compile diagnostics: {diags:?}"
+        );
+        js.expect("module emitted")
+            .replace("from \"lunas\";", "from \"./src/index.mjs\";")
+    };
+
+    let child_file = format!("__exec_{name}_child.gen.mjs");
+    let parent_js = compile(parent_src).replace(
+        &format!("from \"{child_use_path}\";"),
+        &format!("from \"./{child_file}\";"),
+    );
+    let child_js = compile(child_src);
+
+    let parent_path = test_dir.join(format!("__exec_{name}.gen.mjs"));
+    let child_path = test_dir.join(&child_file);
+    std::fs::write(&parent_path, &parent_js).unwrap();
+    std::fs::write(&child_path, &child_js).unwrap();
+
+    let driver = format!(
+        "import {{ installDom }} from \"./test/dom-shim.mjs\";\n\
+         import factory from \"./__exec_{name}.gen.mjs\";\n\
+         const tick = () => new Promise((r) => setTimeout(r, 0));\n\
+         installDom();\n\
+         {driver_body}\n"
+    );
+    let drv_path = test_dir.join(format!("__exec_{name}.drv.mjs"));
+    std::fs::write(&drv_path, driver).unwrap();
+
+    let out = Command::new(NODE)
+        .arg(&drv_path)
+        .current_dir(&test_dir)
+        .output()
+        .expect("spawn node");
+
+    let _ = std::fs::remove_file(&parent_path);
+    let _ = std::fs::remove_file(&child_path);
+    let _ = std::fs::remove_file(&drv_path);
+
+    if !out.status.success() {
+        std::io::stderr().write_all(&out.stderr).unwrap();
+        panic!("node exited with failure for {name}");
+    }
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
 #[test]
 fn counter_renders_and_reacts() {
     if !node_available() {
@@ -280,5 +344,140 @@ fn for_initial_push_splice_and_reorder() {
     assert!(
         out.contains("IDENTITY:true"),
         "surviving key keeps its DOM node across a reorder: {out}"
+    );
+}
+
+// --- child components -----------------------------------------------------
+
+#[test]
+fn child_renders_and_receives_reactive_props() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Parent holds `n`, passes it as a reactive prop to Child, which renders it
+    // as text. A parent event changes `n`; the child's own text must update
+    // (parent -> child reactivity end to end). A child event changes only the
+    // child's local state, never the parent's `n`.
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div><button @click=\"inc()\">p</button><Child :count=\"n\"/></div>\n\
+        script:\n\
+        \x20   let n = 1\n\
+        \x20   function inc(){ n++ }\n";
+    let child = "@input count:number = 0\n\
+        html:\n\
+        \x20   <section><button @click=\"bump()\">c</button><span>${count}+${local}</span></section>\n\
+        script:\n\
+        \x20   let local = 0\n\
+        \x20   function bump(){ local++ }\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const pBtn = div.childNodes[0];\n\
+        const childRoot = div.childNodes[1];\n\
+        const section = childRoot.childNodes[0];\n\
+        const cBtn = section.childNodes[0];\n\
+        const span = section.childNodes[1];\n\
+        console.log('INITIAL:' + span.innerHTMLString());\n\
+        pBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER_PARENT:' + span.innerHTMLString());\n\
+        cBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER_CHILD:' + span.innerHTMLString());\n\
+        // A second parent change must still land (getter/box stays live).\n\
+        pBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER_PARENT2:' + span.innerHTMLString());\n";
+
+    let out = run_parent_child("child_props", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:1+0"),
+        "child renders the seeded prop and its own state: {out}"
+    );
+    assert!(
+        out.contains("AFTER_PARENT:2+0"),
+        "parent state change propagates to child text: {out}"
+    );
+    assert!(
+        out.contains("AFTER_CHILD:2+1"),
+        "child event mutates only child-local state (prop unchanged): {out}"
+    );
+    assert!(
+        out.contains("AFTER_PARENT2:3+1"),
+        "prop stays live across multiple parent changes: {out}"
+    );
+}
+
+#[test]
+fn child_uses_default_when_prop_omitted() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Parent mounts Child with NO props; the child's `@input` default seeds it.
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div><Child/></div>\n";
+    let child = "@input label:string = \"def\"\n\
+        html:\n\
+        \x20   <span>${label}</span>\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const childRoot = root.childNodes[0].childNodes[0];\n\
+        const span = childRoot.childNodes[0];\n\
+        console.log('INITIAL:' + span.innerHTMLString());\n";
+
+    let out = run_parent_child("child_default", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:def"),
+        "omitted prop falls back to the @input default: {out}"
+    );
+}
+
+#[test]
+fn child_in_if_mounts_and_unmounts() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Child lives inside an `:if`. Toggling the condition mounts and unmounts it
+    // (scope teardown): the child's DOM appears and disappears.
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div><button @click=\"toggle()\">t</button><span :if=\"on\"><Child :v=\"n\"/></span></div>\n\
+        script:\n\
+        \x20   let on = false\n\
+        \x20   let n = 5\n\
+        \x20   function toggle(){ on = !on }\n";
+    let child = "@input v:number = 0\n\
+        html:\n\
+        \x20   <b>${v}</b>\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const btn = div.childNodes[0];\n\
+        console.log('INITIAL:' + div.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('SHOWN:' + div.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('HIDDEN:' + div.innerHTMLString());\n";
+
+    let out = run_parent_child("child_in_if", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("INITIAL:") && !l.contains("<b>")),
+        "child absent before the :if is true: {out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("SHOWN:") && l.contains("<b>5</b>")),
+        "child mounts with its prop when the branch shows: {out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("HIDDEN:") && !l.contains("<b>")),
+        "child unmounts when the branch is removed: {out}"
     );
 }

--- a/crates/lunas_compiler/tests/resolve.rs
+++ b/crates/lunas_compiler/tests/resolve.rs
@@ -43,8 +43,13 @@ fn reactive_var_is_mutated_binding() {
     assert!(c.is_reactive("count"));
     // `label` is a const never mutated → not reactive.
     assert!(!c.is_reactive("label"));
-    // `start` is a prop, not a script binding → not numbered here.
-    assert!(!c.is_reactive("start"));
+    // `start` is an `@input` prop: a parent can change it after init, so it is
+    // reactive too, numbered after the script vars.
+    assert!(c.is_reactive("start"));
+    assert!(
+        c.reactive_index("start").unwrap() > c.reactive_index("count").unwrap(),
+        "props are numbered after script reactive vars"
+    );
 }
 
 #[test]

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -263,12 +263,29 @@ export function forBlock(c, anchor, deps, items, opts) {
 }
 
 // mountChild(c, anchor, childFactory, props) — instantiate a child component
-// and insert its root before the anchor. Returns { root, unmount }.
+// and insert its root before the anchor (output-design.md §6).
+//
+// `props` seeds the child once: static props are plain values; reactive props
+// are getter functions (`{ p: () => expr }`) invoked once at construction to
+// seed the child's reactive prop box. The parent keeps a reactive prop live by
+// calling the returned handle's `setProp(name, value)` inside its own bind —
+// that writes the child's `_props[name]` box, so the child's own template
+// binds react. The two contexts are independent (§6): pushing a prop marks the
+// CHILD dirty, a child event marks only the child.
+//
+// Returns a handle: { root, ctx, setProp(name, value), unmount() }.
 export function mountChild(c, anchor, childFactory, props) {
   const root = childFactory(props);
   anchor.parentNode.insertBefore(root, anchor);
+  const childCtx = root && root.__lunasCtx;
   return {
     root,
+    ctx: childCtx,
+    setProp(name, value) {
+      const boxes = childCtx && childCtx._props;
+      const b = boxes && boxes[name];
+      if (b) b.v = value;
+    },
     unmount() {
       root.remove();
     },

--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -82,6 +82,24 @@ export function makeWrap(notify) {
   return wrap;
 }
 
+// prop(c, i, raw, def) — adopt an `@input` prop as a reactive variable at
+// index i (output-design.md §6). The child reads it as a box (`.v`), so its
+// own template binds react when the prop changes. The seed is `raw` when the
+// parent passed a value, else the compiled default `def`. A getter-valued
+// `raw` (the parent passes `() => expr` for a reactive prop) is invoked once
+// to seed; the parent keeps it live by pushing new values through the
+// mountChild handle's setProp, which writes `child._props[name].v`.
+//
+// The box is registered under `name` in `c._props` so a parent's mountChild
+// can find and drive it. `deep` selects a deepBox (the child deeply mutates
+// the prop locally) — parent-driven whole-value replacement still works.
+export function prop(c, name, i, raw, def, deep) {
+  const seed = raw === undefined ? def : typeof raw === "function" ? raw() : raw;
+  const b = deep ? deepBox(c, i, seed) : box(c, i, seed);
+  (c._props || (c._props = {}))[name] = b;
+  return b;
+}
+
 // shared(v) — a value shared across components (prop passed down and
 // mutated). Each dependent component attaches with its own reactive index;
 // a write marks the variable dirty in EVERY attached component.

--- a/packages/lunas/src/dom.mjs
+++ b/packages/lunas/src/dom.mjs
@@ -16,6 +16,11 @@ export function component(tag, attrs, HTML, setup) {
     for (const k in attrs) root.setAttribute(k, attrs[k]);
     root.innerHTML = HTML; // ★ one native parse, detached
     const c = createContext(root);
+    // Expose the context on the root so a parent's mountChild can push
+    // reactive prop updates into the child's own reactive prop boxes
+    // (output-design.md §6). The two contexts stay separate: a child event
+    // mutates only the child's boxes, never the parent's.
+    root.__lunasCtx = c;
     setup(c, props || {});
     return root;
   };

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -16,7 +16,7 @@ export {
   runScope,
 } from "./core.mjs";
 
-export { box, deepBox, shared } from "./boxes.mjs";
+export { box, deepBox, shared, prop } from "./boxes.mjs";
 
 export { computed } from "./computed.mjs";
 

--- a/packages/lunas/test/blocks.test.mjs
+++ b/packages/lunas/test/blocks.test.mjs
@@ -11,7 +11,7 @@ import {
   endScope,
   dropScope,
 } from "../src/core.mjs";
-import { box, deepBox } from "../src/boxes.mjs";
+import { box, deepBox, prop } from "../src/boxes.mjs";
 import {
   anchorBefore,
   anchorBeforeSplit,
@@ -507,6 +507,86 @@ await test("on() wires an event listener (fake dispatch)", () => {
   on(el, "click", () => clicks++);
   el.dispatch("click");
   assert.strictEqual(clicks, 1);
+});
+
+// --- mountChild reactive props (setProp bridge) -------------------------------
+
+await test("mountChild.setProp drives a child's reactive prop box", async () => {
+  const parent = createContext(null);
+  const host = fakeDoc.createElement("div");
+  const anchor = anchorAppend(host);
+
+  // A child built like a compiled component: its own context, a prop box, and
+  // a text node bound to the prop. The context is exposed on the root so the
+  // parent can drive it.
+  let childText = null;
+  const Child = (props) => {
+    const root = fakeDoc.createElement("kid");
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    const v = prop(c, "v", 0, props.v, 0);
+    const t = fakeDoc.createTextNode("");
+    root.appendChild(t);
+    childText = t;
+    bind(c, [0], () => {
+      t.data = String(v.v);
+    });
+    return root;
+  };
+
+  // Parent seeds via a getter and drives via setProp inside its own bind.
+  let n = box(parent, 0, 1);
+  const m = mountChild(parent, anchor, Child, { v: () => n.v });
+  bind(parent, [0], () => m.setProp("v", n.v));
+  assert.strictEqual(childText.data, "1", "seed from getter");
+  assert.ok(m.ctx, "handle exposes the child context");
+
+  n.v = 4;
+  await tick();
+  assert.strictEqual(childText.data, "4", "parent change flows into child");
+});
+
+await test("child event mutates only the child context, not the parent", async () => {
+  const parent = createContext(null);
+  const host = fakeDoc.createElement("div");
+  const anchor = anchorAppend(host);
+
+  let parentRuns = 0;
+  // A parent bind that would run if the parent's own var changed.
+  const pv = box(parent, 0, 0);
+  bind(parent, [0], () => {
+    parentRuns++;
+  });
+  const runsAfterInit = parentRuns;
+
+  let local = null;
+  const Child = (props) => {
+    const root = fakeDoc.createElement("kid");
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    local = box(c, 0, 0);
+    bind(c, [0], () => {}); // child-local reaction
+    return root;
+  };
+  mountChild(parent, anchor, Child, {});
+
+  // Mutate the child's box: only the child flushes; the parent's bind count
+  // is untouched (separate contexts, separate queues).
+  local.v = 9;
+  await tick();
+  assert.strictEqual(
+    parentRuns,
+    runsAfterInit,
+    "child mutation did not re-run any parent bind"
+  );
+});
+
+await test("prop() falls back to the default when the parent omits it", () => {
+  const c = createContext(null);
+  const p = prop(c, "label", 0, undefined, "def");
+  assert.strictEqual(p.v, "def");
+  // Registered under its name for the parent bridge.
+  assert.ok(c._props && c._props.label === p);
 });
 
 console.log("blocks.test.mjs: all " + passed + " tests passed");

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -48,8 +48,8 @@ tree:
         - { id: cg-two-way, title: "Two-way bindings", status: done }
         - { id: cg-if, title: "Conditional rendering (:if/:elseif/:else)", status: done }
         - { id: cg-for, title: "List rendering (keyed :for)", status: done }
-        - { id: cg-components, title: "Child component mounting", status: todo }
-        - { id: cg-inputs, title: "@input props handling", status: todo }
+        - { id: cg-components, title: "Child component mounting", status: done }
+        - { id: cg-inputs, title: "@input props handling", status: done }
         - { id: cg-e2e, title: "End-to-end snapshot + browser smoke tests", status: todo }
     - id: runtime
       title: Runtime (ES2015 + Proxy floor)
@@ -89,7 +89,7 @@ tree:
       title: Component model
       status: todo
       children:
-        - { id: c-props, title: "Props (@input)", status: in_progress }
+        - { id: c-props, title: "Props (@input)", status: done }
         - { id: c-slots, title: "Slots (default / named / scoped)", status: todo }
         - { id: c-emits, title: "Events / emits (child → parent)", status: todo }
         - { id: c-lifecycle, title: "Lifecycle hooks (mount/update/destroy)", status: todo }


### PR DESCRIPTION
## What

Implements child-component code generation and makes `@input` props reactive end to end (roadmap `cg-components`, `cg-inputs`, `c-props`).

### Codegen (`crates/lunas_compiler`)
- **`@input` props are reactive.** Each prop is numbered as a reactive variable (after the script's reactive vars) and adopted at the top of `setup` via a new `prop(c, "name", i, props.name, default)` helper. Prop reads rewrite through `.v` in both template and script, so a parent change re-runs the child's dependent binds. `deepBox` is selected when the child deeply mutates the prop locally.
- **Child mounting.** `<Child :p="e" static="x" flag/>` emits an anchor + `mountChild(c, a, Child, { p: () => e, static: \`x\`, flag: true })`. Reactive props (`:p`, or a static value with an interpolation) are passed as **getters** (seed the child) plus a parent-side `bind(c, deps, () => ch.setProp("p", e))`; static/valueless props are plain values. Works inside `:if`/`:for` branches (recursive emission; item-coupled `bind(c, [], …)` inside `:for`).
- **Imports.** `import Child from "<path>"` from the `@use` table, path verbatim (extension handling left to the resolver). Only tags actually used are imported; duplicates deduped; a tag colliding with a helper name (e.g. `bind`) is imported under a `$`-suffixed alias.

### Runtime (`packages/lunas`)
- New `prop()` box, registered under `c._props[name]`.
- `mountChild` now returns `{ root, ctx, setProp(name, value), unmount() }`; `component` exposes the child context on its root (`root.__lunasCtx`) so the parent's `setProp` can drive the child's reactive prop box. **Contexts stay independent** — a child event marks only the child; a parent prop push marks only the child.

## Props contract

Reactive props flow parent → child as getters + a parent `bind` that calls `ch.setProp(name, expr)` on the expression's compile-time deps; `setProp` writes `child._props[name].v`, flushing the child. Static props are values in the initial object. Documented in `output-design.md` §5/§6 (contract concretized beyond the one-line "passed as a getter" note).

## Tests
- **Emit snapshots** (`codegen_emit.rs`, +8): simple child, reactive+static props, boolean+interpolated props, child-in-`:if`, child-in-`:for`, multiple children + import dedup, unused-`@use` not imported, colliding-name alias. Updated `props_seeded_from_input` for the new reactive-prop shape; `@use`/component tags added to the never-panic fuzz + malformed cases.
- **Exec** (`codegen_exec.rs`, +3, two-module harness): parent→child reactivity (state change updates child text, stays live across multiple changes), child-event isolation (does not touch parent), `@input` default fallback, mount+unmount when a wrapping `:if` toggles (scope teardown).
- **Runtime** (`blocks.test.mjs`, +3): `mountChild.setProp` drives the child box; child mutation doesn't re-run parent binds; `prop()` default fallback + registration.
- `resolve.rs` updated: props are now reactive.

Quality gates green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `node packages/lunas/test/run-all.mjs`.

Roadmap `cg-components`, `cg-inputs`, `c-props` flipped to `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)