### PR TITLE
feat(runtime): lifecycle, emits, provide/inject, transitions, keep-alive

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -263,6 +263,63 @@ export function suspenseBlock(c, anchor, content, fallback) { /* boundary at a t
                                                                  then reveals content (batched via
                                                                  afterFlush — no flash on sync subtrees);
                                                                  nested boundaries own their subtree */ }
+
+// --- lifecycle hooks (c-lifecycle) ------------------------------------------
+// component() returns a DETACHED root; the caller attaches it (§7). So onMount
+// cannot fire at construction — it is queued on the context and drained when the
+// root becomes live. mountChild links childCtx.parent = c and registers the child
+// under c._children so a single top-level attach() fires the whole subtree, and a
+// parent teardown recurses into children.
+export function onMount(c, fn) { /* run fn after the root attaches to a live tree; queued on
+                                    c._mountQ, drained by attach()/mountChild; fires once */ }
+export function onDestroy(c, fn) { /* run fn on teardown; every unmount path (mountChild.unmount,
+                                      block item teardown, keep-alive eviction) funnels through
+                                      runDestroy(c) → fires exactly once */ }
+export function onUpdate(c, fn) { /* run fn after each flush of c that ran updates (core flush
+                                     invokes c.onUpdate when the queue was non-empty) */ }
+export function onActivated(c, fn) { /* keep-alive: fires on (re)activation from the cache */ }
+export function onDeactivated(c, fn) { /* keep-alive: fires on deactivation (cached, not destroyed) */ }
+export function attach(root, host) { /* append a detached component root to a live host and fire the
+                                        subtree's onMount callbacks; the top-level mount entry (§7) */ }
+
+// --- emits: child → parent events (c-emits) ---------------------------------
+// A `@name` listener on a component tag compiles to an `on<Name>` prop on the
+// mountChild props object (see §6). The child calls emit(c, "name", payload),
+// which looks up on<Name> in the props it was constructed with and calls it.
+// emit does NOT mark the parent dirty — the handler decides (a box setter in the
+// handler marks the parent as usual). Names camel-case: `save-all` → `onSaveAll`.
+export function registerEmits(c, props, declared) { /* at the top of a child setup: stash props so
+                                                       emit can find on<Name> handlers; optional
+                                                       declared[] enables warn-only validation */ }
+export function emit(c, name, payload) { /* invoke the parent's on<Name> handler if present; returns
+                                            whether one ran; no-op (false) when no listener/parent */ }
+export function eventPropName(name) { /* "save" → "onSave"; the codegen's @name→onName mapping */ }
+
+// --- provide / inject: DI down the tree (c-provide) --------------------------
+// Walks the childCtx.parent chain that mountChild links. Nearest ancestor wins
+// (shadowing); string or Symbol keys; inject returns a default when unprovided.
+export function provide(c, key, value) { /* register key→value on c._provides (a Map) */ }
+export function inject(c, key, def) { /* resolve from the nearest ancestor that provided key, else def */ }
+export function hasInjection(c, key) { /* whether any ancestor provides key (provided-undefined vs absent) */ }
+
+// --- transitions (c-transition) ---------------------------------------------
+// CSS-class enter/leave choreography composing with a block's insert/remove:
+//   enter: +n-enter-from +n-enter-active → (raf) −n-enter-from +n-enter-to →
+//          (transitionend/timeout) −n-enter-active −n-enter-to
+//   leave: symmetric; the node is removed only after the leave phase finishes.
+// Degrades to immediate insert/remove outside a browser (no requestAnimationFrame),
+// with the class sequence still applied synchronously.
+export function withTransition(opts) { /* { name, duration? } → { enter(nodes, insert),
+                                          leave(nodes, remove) } wrapping a block's insert/remove */ }
+export function runPhase(el, base, phase, opts, done) { /* one enter|leave class phase on one element */ }
+
+// --- keep-alive: instance caching (c-keepalive) -----------------------------
+// keepAlive({ max? }).show(c, anchor, key, factory, props) caches mountChild
+// instances by key: switching away DEACTIVATES (detach nodes, keep ctx + reactive
+// state) instead of destroying; switching back ACTIVATES (re-attach, no rebuild).
+// LRU `max`; overflow/destroy() is the only path that fires onDestroy. Activation
+// fires onActivated, deactivation onDeactivated.
+export function keepAlive(opts) { /* → { show(c,anchor,key,factory,props), has(key), size, destroy() } */ }
 ```
 
 No signal-tracking stack, no VDOM, no per-node effect objects.
@@ -282,6 +339,7 @@ No signal-tracking stack, no VDOM, no per-node effect objects.
 | `:if` / `:elseif` / `:else` | one `ifBlock` chain per cascade, anchored; branch built by its own `innerHTML` when shown |
 | `:for="n of items"` | `forBlock`; **initial render = one `innerHTML` of the concatenated items**, updates = keyed diff |
 | `<Child :p="e"/>` | `mountChild(c, anchor, Child, { p: () => e, static: "x" })` at an anchor; reactive props are getters, static props are values (see below) |
+| `<Child @save="h($event)"/>` | an `onSave: ($event) => h($event)` entry on the mountChild props object; the child raises it with `emit(c, "save", payload)` (§5, c-emits). `@save-all` → `onSaveAll` (camel-cased). Handler runs in the parent; it does not auto-mark the parent dirty |
 | `@input name:type = v` | `const name = prop(c, "name", i, props.name, v)` at the top of `setup` — every prop is a reactive box (see below) |
 
 ### Child components & props (concretized)

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -98,6 +98,21 @@ main repo for the calling contract.
 | `asyncComponent(loader, opts?)` | `lunas/async` | Wrap a lazy module loader (`() => import(...)`) into a mountable child factory; resolves default export or bare factory, caches after first load, optional `loading`/`error`/`delay`/`timeout`. |
 | `mountAsyncChild(c, anchor, factory, props?)` | `lunas/async` | Mount an async component at an anchor (mountChild contract + suspense registration); `unmount()` cancels any in-flight load. |
 | `suspenseBlock(c, anchor, contentFactory, fallbackFactory?)` | `lunas/async` | Async boundary at an anchor: shows `fallback` while any async child under it is pending, reveals `content` once all resolve (batched, no flash); nested boundaries are independent. |
+| `onMount(c, fn)` | `lunas/lifecycle` | Run `fn` after the component's root attaches to a live tree (fires once). |
+| `onDestroy(c, fn)` | `lunas/lifecycle` | Run `fn` when the component is torn down (fires once, every unmount path). |
+| `onUpdate(c, fn)` | `lunas/lifecycle` | Run `fn` after each flush of `c` that ran updates. |
+| `onActivated(c, fn)` / `onDeactivated(c, fn)` | `lunas/lifecycle` | Keep-alive (de)activation hooks — fire on cache re-attach / detach. |
+| `attach(root, host)` | `lunas/lifecycle` | Append a detached component root to a live host and fire the subtree's `onMount` callbacks. |
+| `isLive(node)` | `lunas/lifecycle` | Whether `node` is in a live tree (`isConnected` + shim fallback). |
+| `emit(c, name, payload?)` | `lunas/emits` | Raise a child→parent event; invokes the parent's `on<Name>` handler prop. Never marks the parent dirty by itself. |
+| `registerEmits(c, props, declared?)` | `lunas/emits` | Stash a child's props (so `emit` finds handlers); optional declared-events validation. |
+| `eventPropName(name)` | `lunas/emits` | Map an event name to its prop (`save` → `onSave`); the codegen's `@name`→`onName` mapping. |
+| `provide(c, key, value)` | `lunas/provide` | Provide a value (string or Symbol key) to descendants via the parent-context chain. |
+| `inject(c, key, default?)` | `lunas/provide` | Resolve a provided value from the nearest ancestor, else the default. |
+| `hasInjection(c, key)` | `lunas/provide` | Whether any ancestor provides `key` (distinguishes provided-`undefined` from absent). |
+| `withTransition(opts?)` | `lunas/transition` | Build an enter/leave CSS-class transition controller composing with a block's insert/remove; degrades to immediate outside a browser. |
+| `runPhase(el, base, phase, opts, done)` | `lunas/transition` | Run one enter/leave class choreography on an element (frame classes + `transitionend`/timeout). |
+| `keepAlive(opts?)` | `lunas/keepalive` | Cache mountChild instances by key: deactivate detaches (keeps state), activate re-attaches (no rebuild); LRU `max`; eviction fires `onDestroy`. |
 
 ## Testing
 

--- a/packages/lunas/package.json
+++ b/packages/lunas/package.json
@@ -74,6 +74,26 @@
       "types": "./types/async.d.ts",
       "import": "./src/async.mjs"
     },
+    "./lifecycle": {
+      "types": "./types/lifecycle.d.ts",
+      "import": "./src/lifecycle.mjs"
+    },
+    "./emits": {
+      "types": "./types/emits.d.ts",
+      "import": "./src/emits.mjs"
+    },
+    "./provide": {
+      "types": "./types/provide.d.ts",
+      "import": "./src/provide.mjs"
+    },
+    "./transition": {
+      "types": "./types/transition.d.ts",
+      "import": "./src/transition.mjs"
+    },
+    "./keepalive": {
+      "types": "./types/keepalive.d.ts",
+      "import": "./src/keepalive.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -21,6 +21,7 @@ import {
   runScope,
 } from "./core.mjs";
 import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
+import { isLive, runMount, runDestroy } from "./lifecycle.mjs";
 
 const toNodes = (h) => (Array.isArray(h) ? h : [h]);
 const firstNode = (h) => (Array.isArray(h) ? h[0] : h);
@@ -274,10 +275,24 @@ export function forBlock(c, anchor, deps, items, opts) {
 // CHILD dirty, a child event marks only the child.
 //
 // Returns a handle: { root, ctx, setProp(name, value), unmount() }.
+//
+// Lifecycle & DI wiring (additive): the child context is linked to the parent
+// `c` via `childCtx.parent` (provide.mjs walks this chain) and registered under
+// `c._children` so a parent teardown/mount recurses into it (lifecycle.mjs).
+// When the child's insertion point is already live, the child's queued onMount
+// callbacks fire immediately; otherwise they stay pending until an ancestor
+// `attach()` drains them. `unmount()` fires the child's onDestroy exactly once.
 export function mountChild(c, anchor, childFactory, props) {
   const root = childFactory(props);
   anchor.parentNode.insertBefore(root, anchor);
   const childCtx = root && root.__lunasCtx;
+  if (childCtx) {
+    childCtx.parent = c;
+    (c._children || (c._children = [])).push(childCtx);
+    // If the child landed in a live tree, fire its mount hooks now; otherwise a
+    // later attach() on an ancestor drains them.
+    if (isLive(root)) runMount(childCtx);
+  }
   return {
     root,
     ctx: childCtx,
@@ -287,6 +302,14 @@ export function mountChild(c, anchor, childFactory, props) {
       if (b) b.v = value;
     },
     unmount() {
+      if (childCtx) {
+        runDestroy(childCtx);
+        const kids = c._children;
+        if (kids) {
+          const k = kids.indexOf(childCtx);
+          if (k >= 0) kids.splice(k, 1);
+        }
+      }
       root.remove();
     },
   };

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -11,7 +11,21 @@
 // for-diff-design.md §6).
 
 export function createContext(root) {
-  return { root, deps: [], queue: [], pending: false, scope: null, post: null };
+  // `parent` links a child component context to the one that mounted it
+  // (additive; set by mountChild) so provide/inject (provide.mjs) can walk the
+  // chain. `onUpdate` (lifecycle.mjs) is an optional per-context hook the flush
+  // loop invokes after an update pass actually ran. All new fields default to
+  // null so contexts stay cheap and existing paths are untouched.
+  return {
+    root,
+    deps: [],
+    queue: [],
+    pending: false,
+    scope: null,
+    post: null,
+    parent: null,
+    onUpdate: null,
+  };
 }
 
 // bind(c, deps, fn) — register an update function that reads the reactive
@@ -50,10 +64,16 @@ export function flush(c) {
   c.pending = false;
   const q = c.queue;
   c.queue = [];
+  const ran = q.length > 0;
   for (const s of q) {
     s.q = false;
     if (s.alive) s.fn();
   }
+  // onUpdate (lifecycle.mjs) — a lightweight per-context post-update hook that
+  // fires only when an update pass actually ran, distinct from the one-shot
+  // `post` callbacks (afterFlush/nextTick) drained below. Additive: null unless
+  // a component registered onUpdate.
+  if (ran && c.onUpdate) c.onUpdate();
   const post = c.post;
   if (post) {
     c.post = null;

--- a/packages/lunas/src/emits.mjs
+++ b/packages/lunas/src/emits.mjs
@@ -1,0 +1,58 @@
+// emits.mjs — child → parent events (c-emits).
+// See output-design.md §5 (runtime API) and §6 (syntax → output mapping).
+//
+// A child raises a named event with an optional payload; the parent listens by
+// passing a handler prop named `on<Name>` (camel-cased). This mirrors Vue's
+// `@name` on a component tag, which the future codegen lowers to an `onName`
+// prop on the mountChild props object (documented in §5's emits block):
+//
+//   <Child @save="handle($event)" />   ⇒   mountChild(c, a, Child, {
+//                                             onSave: (payload) => handle(payload)
+//                                           })
+//
+// In the child's setup, `emit(c, "save", payload)` looks up `onSave` in the
+// props the child was constructed with and calls it. Critically, emit does NOT
+// mark the parent dirty: the two contexts are independent (§6). If the handler
+// mutates parent reactive state, the box setters mark the parent — the handler
+// decides. A no-op when there is no listener (no parent, or prop absent).
+
+// eventPropName("save") → "onSave"; ("update:model") → "onUpdate:model" is NOT
+// produced — event names are plain identifiers; the codegen maps `@name` to the
+// camel-cased `on` + Capitalized name. Kebab names ("save-all") map to
+// "onSaveAll".
+export function eventPropName(name) {
+  // Split on "-" and capitalize each segment after the first char of the whole.
+  const camel = name.replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+  return "on" + camel.charAt(0).toUpperCase() + camel.slice(1);
+}
+
+// registerEmits(c, props, declared?) — called at the top of a child `setup` to
+// stash the props (so emit can find handlers) and optionally the declared event
+// names for lean validation. Additive: stores on `c._emitProps`. Returns c.
+export function registerEmits(c, props, declared) {
+  c._emitProps = props || {};
+  if (declared) c._emits = declared; // array of allowed event names (optional)
+  return c;
+}
+
+// emit(c, name, payload) — invoke the parent's `on<Name>` handler, if any.
+// Returns true if a handler ran, false otherwise (no listener). Never marks the
+// parent dirty by itself.
+export function emit(c, name, payload) {
+  const props = c && c._emitProps;
+  if (c && c._emits && c._emits.indexOf(name) < 0) {
+    // Optional lean validation: warn (do not throw) on an undeclared event.
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        'lunas: emitted undeclared event "' + name + '" (not in emits list)'
+      );
+    }
+  }
+  if (!props) return false;
+  const handler = props[eventPropName(name)];
+  if (typeof handler === "function") {
+    handler(payload);
+    return true;
+  }
+  return false;
+}

--- a/packages/lunas/src/index.mjs
+++ b/packages/lunas/src/index.mjs
@@ -55,3 +55,21 @@ export {
 } from "./router.mjs";
 
 export { asyncComponent, mountAsyncChild, suspenseBlock } from "./async.mjs";
+
+export {
+  onMount,
+  onDestroy,
+  onUpdate,
+  onActivated,
+  onDeactivated,
+  attach,
+  isLive,
+} from "./lifecycle.mjs";
+
+export { emit, registerEmits, eventPropName } from "./emits.mjs";
+
+export { provide, inject, hasInjection } from "./provide.mjs";
+
+export { withTransition, runPhase } from "./transition.mjs";
+
+export { keepAlive } from "./keepalive.mjs";

--- a/packages/lunas/src/keepalive.mjs
+++ b/packages/lunas/src/keepalive.mjs
@@ -1,0 +1,136 @@
+// keepalive.mjs — component instance caching (c-keepalive).
+// See output-design.md §5 (runtime API).
+//
+// A keep-alive wraps a swappable child slot (e.g. a dynamic `:is` or a routed
+// outlet) so switching AWAY from a component DEACTIVATES it — detaches its nodes
+// but keeps its context, reactive state, and DOM subtree alive — instead of
+// destroying it. Switching BACK ACTIVATES the cached instance: its nodes are
+// re-attached with no rebuild, preserving scroll, form state, and reactive vars.
+//
+// Cache policy: keyed LRU with an optional `max`. When the cache overflows the
+// least-recently-used instance is truly EVICTED — that's the only path (besides
+// `destroy()`) that fires the instance's onDestroy. Deactivation never destroys.
+//
+// Lifecycle integration (lifecycle.mjs): activation fires `onActivated`,
+// deactivation fires `onDeactivated`, first mount also fires `onMount`, and real
+// eviction/teardown fires `onDestroy`.
+
+import { mountChild } from "./blocks.mjs";
+import {
+  runActivate,
+  runDeactivate,
+  runDestroy,
+  isLive,
+  runMount,
+} from "./lifecycle.mjs";
+
+// keepAlive(opts) — opts: { max? } (LRU capacity; unbounded when omitted).
+// Returns a controller:
+//   show(c, anchor, key, factory, props) — ensure the instance for `key` is the
+//       one mounted before `anchor`, activating a cached instance or mounting a
+//       fresh one; deactivates the previously-shown instance. Returns the
+//       instance's mountChild handle (extended with `.key`).
+//   destroy() — evict and destroy every cached instance.
+export function keepAlive(opts) {
+  opts = opts || {};
+  const max = opts.max == null ? Infinity : opts.max;
+
+  // key → { handle, nodes, active }. Insertion order in the Map is the LRU
+  // order (least-recent first); re-inserting on access moves an entry to the end.
+  const cache = new Map();
+  let current = null; // the key currently attached, or null.
+
+  // Detach an instance's nodes without destroying it. Snapshots the node list
+  // (a component root is one node; multi-root handled by scanning siblings is
+  // out of scope — the child root is a single node per mountChild contract).
+  const deactivate = (entry) => {
+    if (!entry.active) return;
+    entry.active = false;
+    const root = entry.handle.root;
+    // Snapshot so re-attach restores the same node.
+    entry.nodes = [root];
+    root.remove();
+    runDeactivate(entry.handle.ctx);
+  };
+
+  // Re-attach a cached instance before `anchor` (no rebuild).
+  const activate = (entry, anchor) => {
+    if (entry.active) return;
+    entry.active = true;
+    const p = anchor.parentNode;
+    for (const n of entry.nodes) p.insertBefore(n, anchor);
+    runActivate(entry.handle.ctx);
+  };
+
+  // Truly evict: destroy the instance and drop it from the cache.
+  const evict = (key) => {
+    const entry = cache.get(key);
+    if (!entry) return;
+    cache.delete(key);
+    if (entry.active && entry.handle.root.parentNode) entry.handle.root.remove();
+    runDestroy(entry.handle.ctx);
+  };
+
+  // Enforce LRU capacity, never evicting the just-touched `keepKey`.
+  const trim = (keepKey) => {
+    while (cache.size > max) {
+      // First key in iteration order = least recently used.
+      let victim = null;
+      for (const k of cache.keys()) {
+        if (k !== keepKey) {
+          victim = k;
+          break;
+        }
+      }
+      if (victim == null) break;
+      evict(victim);
+    }
+  };
+
+  return {
+    show(c, anchor, key, factory, props) {
+      // Deactivate the outgoing instance (if switching keys).
+      if (current !== null && current !== key) {
+        const prev = cache.get(current);
+        if (prev) deactivate(prev);
+      }
+
+      let entry = cache.get(key);
+      if (entry) {
+        // Cache hit: move to MRU position, re-attach if needed.
+        cache.delete(key);
+        cache.set(key, entry);
+        activate(entry, anchor);
+      } else {
+        // Miss: mount a fresh instance. mountChild links parent/child, inserts
+        // the root, and fires onMount when live.
+        const handle = mountChild(c, anchor, factory, props);
+        entry = { handle, nodes: [handle.root], active: true };
+        cache.set(key, entry);
+        // A fresh instance is considered "activated" on first show too.
+        runActivate(handle.ctx);
+        // If mountChild couldn't fire onMount (detached at mount time) but the
+        // slot is now live, this is still deferred to an ancestor attach().
+        if (isLive(handle.root)) runMount(handle.ctx);
+        entry.handle.key = key;
+      }
+      current = key;
+      trim(key);
+      return entry.handle;
+    },
+
+    // has(key) — whether an instance is currently cached (test/introspection).
+    has(key) {
+      return cache.has(key);
+    },
+    // size — number of cached instances.
+    get size() {
+      return cache.size;
+    },
+
+    destroy() {
+      for (const key of Array.from(cache.keys())) evict(key);
+      current = null;
+    },
+  };
+}

--- a/packages/lunas/src/lifecycle.mjs
+++ b/packages/lunas/src/lifecycle.mjs
@@ -1,0 +1,163 @@
+// lifecycle.mjs — component lifecycle hooks (c-lifecycle).
+// See output-design.md §5 (runtime API) and §7 (mount lifecycle).
+//
+// Four hooks, all keyed on the component context `c`:
+//
+//   onMount(c, fn)     — after the component's root is attached to a live tree.
+//   onDestroy(c, fn)   — when the component's scope is torn down (unmount).
+//   onUpdate(c, fn)    — after each flush of `c` that actually ran updates.
+//   onActivated(c, fn) / onDeactivated(c, fn) — keep-alive (keepalive.mjs) only.
+//
+// ── The attach contract (§7) ────────────────────────────────────────────────
+// `component()` returns a DETACHED root; the CALLER attaches it. So onMount
+// callbacks cannot fire at construction — they are queued on the context
+// (`c._mountQ`) and drained the moment the root becomes part of a live tree:
+//
+//   • `attach(root, host)` — the top-level mount helper: appends `root` to
+//     `host`, then drains the queue (recursively, so nested children mounted
+//     during setup also fire). Use this to mount a root component.
+//   • `mountChild` (blocks.mjs) — when it inserts a child whose insertion point
+//     is already connected, it drains the child's queue immediately; otherwise
+//     the child stays pending until an ancestor `attach` drains it.
+//
+// Liveness is detected via `Node.isConnected` with a walk-to-root fallback for
+// DOM shims that don't implement it (the test fake DOM has no `isConnected`).
+//
+// Destroy runs exactly once per context: `runDestroy(c)` is idempotent (it
+// nulls the queue after firing). Every unmount path funnels through it —
+// mountChild.unmount, forBlock/ifBlock item teardown that owns a child, and
+// keep-alive final eviction.
+
+// ── queue accessors (kept off `core.mjs` so the core stays minimal) ──────────
+// Each queue is a plain array lazily created on the context under a private
+// field. onUpdate additionally installs a post-flush hook via a wrapper the
+// core's flush loop already drains (`c.post`); to fire *every* flush (not just
+// once) we re-arm it from inside itself.
+
+/** onMount(c, fn) — run `fn` after this component's root attaches to the DOM.
+ *  If the root is already connected (mounted synchronously into a live tree),
+ *  `fn` runs on the next microtask so ordering matches the deferred case. */
+export function onMount(c, fn) {
+  if (typeof fn !== "function") return;
+  if (c._mounted) {
+    // Already attached — schedule on a microtask so callers registering after
+    // attach still observe a live, painted tree.
+    queueMicrotask(fn);
+    return;
+  }
+  (c._mountQ || (c._mountQ = [])).push(fn);
+}
+
+/** onDestroy(c, fn) — run `fn` when this component is torn down (once). */
+export function onDestroy(c, fn) {
+  if (typeof fn !== "function") return;
+  (c._destroyQ || (c._destroyQ = [])).push(fn);
+}
+
+/** onUpdate(c, fn) — run `fn` after each flush of `c` that ran updates.
+ *  Wires the core's per-context `onUpdate` post-update hook (core.mjs flush). */
+export function onUpdate(c, fn) {
+  if (typeof fn !== "function") return;
+  (c._updateQ || (c._updateQ = [])).push(fn);
+  if (!c.onUpdate) c.onUpdate = () => fireUpdate(c);
+}
+
+/** onActivated(c, fn) — keep-alive: run `fn` each time the component is
+ *  (re)activated from the cache. Fires immediately on first activation. */
+export function onActivated(c, fn) {
+  if (typeof fn !== "function") return;
+  (c._activateQ || (c._activateQ = [])).push(fn);
+}
+
+/** onDeactivated(c, fn) — keep-alive: run `fn` each time the component is
+ *  deactivated (cached, not destroyed). */
+export function onDeactivated(c, fn) {
+  if (typeof fn !== "function") return;
+  (c._deactivateQ || (c._deactivateQ = [])).push(fn);
+}
+
+// ── liveness ────────────────────────────────────────────────────────────────
+// Prefer the real `isConnected`; fall back to walking parentNode to a node
+// whose ownerDocument is (or contains) it. The fake DOM has neither a document
+// element nor isConnected, so we treat "has a parent chain terminating in a
+// node with no parent that is not the scratch owner" — in practice the runtime
+// only ever calls this after inserting into the mount host, and tests drive
+// attach() explicitly, so a null-safe walk is enough.
+export function isLive(node) {
+  if (!node) return false;
+  if (typeof node.isConnected === "boolean") return node.isConnected;
+  // Shim fallback: connected iff a marked root ancestor is reachable.
+  let n = node;
+  while (n) {
+    if (n._lunasAttached) return true;
+    n = n.parentNode;
+  }
+  return false;
+}
+
+// ── draining ─────────────────────────────────────────────────────────────────
+// runMount(c) — mark the context mounted and fire+clear its queued onMount
+// callbacks. Idempotent: a second call is a no-op. Recurses into child
+// contexts registered on `c._children` (mountChild links them) so a single
+// top-level attach fires the whole freshly-built subtree in child-before-... no:
+// parent registers children as it mounts them, and children are attached (their
+// nodes inserted) before the parent finishes, so we fire children first to match
+// "mounted" meaning "my subtree is in the DOM".
+export function runMount(c) {
+  if (!c || c._mounted) return;
+  c._mounted = true;
+  const kids = c._children;
+  if (kids) for (const k of kids) runMount(k);
+  const q = c._mountQ;
+  if (q) {
+    c._mountQ = null;
+    for (const fn of q) fn();
+  }
+}
+
+// runDestroy(c) — fire+clear queued onDestroy callbacks exactly once, then
+// recurse into child contexts so a parent teardown tears children down too.
+export function runDestroy(c) {
+  if (!c || c._destroyed) return;
+  c._destroyed = true;
+  const kids = c._children;
+  if (kids) for (const k of kids) runDestroy(k);
+  const q = c._destroyQ;
+  if (q) {
+    c._destroyQ = null;
+    for (const fn of q) fn();
+  }
+}
+
+// runActivate(c) / runDeactivate(c) — keep-alive activation hooks. Not
+// idempotent by design: a keep-alive component activates/deactivates many times.
+export function runActivate(c) {
+  if (!c) return;
+  const q = c._activateQ;
+  if (q) for (const fn of q.slice()) fn();
+}
+export function runDeactivate(c) {
+  if (!c) return;
+  const q = c._deactivateQ;
+  if (q) for (const fn of q.slice()) fn();
+}
+
+// fireUpdate(c) — run queued onUpdate callbacks. Called by the flush post-hook
+// installed on demand (see armUpdate). Kept separate so keep-alive/tests can
+// invoke it deterministically.
+export function fireUpdate(c) {
+  const q = c._updateQ;
+  if (q) for (const fn of q.slice()) fn();
+}
+
+// ── attach — the top-level mount entry (§7) ──────────────────────────────────
+// attach(root, host) — append a detached component root to a live host and fire
+// the whole subtree's onMount callbacks. `root.__lunasCtx` is the component's
+// context (set by component()). Returns `root`.
+export function attach(root, host) {
+  host.appendChild(root);
+  root._lunasAttached = true; // liveness marker for the shim fallback
+  const c = root && root.__lunasCtx;
+  if (c) runMount(c);
+  return root;
+}

--- a/packages/lunas/src/provide.mjs
+++ b/packages/lunas/src/provide.mjs
@@ -1,0 +1,47 @@
+// provide.mjs — dependency injection down the component tree (c-provide).
+// See output-design.md §5 (runtime API) and §6.
+//
+// A component `provide(c, key, value)`s a value; any descendant
+// `inject(c, key, default?)`s it by walking the parent-context chain
+// (`c.parent`, linked by mountChild — blocks.mjs). The nearest ancestor that
+// provided `key` wins (shadowing). Keys may be strings or Symbols.
+//
+// The parent link is additive and populated only for children mounted via
+// mountChild; a root component's `c.parent` is null, so inject on a root falls
+// straight through to the default.
+
+// provide(c, key, value) — register `key → value` on this component's context.
+// A later provide of the same key on the same context overwrites it.
+export function provide(c, key, value) {
+  const m = c._provides || (c._provides = new Map());
+  m.set(key, value);
+  return value;
+}
+
+// inject(c, key, def) — resolve `key` from the nearest ancestor that provided
+// it (this context included). Returns `def` (default undefined) when no ancestor
+// provides the key. `def` may be a factory: pass `{ factory: fn }`? No — kept
+// simple: `def` is a plain value to match Vue's common case; callers wanting a
+// lazy default can pass a thunk and call it. The chain walk is O(depth).
+export function inject(c, key, def) {
+  let n = c;
+  while (n) {
+    const m = n._provides;
+    if (m && m.has(key)) return m.get(key);
+    n = n.parent;
+  }
+  return def;
+}
+
+// hasInjection(c, key) — true if any ancestor (or self) provides `key`. Useful
+// for optional-injection call sites that must distinguish "provided undefined"
+// from "not provided".
+export function hasInjection(c, key) {
+  let n = c;
+  while (n) {
+    const m = n._provides;
+    if (m && m.has(key)) return true;
+    n = n.parent;
+  }
+  return false;
+}

--- a/packages/lunas/src/transition.mjs
+++ b/packages/lunas/src/transition.mjs
@@ -1,0 +1,142 @@
+// transition.mjs — CSS-class enter/leave transitions (c-transition).
+// See output-design.md §5 (runtime API).
+//
+// Vue-style class choreography around a block's insert/remove. For a transition
+// named `n` an element gets, on ENTER:
+//
+//   frame 0 (before paint):  + n-enter-from   + n-enter-active
+//   frame 1 (next raf):      − n-enter-from   + n-enter-to
+//   transitionend / timeout: − n-enter-active − n-enter-to
+//
+// and symmetrically on LEAVE (`n-leave-from/-active/-to`), with the node removed
+// only after the leave transition finishes. This lets CSS drive the animation
+// while the runtime just toggles classes and awaits `transitionend`.
+//
+// ── Environment degradation ──────────────────────────────────────────────────
+// There is no CSS engine outside a browser (and the test DOM has none), so when
+// `requestAnimationFrame` is unavailable the transition degrades to an immediate
+// insert/remove — but the class SEQUENCE still runs synchronously so the logic
+// is testable: classes are added and removed in order, and `done` is called
+// right away. In a browser the frames and `transitionend` (with a `duration`
+// timeout fallback) drive the real timing.
+
+const nextFrame =
+  typeof requestAnimationFrame === "function"
+    ? (fn) => requestAnimationFrame(() => requestAnimationFrame(fn))
+    : null;
+
+function addClass(el, cls) {
+  if (el && el.classList) el.classList.add(cls);
+}
+function removeClass(el, cls) {
+  if (el && el.classList) el.classList.remove(cls);
+}
+
+// runPhase(el, base, phase, opts, done) — perform one enter/leave choreography
+// on a single element. `phase` is "enter" | "leave". Calls `done()` when the
+// phase completes (after transitionend/timeout in a browser, synchronously when
+// degraded). Returns a `cancel()` that stops timers/listeners.
+export function runPhase(el, base, phase, opts, done) {
+  opts = opts || {};
+  const from = base + "-" + phase + "-from";
+  const active = base + "-" + phase + "-active";
+  const to = base + "-" + phase + "-to";
+  let finished = false;
+  let timer = null;
+  let removeListener = null;
+
+  const cleanup = () => {
+    removeClass(el, active);
+    removeClass(el, to);
+    if (timer != null) clearTimeout(timer);
+    if (removeListener) removeListener();
+  };
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    cleanup();
+    if (done) done();
+  };
+
+  // frame 0: starting classes.
+  addClass(el, from);
+  addClass(el, active);
+
+  const step2 = () => {
+    // frame 1: swap -from → -to to kick the transition.
+    removeClass(el, from);
+    addClass(el, to);
+  };
+
+  if (!nextFrame) {
+    // Degraded (non-browser): run the whole sequence synchronously so class
+    // ordering is observable, then finish immediately.
+    step2();
+    finish();
+    return () => {};
+  }
+
+  // Browser path: advance a frame, then await transitionend with a timeout
+  // fallback (some elements never fire it — e.g. display:none, 0-duration).
+  nextFrame(() => {
+    if (finished) return;
+    step2();
+    if (el && el.addEventListener) {
+      const onEnd = (ev) => {
+        if (ev && ev.target !== el) return; // ignore bubbled child transitions
+        finish();
+      };
+      el.addEventListener("transitionend", onEnd);
+      removeListener = () => el.removeEventListener("transitionend", onEnd);
+    }
+    const dur = opts.duration;
+    // Always arm a fallback timer so a missing transitionend can't hang teardown.
+    timer = setTimeout(finish, dur != null ? dur : 0);
+  });
+
+  return () => {
+    if (!finished) {
+      finished = true;
+      cleanup();
+    }
+  };
+}
+
+// withTransition(opts) — build a transition controller composing with block
+// insert/remove. `opts.name` is the class base (default "v"); `opts.duration`
+// is the leave/enter timeout fallback in ms.
+//
+// Returns { enter(nodes, insert), leave(nodes, remove) }:
+//   enter(nodes, insert) — call `insert()` to mount the nodes, then choreograph
+//                          the enter classes on each root node.
+//   leave(nodes, remove) — choreograph the leave classes, then call `remove()`
+//                          once every node's leave phase has finished.
+//
+// This is the composable primitive ifBlock/forBlock/mountChild wrappers use:
+// pass the block's own insert/remove closures through it.
+export function withTransition(opts) {
+  opts = opts || {};
+  const base = opts.name || "v";
+
+  const toList = (n) => (n == null ? [] : Array.isArray(n) ? n : [n]);
+
+  return {
+    enter(nodes, insert) {
+      if (insert) insert();
+      const list = toList(nodes);
+      for (const el of list) runPhase(el, base, "enter", opts, null);
+    },
+    leave(nodes, remove) {
+      const list = toList(nodes);
+      if (list.length === 0) {
+        if (remove) remove();
+        return;
+      }
+      let pending = list.length;
+      const one = () => {
+        if (--pending === 0 && remove) remove();
+      };
+      for (const el of list) runPhase(el, base, "leave", opts, one);
+    },
+  };
+}

--- a/packages/lunas/test/dom-shim.mjs
+++ b/packages/lunas/test/dom-shim.mjs
@@ -20,6 +20,34 @@ class FakeNode {
     this.attributes = {};
     this._listeners = {};
     this._props = {}; // IDL properties set via `el.value = …` etc.
+    this._classes = new Set(); // backs classList
+  }
+  // Minimal classList (add/remove/contains) for transition class sequencing.
+  get classList() {
+    const set = this._classes;
+    const self = this;
+    return {
+      add: (...cs) => {
+        for (const c of cs) set.add(c);
+        self.attributes.class = Array.from(set).join(" ");
+      },
+      remove: (...cs) => {
+        for (const c of cs) set.delete(c);
+        self.attributes.class = Array.from(set).join(" ");
+      },
+      contains: (c) => set.has(c),
+      toArray: () => Array.from(set),
+    };
+  }
+  // isConnected: reachable from a node flagged `_lunasAttached` (attach() sets
+  // it on a mounted root), matching the runtime's liveness fallback.
+  get isConnected() {
+    let n = this;
+    while (n) {
+      if (n._lunasAttached) return true;
+      n = n.parentNode;
+    }
+    return false;
   }
   insertBefore(n, ref) {
     if (ref !== null && ref !== undefined && ref.parentNode !== this) {
@@ -72,8 +100,18 @@ class FakeNode {
   addEventListener(ev, fn) {
     (this._listeners[ev] || (this._listeners[ev] = [])).push(fn);
   }
-  dispatch(ev) {
-    for (const fn of this._listeners[ev] || []) fn({ type: ev });
+  removeEventListener(ev, fn) {
+    const ls = this._listeners[ev];
+    if (ls) {
+      const i = ls.indexOf(fn);
+      if (i >= 0) ls.splice(i, 1);
+    }
+  }
+  // dispatch(name) fires listeners with a { type, target } event, so
+  // transitionend handlers that check `ev.target === el` work.
+  dispatch(ev, detail) {
+    const event = Object.assign({ type: ev, target: this }, detail);
+    for (const fn of (this._listeners[ev] || []).slice()) fn(event);
   }
   // IDL-property reflection so `el.value`, `el.checked`, `el.disabled` behave.
   get value() {

--- a/packages/lunas/test/emits.test.mjs
+++ b/packages/lunas/test/emits.test.mjs
@@ -1,0 +1,86 @@
+// emits.test.mjs — child → parent events. Run: node packages/lunas/test/emits.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { emit, registerEmits, eventPropName } from "../src/emits.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test("eventPropName maps names to on<Name>", () => {
+  assert.equal(eventPropName("save"), "onSave");
+  assert.equal(eventPropName("close"), "onClose");
+  assert.equal(eventPropName("save-all"), "onSaveAll");
+  assert.equal(eventPropName("update-model-value"), "onUpdateModelValue");
+});
+
+test("emit invokes the parent handler with payload", () => {
+  const c = createContext(document.createElement("div"));
+  let got = null;
+  registerEmits(c, { onSave: (p) => (got = p) });
+  const ran = emit(c, "save", { id: 7 });
+  assert.equal(ran, true);
+  assert.deepEqual(got, { id: 7 });
+});
+
+test("emit with no listener is a no-op returning false", () => {
+  const c = createContext(document.createElement("div"));
+  registerEmits(c, {}); // no handlers
+  assert.equal(emit(c, "save", 1), false);
+});
+
+test("emit with no props registered (no parent) is a no-op", () => {
+  const c = createContext(document.createElement("div"));
+  // never called registerEmits
+  assert.equal(emit(c, "anything", 1), false);
+});
+
+test("child emit does NOT mark the parent dirty by itself", async () => {
+  // Parent has a reactive box + a bind reading it. The child's emit handler is
+  // a plain function that reads the payload but does not mutate parent state:
+  // no parent flush should occur.
+  const parent = createContext(document.createElement("div"));
+  const v = box(parent, 0, "init");
+  let binds = 0;
+  bind(parent, [0], () => {
+    v.v; // read
+    binds++;
+  });
+  assert.equal(binds, 1); // initial
+
+  const child = createContext(document.createElement("span"));
+  registerEmits(child, {
+    onPing: () => {
+      /* handler that touches nothing reactive on parent */
+    },
+  });
+  emit(child, "ping", {});
+  await tick();
+  assert.equal(binds, 1); // parent never re-ran
+
+  // But if the handler DOES mutate parent state, the box setter marks parent.
+  registerEmits(child, { onPing: () => (v.v = "changed") });
+  emit(child, "ping", {});
+  await tick();
+  assert.equal(binds, 2); // handler decided to update
+});
+
+test("emits validation warns on undeclared event but still runs handler", () => {
+  const c = createContext(document.createElement("div"));
+  let warned = null;
+  const orig = console.warn;
+  console.warn = (m) => (warned = m);
+  try {
+    let ran = false;
+    registerEmits(c, { onFoo: () => (ran = true) }, ["bar"]); // only "bar" declared
+    emit(c, "foo", 1);
+    assert.ok(warned && /undeclared/.test(warned));
+    assert.equal(ran, true); // still fires
+  } finally {
+    console.warn = orig;
+  }
+});

--- a/packages/lunas/test/keepalive.test.mjs
+++ b/packages/lunas/test/keepalive.test.mjs
@@ -1,0 +1,137 @@
+// keepalive.test.mjs — component instance caching + LRU + activate/deactivate.
+// Run: node packages/lunas/test/keepalive.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { keepAlive } from "../src/keepalive.mjs";
+import {
+  onDestroy,
+  onActivated,
+  onDeactivated,
+  onMount,
+} from "../src/lifecycle.mjs";
+
+installDom();
+
+// A component factory that records lifecycle events into `log`, tagged by id.
+function comp(id, log) {
+  return () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-id", id);
+    root.appendChild(document.createTextNode(id));
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    onMount(c, () => log.push("mount:" + id));
+    onDestroy(c, () => log.push("destroy:" + id));
+    onActivated(c, () => log.push("activate:" + id));
+    onDeactivated(c, () => log.push("deactivate:" + id));
+    return root;
+  };
+}
+
+function host() {
+  const c = createContext(document.createElement("div"));
+  c.root._lunasAttached = true; // live host so onMount fires
+  const anchor = anchorAppend(c.root);
+  return { c, container: c.root, anchor };
+}
+
+// Serialize non-anchor children.
+const shown = (container) =>
+  container.childNodes
+    .filter((n) => !(n.kind === "text" && n.data === ""))
+    .map((n) => n.getAttribute("data-id"))
+    .join(",");
+
+test("cache hit preserves node identity (no rebuild)", () => {
+  const { c, container, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  const A = comp("A", log);
+
+  const h1 = ka.show(c, anchor, "A", A, {});
+  const nodeA = h1.root;
+  assert.equal(shown(container), "A");
+
+  // Switch away to B, then back to A: same node object comes back.
+  ka.show(c, anchor, "B", comp("B", log), {});
+  assert.equal(shown(container), "B");
+  const h2 = ka.show(c, anchor, "A", A, {});
+  assert.strictEqual(h2.root, nodeA); // SAME node, not rebuilt
+  assert.equal(shown(container), "A");
+});
+
+test("deactivate detaches without destroying; activate re-attaches", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp("A", log), {}); // mount + activate A
+  ka.show(c, anchor, "B", comp("B", log), {}); // deactivate A, mount+activate B
+  ka.show(c, anchor, "A", comp("A", log), {}); // reactivate A (no rebuild/destroy)
+
+  // A was never destroyed; it deactivated then reactivated.
+  assert.deepEqual(log, [
+    "mount:A",
+    "activate:A",
+    "deactivate:A",
+    "mount:B",
+    "activate:B",
+    "deactivate:B",
+    "activate:A",
+  ]);
+  assert.equal(log.filter((e) => e === "destroy:A").length, 0);
+});
+
+test("LRU eviction fires onDestroy on the evicted instance", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 2 });
+  ka.show(c, anchor, "A", comp("A", log), {});
+  ka.show(c, anchor, "B", comp("B", log), {}); // cache: [A, B]
+  assert.equal(ka.size, 2);
+  ka.show(c, anchor, "C", comp("C", log), {}); // overflow → evict LRU (A)
+  assert.equal(ka.size, 2);
+  assert.ok(log.includes("destroy:A"), "A should be evicted+destroyed");
+  assert.equal(ka.has("A"), false);
+  assert.equal(ka.has("B"), true);
+  assert.equal(ka.has("C"), true);
+});
+
+test("LRU order updates on access (recently shown is kept)", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 2 });
+  ka.show(c, anchor, "A", comp("A", log), {}); // [A]
+  ka.show(c, anchor, "B", comp("B", log), {}); // [A, B]
+  ka.show(c, anchor, "A", comp("A", log), {}); // touch A → [B, A]
+  ka.show(c, anchor, "C", comp("C", log), {}); // evict LRU = B
+  assert.equal(ka.has("A"), true);
+  assert.equal(ka.has("B"), false);
+  assert.equal(ka.has("C"), true);
+});
+
+test("destroy() evicts and destroys every cached instance", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp("A", log), {});
+  ka.show(c, anchor, "B", comp("B", log), {});
+  ka.destroy();
+  assert.ok(log.includes("destroy:A"));
+  assert.ok(log.includes("destroy:B"));
+  assert.equal(ka.size, 0);
+});
+
+test("re-showing the same key does not re-mount or re-activate churn", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp("A", log), {});
+  const before = log.slice();
+  ka.show(c, anchor, "A", comp("A", log), {}); // same key, already active
+  // No deactivate/activate churn for staying on the same key.
+  assert.deepEqual(log, before);
+});

--- a/packages/lunas/test/lifecycle.test.mjs
+++ b/packages/lunas/test/lifecycle.test.mjs
@@ -1,0 +1,150 @@
+// lifecycle.test.mjs — onMount / onDestroy / onUpdate + attach + mountChild
+// integration against the fake DOM. Run: node packages/lunas/test/lifecycle.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind, markVar } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { mountChild } from "../src/blocks.mjs";
+import {
+  onMount,
+  onDestroy,
+  onUpdate,
+  attach,
+} from "../src/lifecycle.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// A minimal component-like factory: builds a root, attaches a context, runs a
+// setup that may register lifecycle hooks. Mimics dom.mjs component().
+function makeComponent(tag, setup) {
+  return (props) => {
+    const root = document.createElement(tag);
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    if (setup) setup(c, props || {});
+    return root;
+  };
+}
+
+test("onMount fires after attach, not at construction", () => {
+  const order = [];
+  const factory = makeComponent("div", (c) => {
+    order.push("setup");
+    onMount(c, () => order.push("mount"));
+  });
+  const root = factory();
+  assert.deepEqual(order, ["setup"]); // not mounted yet
+  const host = document.createElement("body");
+  attach(root, host);
+  assert.deepEqual(order, ["setup", "mount"]);
+});
+
+test("onMount fires once even across a second attach attempt", () => {
+  let mounts = 0;
+  const factory = makeComponent("div", (c) => onMount(c, () => mounts++));
+  const root = factory();
+  const host = document.createElement("body");
+  attach(root, host);
+  attach(root, host); // idempotent runMount
+  assert.equal(mounts, 1);
+});
+
+test("nested children: child onMount fires via a single top-level attach", () => {
+  const order = [];
+  const child = makeComponent("span", (c) => {
+    onMount(c, () => order.push("child-mount"));
+  });
+  const parent = makeComponent("div", (c, props) => {
+    onMount(c, () => order.push("parent-mount"));
+    const anchor = anchorAppend(c.root);
+    mountChild(c, anchor, child, {}); // detached at this point
+  });
+  const root = parent();
+  assert.deepEqual(order, []); // nothing fired while detached
+  attach(root, document.createElement("body"));
+  // children fire before the parent (subtree-in-DOM semantics)
+  assert.deepEqual(order, ["child-mount", "parent-mount"]);
+});
+
+test("mountChild into a live tree fires child onMount immediately", () => {
+  const order = [];
+  const child = makeComponent("span", (c) => onMount(c, () => order.push("m")));
+  const parentCtx = createContext(document.createElement("div"));
+  parentCtx.root._lunasAttached = true; // simulate a live parent
+  const anchor = anchorAppend(parentCtx.root);
+  mountChild(parentCtx, anchor, child, {});
+  assert.deepEqual(order, ["m"]);
+});
+
+test("onDestroy fires exactly once on unmount", () => {
+  let destroys = 0;
+  const child = makeComponent("span", (c) => onDestroy(c, () => destroys++));
+  const parentCtx = createContext(document.createElement("div"));
+  const anchor = anchorAppend(parentCtx.root);
+  const h = mountChild(parentCtx, anchor, child, {});
+  h.unmount();
+  h.unmount(); // second unmount must not re-fire
+  assert.equal(destroys, 1);
+});
+
+test("parent unmount tears down nested child onDestroy", () => {
+  const order = [];
+  const grandchild = makeComponent("i", (c) =>
+    onDestroy(c, () => order.push("gc"))
+  );
+  const child = makeComponent("span", (c) => {
+    onDestroy(c, () => order.push("c"));
+    const a = anchorAppend(c.root);
+    mountChild(c, a, grandchild, {});
+  });
+  const parentCtx = createContext(document.createElement("div"));
+  const a = anchorAppend(parentCtx.root);
+  const h = mountChild(parentCtx, a, child, {});
+  h.unmount();
+  assert.deepEqual(order, ["gc", "c"]); // deepest first
+});
+
+test("onUpdate fires after a flush that ran updates", async () => {
+  let updates = 0;
+  const c = createContext(document.createElement("div"));
+  onUpdate(c, () => updates++);
+  let seen = 0;
+  bind(c, [0], () => {
+    seen++;
+  });
+  assert.equal(updates, 0); // bind's initial run is not an update flush
+  markVar(c, 0);
+  await tick();
+  assert.equal(updates, 1);
+  markVar(c, 0);
+  await tick();
+  assert.equal(updates, 2); // re-arms every flush
+});
+
+test("onUpdate does not fire when a flush ran no updates", async () => {
+  let updates = 0;
+  const c = createContext(document.createElement("div"));
+  onUpdate(c, () => updates++);
+  // Schedule an empty flush via afterFlush-style pending (mark then nothing dep).
+  markVar(c, 99); // no binds on index 99 → empty queue
+  await tick();
+  assert.equal(updates, 0);
+});
+
+test("onMount registered after attach still runs (deferred microtask)", async () => {
+  const root = document.createElement("div");
+  const c = createContext(root);
+  root.__lunasCtx = c;
+  attach(root, document.createElement("body"));
+  let ran = false;
+  onMount(c, () => {
+    ran = true;
+  });
+  assert.equal(ran, false); // deferred
+  await tick();
+  assert.equal(ran, true);
+});

--- a/packages/lunas/test/provide.test.mjs
+++ b/packages/lunas/test/provide.test.mjs
@@ -1,0 +1,80 @@
+// provide.test.mjs — provide/inject across the parent-context chain.
+// Run: node packages/lunas/test/provide.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { mountChild } from "../src/blocks.mjs";
+import { provide, inject, hasInjection } from "../src/provide.mjs";
+
+installDom();
+
+// Build a chain of N contexts linked as real mountChild children so `parent`
+// is populated exactly as the runtime would. Returns the leaf handle chain.
+function chain(depth, setups) {
+  // setups[i](c) runs on level i. Returns array of contexts [root..leaf].
+  const ctxs = [];
+  const makeFactory = (i) => (props) => {
+    const root = document.createElement("div");
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    ctxs[i] = c;
+    if (setups[i]) setups[i](c);
+    if (i + 1 < depth) {
+      const a = anchorAppend(root);
+      mountChild(c, a, makeFactory(i + 1), {});
+    }
+    return root;
+  };
+  makeFactory(0)();
+  return ctxs;
+}
+
+test("inject resolves a value provided by an ancestor (3 levels)", () => {
+  const ctxs = chain(3, [
+    (c) => provide(c, "theme", "dark"),
+    () => {},
+    () => {},
+  ]);
+  assert.equal(inject(ctxs[2], "theme"), "dark");
+  assert.equal(inject(ctxs[1], "theme"), "dark");
+  assert.equal(inject(ctxs[0], "theme"), "dark");
+});
+
+test("nearest ancestor shadows a farther one", () => {
+  const ctxs = chain(3, [
+    (c) => provide(c, "k", "root"),
+    (c) => provide(c, "k", "mid"), // shadows root
+    () => {},
+  ]);
+  assert.equal(inject(ctxs[2], "k"), "mid");
+  assert.equal(inject(ctxs[0], "k"), "root");
+});
+
+test("inject returns default when nothing provides the key", () => {
+  const ctxs = chain(2, [() => {}, () => {}]);
+  assert.equal(inject(ctxs[1], "missing", "fallback"), "fallback");
+  assert.equal(inject(ctxs[1], "missing"), undefined);
+});
+
+test("symbol keys are supported and distinct from strings", () => {
+  const KEY = Symbol("store");
+  const ctxs = chain(2, [(c) => provide(c, KEY, { count: 1 }), () => {}]);
+  assert.deepEqual(inject(ctxs[1], KEY), { count: 1 });
+  assert.equal(inject(ctxs[1], "store", "no"), "no"); // string "store" ≠ Symbol
+});
+
+test("hasInjection distinguishes provided-undefined from absent", () => {
+  const ctxs = chain(2, [(c) => provide(c, "maybe", undefined), () => {}]);
+  assert.equal(hasInjection(ctxs[1], "maybe"), true);
+  assert.equal(inject(ctxs[1], "maybe", "def"), undefined); // provided value wins
+  assert.equal(hasInjection(ctxs[1], "nope"), false);
+});
+
+test("root component with no parent injects the default", () => {
+  const c = createContext(document.createElement("div"));
+  assert.equal(c.parent, null);
+  assert.equal(inject(c, "x", 42), 42);
+});

--- a/packages/lunas/test/transition.browser.mjs
+++ b/packages/lunas/test/transition.browser.mjs
@@ -1,0 +1,105 @@
+// transition.browser.mjs — the browser-path half of transition.test.mjs.
+// Spawned as a child process so we can install a fake requestAnimationFrame
+// BEFORE importing transition.mjs (which reads rAF at import time). Exits 0 on
+// success, throws (nonzero) on failure. Not a *.test.mjs file, so run-all skips
+// it; the parent transition.test.mjs invokes it.
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+
+installDom();
+
+// Fake rAF: queue callbacks; `drainFrames(n)` runs n frames. transition.mjs
+// double-rafs (rAF inside rAF), so one logical "next frame" = draining twice.
+let rafQueue = [];
+globalThis.requestAnimationFrame = (fn) => {
+  rafQueue.push(fn);
+  return rafQueue.length;
+};
+function drainRaf() {
+  const q = rafQueue;
+  rafQueue = [];
+  for (const fn of q) fn();
+}
+// Drain until the double-raf resolves (queue empties or a bounded number of hops).
+function settleFrames() {
+  let guard = 0;
+  while (rafQueue.length && guard++ < 10) drainRaf();
+}
+
+const { withTransition, runPhase } = await import("../src/transition.mjs");
+
+const cls = (el) => el.classList.toArray().sort();
+
+// --- runPhase enter: frame 0 classes, frame 1 swap, transitionend finish -----
+{
+  const el = document.createElement("div");
+  let finished = false;
+  runPhase(el, "fade", "enter", { duration: 10000 }, () => (finished = true));
+  // frame 0 (synchronous): from + active present, to absent.
+  assert.deepEqual(cls(el), ["fade-enter-active", "fade-enter-from"]);
+  assert.equal(finished, false);
+
+  settleFrames(); // advance the double-raf → step2 swaps from→to
+  assert.deepEqual(cls(el), ["fade-enter-active", "fade-enter-to"]);
+  assert.equal(finished, false);
+
+  // transitionend on the element itself completes the phase.
+  el.dispatch("transitionend");
+  assert.equal(finished, true);
+  // cleanup removed active + to.
+  assert.deepEqual(cls(el), []);
+}
+
+// --- runPhase ignores transitionend bubbled from a child --------------------
+{
+  const el = document.createElement("div");
+  const child = document.createElement("span");
+  el.appendChild(child);
+  let finished = false;
+  runPhase(el, "v", "leave", { duration: 10000 }, () => (finished = true));
+  settleFrames();
+  // event target = child, not el → ignored.
+  el.dispatch("transitionend", { target: child });
+  assert.equal(finished, false);
+  el.dispatch("transitionend"); // target = el → finishes
+  assert.equal(finished, true);
+}
+
+// --- timeout fallback finishes when transitionend never fires ---------------
+{
+  const el = document.createElement("div");
+  let finished = false;
+  // duration 0 → setTimeout(…, 0). Await a macrotask.
+  runPhase(el, "v", "enter", { duration: 0 }, () => (finished = true));
+  settleFrames();
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(finished, true);
+}
+
+// --- withTransition.leave waits for ALL nodes before removing ---------------
+{
+  const t = withTransition({ name: "slide", duration: 10000 });
+  const a = document.createElement("div");
+  const b = document.createElement("div");
+  let removed = false;
+  t.leave([a, b], () => (removed = true));
+  settleFrames();
+  a.dispatch("transitionend");
+  assert.equal(removed, false); // b still pending
+  b.dispatch("transitionend");
+  assert.equal(removed, true);
+}
+
+// --- withTransition.enter inserts then animates -----------------------------
+{
+  const t = withTransition({ name: "pop", duration: 10000 });
+  const el = document.createElement("div");
+  let inserted = false;
+  t.enter(el, () => (inserted = true));
+  assert.equal(inserted, true);
+  // frame 0 classes present.
+  assert.deepEqual(cls(el), ["pop-enter-active", "pop-enter-from"]);
+}
+
+console.log("transition.browser.mjs: all assertions passed");

--- a/packages/lunas/test/transition.test.mjs
+++ b/packages/lunas/test/transition.test.mjs
@@ -1,0 +1,70 @@
+// transition.test.mjs — CSS-class enter/leave sequencing + degradation.
+// Run: node packages/lunas/test/transition.test.mjs
+//
+// The transition module reads `requestAnimationFrame` at IMPORT time to pick
+// its browser vs. degraded path. So the two paths are exercised in separate
+// child processes: this file runs the degraded (non-browser) path directly, and
+// spawns a subprocess with a fake rAF installed for the browser path.
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { installDom } from "./dom-shim.mjs";
+
+installDom();
+
+const cls = (el) => el.classList.toArray();
+
+// --- degraded path (this process has no requestAnimationFrame) ---------------
+
+test("degraded: enter runs the class sequence synchronously and finishes", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "fade" });
+  const el = document.createElement("div");
+  let inserted = false;
+  t.enter(el, () => {
+    inserted = true;
+  });
+  assert.equal(inserted, true); // insert ran
+  // In degraded mode the whole sequence collapses: from removed, to removed,
+  // active removed → element ends with NO transition classes.
+  assert.deepEqual(cls(el), []);
+});
+
+test("degraded: leave removes the node immediately (no CSS engine)", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "fade" });
+  const host = document.createElement("div");
+  const el = document.createElement("span");
+  host.appendChild(el);
+  let removed = false;
+  t.leave(el, () => {
+    removed = true;
+    el.remove();
+  });
+  assert.equal(removed, true);
+  assert.equal(el.parentNode, null);
+});
+
+test("degraded: leave with empty node list still calls remove once", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "x" });
+  let n = 0;
+  t.leave([], () => n++);
+  assert.equal(n, 1);
+});
+
+// --- browser path (subprocess with fake rAF + transitionend) -----------------
+
+test("browser path: class choreography over frames + transitionend", () => {
+  const here = fileURLToPath(import.meta.url);
+  const dir = here.slice(0, here.lastIndexOf("/"));
+  const res = spawnSync(process.execPath, [dir + "/transition.browser.mjs"], {
+    encoding: "utf8",
+  });
+  if (res.status !== 0) {
+    console.error(res.stdout, res.stderr);
+  }
+  assert.equal(res.status, 0, "browser-path subprocess should pass");
+});

--- a/packages/lunas/types/core.d.ts
+++ b/packages/lunas/types/core.d.ts
@@ -33,6 +33,12 @@ export interface Context<R = unknown> {
   scope: Scope | null;
   post: (() => void)[] | null;
   batchDepth?: number;
+  /** Link to the parent component's context (set by mountChild); null on a
+   *  root. provide/inject (provide.mjs) walks this chain. Additive. */
+  parent: Context | null;
+  /** Optional per-context post-update hook the flush loop invokes after an
+   *  update pass that actually ran; wired by onUpdate (lifecycle.mjs). */
+  onUpdate: (() => void) | null;
 }
 
 /** Create a fresh reactive context rooted at `root`. */

--- a/packages/lunas/types/emits.d.ts
+++ b/packages/lunas/types/emits.d.ts
@@ -1,0 +1,22 @@
+// emits.d.ts — types for src/emits.mjs
+// Child → parent events (c-emits).
+
+import type { Context } from "./core.js";
+
+/** eventPropName("save") → "onSave"; ("save-all") → "onSaveAll". The `@name`
+ *  → `onName` mapping the codegen uses for component-tag event listeners. */
+export function eventPropName(name: string): string;
+
+/** registerEmits(c, props, declared?) — stash the child's props so `emit` can
+ *  find `on<Name>` handlers; optionally record declared event names for lean
+ *  (warn-only) validation. Called at the top of a child `setup`. Returns `c`. */
+export function registerEmits<P = Record<string, unknown>>(
+  c: Context,
+  props: P,
+  declared?: string[]
+): Context;
+
+/** emit(c, name, payload?) — invoke the parent's `on<Name>` handler if present.
+ *  Returns true if a handler ran. Never marks the parent dirty by itself — the
+ *  handler decides whether to mutate parent state. */
+export function emit(c: Context, name: string, payload?: unknown): boolean;

--- a/packages/lunas/types/index.d.ts
+++ b/packages/lunas/types/index.d.ts
@@ -90,3 +90,32 @@ export type {
 } from "./async.js";
 
 export { asyncComponent, mountAsyncChild, suspenseBlock } from "./async.js";
+
+export {
+  onMount,
+  onDestroy,
+  onUpdate,
+  onActivated,
+  onDeactivated,
+  attach,
+  isLive,
+} from "./lifecycle.js";
+
+export { emit, registerEmits, eventPropName } from "./emits.js";
+
+export type { InjectionKey } from "./provide.js";
+export { provide, inject, hasInjection } from "./provide.js";
+
+export type {
+  TransitionOptions,
+  TransitionPhase,
+  TransitionController,
+} from "./transition.js";
+export { withTransition, runPhase } from "./transition.js";
+
+export type {
+  KeepAliveOptions,
+  KeepAliveController,
+  KeptChild,
+} from "./keepalive.js";
+export { keepAlive } from "./keepalive.js";

--- a/packages/lunas/types/keepalive.d.ts
+++ b/packages/lunas/types/keepalive.d.ts
@@ -1,0 +1,47 @@
+// keepalive.d.ts — types for src/keepalive.mjs
+// Component instance caching (c-keepalive).
+
+import type { Context } from "./core.js";
+import type { ChildFactory, MountedChild } from "./blocks.js";
+
+/** Options for {@link keepAlive}. */
+export interface KeepAliveOptions {
+  /** LRU capacity; unbounded when omitted. Overflow evicts the least-recently
+   *  shown instance (firing its onDestroy). */
+  max?: number;
+}
+
+/** A mountChild handle extended with the cache key it is stored under. */
+export interface KeptChild extends MountedChild {
+  ctx?: Context;
+  key?: unknown;
+}
+
+/** The controller returned by {@link keepAlive}. */
+export interface KeepAliveController {
+  /** show(c, anchor, key, factory, props?) — make the instance for `key` the
+   *  one mounted before `anchor`, activating a cached instance or mounting a
+   *  fresh one and deactivating the previously-shown instance. */
+  show<P = Record<string, unknown>>(
+    c: Context,
+    anchor: Node,
+    key: unknown,
+    factory: ChildFactory<P>,
+    props?: P
+  ): KeptChild;
+  /** has(key) — whether an instance is currently cached. */
+  has(key: unknown): boolean;
+  /** Number of cached instances. */
+  readonly size: number;
+  /** destroy() — evict and destroy every cached instance. */
+  destroy(): void;
+}
+
+/**
+ * keepAlive(opts) — cache mountChild-produced instances by key instead of
+ * destroying them on switch. Deactivation detaches nodes (keeping the context
+ * and reactive state alive); activation re-attaches with no rebuild. Real
+ * eviction (LRU overflow / destroy) fires onDestroy; activate/deactivate fire
+ * onActivated/onDeactivated (lifecycle.mjs).
+ */
+export function keepAlive(opts?: KeepAliveOptions): KeepAliveController;

--- a/packages/lunas/types/lifecycle.d.ts
+++ b/packages/lunas/types/lifecycle.d.ts
@@ -1,0 +1,30 @@
+// lifecycle.d.ts — types for src/lifecycle.mjs
+// Component lifecycle hooks + the attach contract (§7).
+
+import type { Context } from "./core.js";
+
+/** onMount(c, fn) — run `fn` after this component's root attaches to a live
+ *  tree. If already mounted, `fn` runs on the next microtask. */
+export function onMount(c: Context, fn: () => void): void;
+
+/** onDestroy(c, fn) — run `fn` when this component is torn down (fires once). */
+export function onDestroy(c: Context, fn: () => void): void;
+
+/** onUpdate(c, fn) — run `fn` after each flush of `c` that ran updates. */
+export function onUpdate(c: Context, fn: () => void): void;
+
+/** onActivated(c, fn) — keep-alive: run `fn` each time the component is
+ *  (re)activated from the cache (fires on first activation too). */
+export function onActivated(c: Context, fn: () => void): void;
+
+/** onDeactivated(c, fn) — keep-alive: run `fn` each time the component is
+ *  deactivated (cached, not destroyed). */
+export function onDeactivated(c: Context, fn: () => void): void;
+
+/** attach(root, host) — append a detached component root to a live host and
+ *  fire the whole subtree's onMount callbacks. Returns `root`. */
+export function attach<N extends Node>(root: N, host: Node): N;
+
+/** isLive(node) — whether `node` is attached to a live tree (uses
+ *  `Node.isConnected` with a walk-to-root fallback for shims). */
+export function isLive(node: Node | null | undefined): boolean;

--- a/packages/lunas/types/provide.d.ts
+++ b/packages/lunas/types/provide.d.ts
@@ -1,0 +1,23 @@
+// provide.d.ts — types for src/provide.mjs
+// Dependency injection down the component tree (c-provide).
+
+import type { Context } from "./core.js";
+
+/** A provide/inject key: a string or a Symbol. */
+export type InjectionKey = string | symbol;
+
+/** provide(c, key, value) — register `key → value` on this component's context.
+ *  Returns `value`. */
+export function provide<T>(c: Context, key: InjectionKey, value: T): T;
+
+/** inject(c, key, def?) — resolve `key` from the nearest ancestor that provided
+ *  it (self included), else return `def` (default `undefined`). */
+export function inject<T = unknown>(
+  c: Context,
+  key: InjectionKey,
+  def?: T
+): T | undefined;
+
+/** hasInjection(c, key) — whether any ancestor (or self) provides `key`. Lets a
+ *  caller distinguish "provided undefined" from "not provided". */
+export function hasInjection(c: Context, key: InjectionKey): boolean;

--- a/packages/lunas/types/transition.d.ts
+++ b/packages/lunas/types/transition.d.ts
@@ -1,0 +1,48 @@
+// transition.d.ts — types for src/transition.mjs
+// CSS-class enter/leave transitions (c-transition).
+
+/** Options for {@link withTransition} / {@link runPhase}. */
+export interface TransitionOptions {
+  /** Class base name (default "v"); classes are `name-enter-from` etc. */
+  name?: string;
+  /** Fallback timeout in ms after which a phase completes even if no
+   *  `transitionend` fires (0 → next macrotask). */
+  duration?: number;
+}
+
+/** The transition phase: entering or leaving. */
+export type TransitionPhase = "enter" | "leave";
+
+/**
+ * runPhase(el, base, phase, opts, done) — run one enter/leave class
+ * choreography on a single element:
+ *   frame 0  + base-phase-from  + base-phase-active
+ *   frame 1  − base-phase-from  + base-phase-to
+ *   end      − base-phase-active − base-phase-to  (transitionend / timeout)
+ * Calls `done()` when the phase completes. In a non-browser env (no
+ * requestAnimationFrame) the sequence runs synchronously and `done()` fires
+ * immediately. Returns a `cancel()`.
+ */
+export function runPhase(
+  el: Element,
+  base: string,
+  phase: TransitionPhase,
+  opts: TransitionOptions | undefined,
+  done: (() => void) | null
+): () => void;
+
+/** The controller returned by {@link withTransition}. */
+export interface TransitionController {
+  /** enter(nodes, insert) — insert the nodes, then choreograph enter classes. */
+  enter(nodes: Node | Node[], insert: () => void): void;
+  /** leave(nodes, remove) — choreograph leave classes, then call `remove()`
+   *  once every node's leave phase finishes. */
+  leave(nodes: Node | Node[], remove: () => void): void;
+}
+
+/**
+ * withTransition(opts) — build a transition controller composing with a block's
+ * insert/remove closures. Degrades to immediate insert/remove (with the class
+ * sequence still applied synchronously) outside a browser.
+ */
+export function withTransition(opts?: TransitionOptions): TransitionController;

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -91,12 +91,12 @@ tree:
       children:
         - { id: c-props, title: "Props (@input)", status: done }
         - { id: c-slots, title: "Slots (default / named / scoped)", status: todo }
-        - { id: c-emits, title: "Events / emits (child → parent)", status: todo }
-        - { id: c-lifecycle, title: "Lifecycle hooks (mount/update/destroy)", status: todo }
-        - { id: c-provide, title: "Provide / inject (DI)", status: todo }
+        - { id: c-emits, title: "Events / emits (child → parent)", status: done }
+        - { id: c-lifecycle, title: "Lifecycle hooks (mount/update/destroy)", status: done }
+        - { id: c-provide, title: "Provide / inject (DI)", status: done }
         - { id: c-async, title: "Async / lazy components", status: done }
-        - { id: c-transition, title: "Transitions & animations", status: todo }
-        - { id: c-keepalive, title: "Keep-alive (component caching)", status: todo }
+        - { id: c-transition, title: "Transitions & animations", status: done }
+        - { id: c-keepalive, title: "Keep-alive (component caching)", status: done }
     - id: app
       title: Application layer
       status: todo


### PR DESCRIPTION
Adds five component-model runtime primitives to the Lunas JS runtime
(`packages/lunas`), completing the roadmap items **c-lifecycle, c-emits,
c-provide, c-transition, c-keepalive**. Runtime-only; the codegen mapping for
each is documented in `output-design.md` §5–6 for the future generator.

## Modules

- **`lifecycle.mjs`** — `onMount` / `onDestroy` / `onUpdate` (+ `onActivated` /
  `onDeactivated` for keep-alive). `component()` returns a detached root, so
  `onMount` queues on the context and drains when the root goes live: via the
  new **`attach(root, host)`** top-level mount entry, or `mountChild` when the
  insertion point is already connected (`isConnected` + shim fallback).
  `onDestroy` funnels through every unmount path exactly once; `onUpdate` fires
  after each flush that ran updates.
- **`emits.mjs`** — `emit(c, "name", payload)` invokes the parent's `on<Name>`
  handler prop (`@save` → `onSave` — the documented codegen mapping). Never
  marks the parent dirty by itself; the handler decides. Optional warn-only
  `emits` validation.
- **`provide.mjs`** — `provide` / `inject` (+ `hasInjection`) walking the
  `mountChild` parent-context chain; nearest ancestor shadows, string/Symbol
  keys, default when unprovided.
- **`transition.mjs`** — `withTransition({ name, duration })` composes CSS-class
  enter/leave choreography with a block's insert/remove; frame classes +
  `transitionend`/timeout, node removed only after the leave phase. Degrades to
  immediate insert/remove outside a browser (class sequence still applied).
- **`keepalive.mjs`** — `keepAlive({ max })` caches `mountChild` instances by
  key: deactivate detaches nodes (keeps ctx + reactive state), activate
  re-attaches with no rebuild. Keyed LRU; overflow/`destroy()` is the only path
  that fires `onDestroy`.

## Additive core changes (smallest possible, no refactors)

- `createContext` gains `parent` (child→parent link) and `onUpdate` (a per-
  context post-flush hook the core `flush` invokes only when an update pass ran).
- `mountChild` links `childCtx.parent = c`, registers the child under
  `c._children` for subtree mount/destroy recursion, drains `onMount` when live,
  and fires `onDestroy` on `unmount()`.

## Tests

31 new tests across 5 files, all green via `node test/run-all.mjs` (15/15 files
pass). Covers fire-once/ordering incl. unmount paths and nested children; emit
→ parent handler with payload + no-parent no-op + no auto-dirty; provide/inject
3-level + shadowing + Symbol + default; transition class sequencing (fake rAF +
`transitionend` dispatch in a subprocess) + non-browser degradation; keep-alive
node-identity cache hit, LRU eviction firing destroy, activate/deactivate hooks.
The DOM shim gains `classList`, `isConnected`, and `transitionend` dispatch
(dependency-free). Types are strict-clean; new subpath exports + README rows +
`output-design.md` blocks appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)