### PR TITLE
feat(tooling): Vite plugin + create-lunas scaffolding CLI (wasm compiler bindings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,46 @@ jobs:
 
       - name: Tree-shaking / no-side-effects check
         run: node test/treeshake.check.mjs
+
+  tooling:
+    name: tooling tests (vite plugin · create-lunas)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install toolchain + wasm target (from rust-toolchain.toml)
+        working-directory: crates
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup target add wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            crates/target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('crates/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      # Build the wasm compiler once so the plugin's opt-in integration test
+      # runs the real end-to-end path (mock-compiler unit tests run regardless).
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build lunas_wasm (nodejs target)
+        working-directory: crates/lunas_wasm
+        run: wasm-pack build --target nodejs
+
+      - name: vite-plugin-lunas tests
+        working-directory: packages/vite-plugin-lunas
+        run: node test/run-all.mjs
+
+      - name: create-lunas tests
+        working-directory: packages/create-lunas
+        run: node test/run-all.mjs

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -705,6 +705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lunas_wasm"
+version = "0.1.0"
+dependencies = [
+ "lunas_compiler",
+ "lunas_span",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "lunas_parser",
     "lunas_compiler",
     "lunas_css",
+    "lunas_wasm",
 ]

--- a/crates/lunas_compiler/tests/scaffold_template.rs
+++ b/crates/lunas_compiler/tests/scaffold_template.rs
@@ -1,0 +1,36 @@
+//! Guards that the `create-lunas` scaffolding template's root component stays
+//! valid for the current compiler: it must compile to a module with no error
+//! diagnostics. If a compiler change breaks the shipped starter, this fails
+//! loudly instead of the user hitting it after `npm create lunas`.
+
+use std::path::PathBuf;
+
+/// Path to `packages/create-lunas/template/src/App.lunas` from this crate.
+fn template_app() -> PathBuf {
+    // CARGO_MANIFEST_DIR = crates/lunas_compiler
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // crates
+        .unwrap()
+        .parent() // repo root
+        .unwrap()
+        .join("packages/create-lunas/template/src/App.lunas")
+}
+
+#[test]
+fn scaffold_template_app_compiles_without_errors() {
+    let path = template_app();
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()));
+
+    let (code, diags) = lunas_compiler::compile(&source);
+
+    let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+    assert!(
+        errors.is_empty(),
+        "template App.lunas has compile errors: {errors:?}"
+    );
+    assert!(
+        code.is_some(),
+        "template App.lunas produced no module output"
+    );
+}

--- a/crates/lunas_wasm/.gitignore
+++ b/crates/lunas_wasm/.gitignore
@@ -1,0 +1,2 @@
+/pkg
+/pkg-web

--- a/crates/lunas_wasm/Cargo.toml
+++ b/crates/lunas_wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lunas_wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Thin wasm-bindgen bindings over the Lunas compiler: compile a .lunas source string to JS + diagnostics from JavaScript."
+repository = "https://github.com/lunasrun/lunas"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+lunas_compiler = { path = "../lunas_compiler" }
+lunas_span = { path = "../lunas_span" }
+serde = { version = "1", features = ["derive"] }
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"

--- a/crates/lunas_wasm/README.md
+++ b/crates/lunas_wasm/README.md
@@ -1,0 +1,56 @@
+# lunas_wasm
+
+Thin [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) bindings over
+the Lunas compiler. It exposes one function — `compile(source)` — that turns a
+`.lunas`/`.lun` source string into a compiled ES module plus diagnostics, from
+JavaScript.
+
+This crate is **bindings only**: all logic lives in `lunas_compiler`. It exists
+so a bundler plugin (`packages/vite-plugin-lunas`) or a browser playground can
+run the real compiler without a native toolchain.
+
+## API
+
+```js
+import { compile, version } from "lunas_wasm";
+
+const { code, diagnostics } = compile(source);
+// code:        string | null   — the emitted ES module (null on failure)
+// diagnostics: Array<{ message, severity, start, end }>
+//   severity:  "error" | "warning" | "hint"
+//   start/end: UTF-8 byte offsets into `source`
+```
+
+`compile` never throws for compiler problems — they come back as
+`diagnostics`. `code` is `null` when there is an error (or nothing to emit).
+
+## Building
+
+Requires [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) and the
+`wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`).
+
+Build from **this crate's directory** (`crates/lunas_wasm`):
+
+```sh
+# Node target (what the Vite plugin loads by default) → ./pkg
+wasm-pack build --target nodejs
+
+# Browser/bundler target (for a playground or the `web` build) → ./pkg-web
+wasm-pack build --target web --out-dir pkg-web
+```
+
+Each build produces a JS wrapper + `lunas_wasm_bg.wasm` in the out dir. The
+Vite plugin looks for the `nodejs` build at `crates/lunas_wasm/pkg` by default;
+override the location with the plugin's `wasmPkgPath` option or the
+`LUNAS_WASM_PKG` environment variable (see `packages/vite-plugin-lunas`).
+
+`pkg/` and `pkg-web/` are build artifacts and are git-ignored.
+
+## Notes
+
+- The `rlib` crate type is kept alongside `cdylib` so the host
+  `cargo test --workspace` can exercise the pure-Rust adapter logic (diagnostic
+  flattening, error passthrough) without a wasm runtime.
+- Spans are UTF-8 byte offsets, matching the compiler. A JS consumer that needs
+  line/column (e.g. for editor squiggles) builds its own line index over the
+  original source.

--- a/crates/lunas_wasm/src/lib.rs
+++ b/crates/lunas_wasm/src/lib.rs
@@ -1,0 +1,124 @@
+//! Thin [`wasm-bindgen`] bindings over the Lunas compiler.
+//!
+//! This crate contains **no compiler logic** — it only adapts
+//! [`lunas_compiler::compile`] into a shape JavaScript can consume, and
+//! serializes the resulting diagnostics into plain JS objects. Build it with
+//! `wasm-pack` (see the crate README) and load the generated package from a
+//! bundler plugin or the browser.
+//!
+//! The single entry point is [`compile`], which returns a JS value shaped like:
+//!
+//! ```js
+//! {
+//!   code: string | null,          // the emitted ES module, or null on failure
+//!   diagnostics: Array<{
+//!     message: string,
+//!     severity: "error" | "warning" | "hint",
+//!     start: number,              // byte offset (inclusive)
+//!     end: number,                // byte offset (exclusive)
+//!   }>
+//! }
+//! ```
+//!
+//! Byte offsets index the original source string; a JS consumer maps them to
+//! line/column with its own line index (the offsets are UTF-8 byte offsets,
+//! matching the compiler's spans).
+
+use lunas_span::{Diagnostic, Severity};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+/// One diagnostic, flattened for JavaScript: `range` is unwrapped to
+/// `start`/`end` byte offsets and `severity` is a lowercase string.
+#[derive(Serialize)]
+struct JsDiagnostic {
+    message: String,
+    severity: &'static str,
+    start: u32,
+    end: u32,
+}
+
+impl From<&Diagnostic> for JsDiagnostic {
+    fn from(d: &Diagnostic) -> Self {
+        JsDiagnostic {
+            message: d.message.clone(),
+            severity: match d.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Hint => "hint",
+            },
+            start: d.range.start().raw(),
+            end: d.range.end().raw(),
+        }
+    }
+}
+
+/// The result of a [`compile`] call, serialized to a plain JS object.
+#[derive(Serialize)]
+struct CompileResult {
+    code: Option<String>,
+    diagnostics: Vec<JsDiagnostic>,
+}
+
+/// Compiles a `.lunas`/`.lun` source string into an ES module.
+///
+/// Never throws: parse/resolve problems are returned as `diagnostics`, and a
+/// missing/unemittable module yields `code: null`. Mirrors
+/// [`lunas_compiler::compile`] exactly — this is only the serialization shim.
+///
+/// Returns a JS object `{ code, diagnostics }` (see the crate-level docs for
+/// the exact shape).
+#[wasm_bindgen]
+pub fn compile(source: &str) -> Result<JsValue, JsValue> {
+    let (code, diags) = lunas_compiler::compile(source);
+    let result = CompileResult {
+        code,
+        diagnostics: diags.iter().map(JsDiagnostic::from).collect(),
+    };
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// The compiler package version (the `lunas_wasm` crate version). Useful for a
+/// plugin to log which compiler build is loaded.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These run on the host target (`cargo test --workspace`). They exercise the
+    // pure-Rust adapter logic without wasm-bindgen's JsValue bridge, so the
+    // workspace test job stays green without a wasm runtime.
+
+    #[test]
+    fn diagnostic_flattening_lowercases_and_unwraps_range() {
+        let d = Diagnostic::warning(lunas_span::TextRange::at(3, 8), "careful");
+        let js = JsDiagnostic::from(&d);
+        assert_eq!(js.severity, "warning");
+        assert_eq!(js.start, 3);
+        assert_eq!(js.end, 8);
+        assert_eq!(js.message, "careful");
+    }
+
+    #[test]
+    fn compile_a_valid_component_yields_code_and_no_errors() {
+        let (code, diags) = lunas_compiler::compile(
+            "html:\n    <button @click=\"inc()\">${count}</button>\nscript:\n    let count = 0\n    function inc(){ count++ }\n",
+        );
+        assert!(code.is_some());
+        assert!(!diags.iter().any(|d| d.is_error()));
+    }
+
+    #[test]
+    fn compile_reports_errors_without_panicking() {
+        // A malformed script block surfaces a diagnostic, not a panic.
+        let (_code, diags) =
+            lunas_compiler::compile("html:\n    <p>${x}</p>\nscript:\n    let = = =\n");
+        // Whatever the outcome, the adapter must serialize cleanly.
+        let dtos: Vec<JsDiagnostic> = diags.iter().map(JsDiagnostic::from).collect();
+        assert_eq!(dtos.len(), diags.len());
+    }
+}

--- a/packages/create-lunas/LICENSE
+++ b/packages/create-lunas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lunas Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-lunas/README.md
+++ b/packages/create-lunas/README.md
@@ -1,0 +1,42 @@
+# create-lunas
+
+Scaffold a new [Lunas](https://github.com/lunasrun/lunas) + [Vite](https://vitejs.dev)
+project.
+
+## Usage
+
+```sh
+npm create lunas@latest my-app
+# or
+npm create lunas@latest        # prompts for a project name
+```
+
+Then:
+
+```sh
+cd my-app
+npm install
+npm run dev
+```
+
+## What you get
+
+A minimal Vite app wired up with `vite-plugin-lunas`:
+
+- `index.html` + `src/main.mjs` — mounts the app into `#app` via `attach`.
+- `src/App.lunas` — a root component demonstrating reactive state, an event
+  handler, and `:if` / `:for` in the template.
+- `vite.config.mjs` — the Lunas Vite plugin.
+
+The scaffolder copies the bundled `template/` into your target directory
+(refusing to overwrite a non-empty one) and rewrites the project's package name.
+
+## Development
+
+```sh
+npm test   # scaffolds into a temp dir and asserts the file set + name rewrite
+```
+
+The template's `App.lunas` is also compiled by the Rust test suite
+(`crates/lunas_compiler/tests/scaffold_template.rs`) to guarantee it stays valid
+for the current compiler.

--- a/packages/create-lunas/bin/create-lunas.mjs
+++ b/packages/create-lunas/bin/create-lunas.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// create-lunas — scaffold a new Lunas + Vite project.
+//
+// Usage:
+//   npm create lunas@latest my-app
+//   npm create lunas@latest            # prompts for a project name
+//
+// Plain node ESM, no dependencies. Prompting falls back to a default when
+// stdin is not a TTY (e.g. CI / piped input).
+
+import { createInterface } from "node:readline";
+import { resolve } from "node:path";
+
+import { scaffold, normalizeName } from "../src/scaffold.mjs";
+
+const DEFAULT_NAME = "lunas-app";
+
+async function prompt(question, fallback) {
+  if (!process.stdin.isTTY) return fallback;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise((res) => rl.question(question, res));
+    const trimmed = answer.trim();
+    return trimmed || fallback;
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  // First non-flag CLI arg is the project directory/name.
+  const arg = process.argv.slice(2).find((a) => !a.startsWith("-"));
+  const projectName =
+    arg || (await prompt(`Project name: (${DEFAULT_NAME}) `, DEFAULT_NAME));
+
+  const targetDir = resolve(process.cwd(), projectName);
+  const pkgName = normalizeName(projectName);
+
+  let files;
+  try {
+    files = scaffold({ targetDir, projectName });
+  } catch (err) {
+    console.error("\n✖ " + (err && err.message ? err.message : String(err)));
+    process.exit(1);
+  }
+
+  console.log(`\n✔ Scaffolded ${pkgName} into ${targetDir}`);
+  console.log(`  ${files.length} files written.\n`);
+  console.log("Next steps:");
+  console.log(`  cd ${projectName}`);
+  console.log("  npm install");
+  console.log("  npm run dev\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-lunas/package.json
+++ b/packages/create-lunas/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "create-lunas",
+  "version": "0.0.1-beta.11-alpha.0",
+  "description": "Scaffold a new Lunas + Vite project.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lunasrun/lunas.git",
+    "directory": "packages/create-lunas"
+  },
+  "homepage": "https://github.com/lunasrun/lunas/tree/main/packages/create-lunas#readme",
+  "bugs": {
+    "url": "https://github.com/lunasrun/lunas/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "create-lunas": "./bin/create-lunas.mjs"
+  },
+  "files": [
+    "bin",
+    "src",
+    "template",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node test/run-all.mjs"
+  }
+}

--- a/packages/create-lunas/src/scaffold.mjs
+++ b/packages/create-lunas/src/scaffold.mjs
@@ -1,0 +1,77 @@
+// scaffold.mjs — copy the bundled template/ into a target directory and rewrite
+// the package name. Pure filesystem logic, no prompting, so it is unit-testable.
+//
+// No dependencies beyond node builtins.
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const TEMPLATE_DIR = resolve(here, "..", "template");
+
+// npm package names: lowercase, no spaces, url-safe. Good enough for scaffolding.
+export function normalizeName(raw) {
+  return String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-~._]+/g, "-")
+    .replace(/^[-_.]+|[-_.]+$/g, "") || "lunas-app";
+}
+
+// Is `dir` a safe scaffold target? Missing or empty is fine; a non-empty
+// existing directory is refused (we never overwrite user files).
+export function isEmptyDir(dir) {
+  if (!existsSync(dir)) return true;
+  return readdirSync(dir).length === 0;
+}
+
+// Scaffold the template into `targetDir`, rewriting the project's package name.
+// Returns the list of files written (relative paths), sorted.
+export function scaffold({ targetDir, projectName }) {
+  const dir = resolve(targetDir);
+  if (!isEmptyDir(dir)) {
+    throw new Error(
+      `target directory is not empty: ${dir}\n` +
+        "refusing to overwrite existing files."
+    );
+  }
+  const name = normalizeName(projectName);
+
+  mkdirSync(dir, { recursive: true });
+  // Copy the whole template tree.
+  cpSync(TEMPLATE_DIR, dir, { recursive: true });
+
+  // Rewrite the package name in package.json.
+  const pkgPath = join(dir, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  pkg.name = name;
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+  return listFiles(dir);
+}
+
+// Recursively list files under `dir`, as sorted paths relative to `dir`.
+export function listFiles(dir) {
+  const out = [];
+  const root = resolve(dir);
+  const walk = (cur, prefix) => {
+    for (const entry of readdirSync(cur, { withFileTypes: true })) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(join(cur, entry.name), rel);
+      } else {
+        out.push(rel);
+      }
+    }
+  };
+  walk(root, "");
+  return out.sort();
+}

--- a/packages/create-lunas/template/README.md
+++ b/packages/create-lunas/template/README.md
@@ -1,0 +1,49 @@
+# lunas-app
+
+A minimal [Lunas](https://github.com/lunasrun/lunas) + [Vite](https://vitejs.dev)
+starter, scaffolded with `create-lunas`.
+
+## Getting started
+
+```sh
+npm install
+npm run dev
+```
+
+Then open the printed local URL. Edit `src/App.lunas` and the page updates.
+
+## Scripts
+
+- `npm run dev` — start the Vite dev server (HMR: a `.lunas` change reloads).
+- `npm run build` — production build into `dist/`.
+- `npm run preview` — preview the production build locally.
+
+## Project layout
+
+- `index.html` — the app shell; mounts into `#app`.
+- `src/main.mjs` — imports the compiled `App.lunas` and `attach`es it.
+- `src/App.lunas` — the root component: reactive state, an event handler, and
+  `:if` / `:for` in the template.
+- `vite.config.mjs` — wires up `vite-plugin-lunas`.
+
+## Notes
+
+The template pins `lunas` and `vite-plugin-lunas` with normal semver ranges. If
+you are developing against a local checkout of the Lunas monorepo instead of the
+published packages, point these at the local builds, e.g.:
+
+```jsonc
+{
+  "dependencies": {
+    // "lunas": "file:../lunas/packages/lunas"
+  },
+  "devDependencies": {
+    // "vite-plugin-lunas": "file:../lunas/packages/vite-plugin-lunas"
+  }
+}
+```
+
+The plugin loads the compiler from the `lunas_wasm` wasm-pack build. In the
+monorepo it defaults to `crates/lunas_wasm/pkg`; override with the plugin's
+`wasmPkgPath` option or the `LUNAS_WASM_PKG` environment variable. See the
+`vite-plugin-lunas` README for details.

--- a/packages/create-lunas/template/index.html
+++ b/packages/create-lunas/template/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lunas App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.mjs"></script>
+  </body>
+</html>

--- a/packages/create-lunas/template/package.json
+++ b/packages/create-lunas/template/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "lunas-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lunas": "^0.0.1"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "vite-plugin-lunas": "^0.0.1"
+  }
+}

--- a/packages/create-lunas/template/src/App.lunas
+++ b/packages/create-lunas/template/src/App.lunas
@@ -1,0 +1,29 @@
+html:
+    <main class="app">
+        <h1>Lunas Counter</h1>
+        <p>Count: ${count}</p>
+        <button @click="increment()">+1</button>
+        <button @click="reset()">Reset</button>
+        <p :if="count == 0">Click the button to begin.</p>
+        <p :elseif="count > 5">You are on a roll!</p>
+        <p :else>Keep going.</p>
+        <ul>
+            <li :for="n of history">Was ${n}</li>
+        </ul>
+    </main>
+
+style:
+    .app { font-family: sans-serif; max-width: 40rem; margin: 2rem auto; }
+    button { margin-right: 0.5rem; }
+
+script:
+    let count = 0
+    let history = []
+    function increment() {
+        history = [...history, count]
+        count = count + 1
+    }
+    function reset() {
+        count = 0
+        history = []
+    }

--- a/packages/create-lunas/template/src/main.mjs
+++ b/packages/create-lunas/template/src/main.mjs
@@ -1,0 +1,6 @@
+import { attach } from "lunas";
+import App from "./App.lunas";
+
+// A compiled Lunas component's default export is a factory: call it with props
+// to build a detached root, then `attach` it to a host element in the DOM.
+attach(App(), document.getElementById("app"));

--- a/packages/create-lunas/template/vite.config.mjs
+++ b/packages/create-lunas/template/vite.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import lunas from "vite-plugin-lunas";
+
+export default defineConfig({
+  plugins: [lunas()],
+});

--- a/packages/create-lunas/test/run-all.mjs
+++ b/packages/create-lunas/test/run-all.mjs
@@ -1,0 +1,38 @@
+// run-all.mjs — test driver: discovers every *.test.mjs in this directory and
+// runs each in its own child process. Mirrors packages/lunas/test/run-all.mjs.
+
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const files = readdirSync(here)
+  .filter((f) => f.endsWith(".test.mjs"))
+  .sort();
+
+if (files.length === 0) {
+  console.error("run-all: no *.test.mjs files found in " + here);
+  process.exit(1);
+}
+
+let failed = 0;
+
+for (const file of files) {
+  const full = join(here, file);
+  console.log("\n> node test/" + file);
+  const res = spawnSync(process.execPath, [full], { stdio: "inherit" });
+  if (res.status !== 0) {
+    failed++;
+    console.error("FAIL  " + file + " (exit " + res.status + ")");
+  }
+}
+
+console.log("");
+if (failed > 0) {
+  console.error(failed + "/" + files.length + " test file(s) failed.");
+  process.exit(1);
+}
+
+console.log("all " + files.length + " test file(s) passed.");

--- a/packages/create-lunas/test/scaffold.test.mjs
+++ b/packages/create-lunas/test/scaffold.test.mjs
@@ -1,0 +1,89 @@
+// scaffold.test.mjs — scaffold into a temp dir; assert the file set and the
+// package-name rewrite. Run: node packages/create-lunas/test/scaffold.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  scaffold,
+  normalizeName,
+  isEmptyDir,
+  listFiles,
+  TEMPLATE_DIR,
+} from "../src/scaffold.mjs";
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), "create-lunas-"));
+}
+
+test("normalizeName sanitizes to a valid npm name", () => {
+  assert.strictEqual(normalizeName("My App"), "my-app");
+  assert.strictEqual(normalizeName("  Foo/Bar  "), "foo-bar");
+  assert.strictEqual(normalizeName("Ok-Name_1.2"), "ok-name_1.2");
+  assert.strictEqual(normalizeName(""), "lunas-app");
+  assert.strictEqual(normalizeName("!!!"), "lunas-app");
+});
+
+test("scaffold writes the expected file set", () => {
+  const base = tmp();
+  const target = join(base, "my-app");
+  const files = scaffold({ targetDir: target, projectName: "My App" });
+
+  // Compare against the template's own file set (name rewrite doesn't add/remove
+  // files), so this test stays correct if the template grows.
+  const expected = listFiles(TEMPLATE_DIR);
+  assert.deepStrictEqual(files, expected);
+
+  // Spot-check the essential files are present.
+  for (const f of ["package.json", "index.html", "vite.config.mjs", "src/main.mjs", "src/App.lunas"]) {
+    assert.ok(files.includes(f), `expected ${f} in scaffold`);
+  }
+  rmSync(base, { recursive: true, force: true });
+});
+
+test("scaffold rewrites the package name", () => {
+  const base = tmp();
+  const target = join(base, "cool-thing");
+  scaffold({ targetDir: target, projectName: "Cool Thing" });
+  const pkg = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
+  assert.strictEqual(pkg.name, "cool-thing");
+  // Deps are preserved from the template.
+  assert.ok(pkg.dependencies.lunas);
+  assert.ok(pkg.devDependencies["vite-plugin-lunas"]);
+  assert.ok(pkg.devDependencies.vite);
+  rmSync(base, { recursive: true, force: true });
+});
+
+test("template deps use real semver ranges, not file: paths", () => {
+  const pkg = JSON.parse(readFileSync(join(TEMPLATE_DIR, "package.json"), "utf8"));
+  const all = { ...pkg.dependencies, ...pkg.devDependencies };
+  for (const [name, range] of Object.entries(all)) {
+    assert.ok(!range.startsWith("file:"), `${name} should not use a file: path`);
+  }
+});
+
+test("scaffold refuses a non-empty target dir", () => {
+  const base = tmp();
+  const target = join(base, "occupied");
+  mkdirSync(target, { recursive: true });
+  writeFileSync(join(target, "keep.txt"), "hi");
+  assert.throws(
+    () => scaffold({ targetDir: target, projectName: "x" }),
+    /not empty/
+  );
+  rmSync(base, { recursive: true, force: true });
+});
+
+test("isEmptyDir: missing and empty are ok, populated is not", () => {
+  const base = tmp();
+  assert.strictEqual(isEmptyDir(join(base, "nope")), true);
+  const empty = join(base, "empty");
+  mkdirSync(empty);
+  assert.strictEqual(isEmptyDir(empty), true);
+  writeFileSync(join(empty, "f"), "x");
+  assert.strictEqual(isEmptyDir(empty), false);
+  rmSync(base, { recursive: true, force: true });
+});

--- a/packages/vite-plugin-lunas/LICENSE
+++ b/packages/vite-plugin-lunas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lunas Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vite-plugin-lunas/README.md
+++ b/packages/vite-plugin-lunas/README.md
@@ -1,0 +1,89 @@
+# vite-plugin-lunas
+
+[Vite](https://vitejs.dev) plugin that compiles Lunas single-file components
+(`.lunas` / `.lun`) into ES modules with the Lunas compiler. The emitted module
+imports its runtime from the [`lunas`](https://github.com/lunasrun/lunas/tree/main/packages/lunas)
+package.
+
+## Install
+
+```sh
+npm install -D vite-plugin-lunas
+npm install lunas
+```
+
+`vite` is a peer dependency (`>=5`).
+
+## Usage
+
+```js
+// vite.config.mjs
+import { defineConfig } from "vite";
+import lunas from "vite-plugin-lunas";
+
+export default defineConfig({
+  plugins: [lunas()],
+});
+```
+
+Import components as normal modules — their default export is the compiled
+component factory:
+
+```js
+import { attach } from "lunas";
+import App from "./App.lunas";
+
+attach(App(), document.getElementById("app"));
+```
+
+## Options
+
+| Option        | Type              | Default             | Description |
+| ------------- | ----------------- | ------------------- | ----------- |
+| `extensions`  | `string[]`        | `[".lunas", ".lun"]`| File extensions to handle. |
+| `compiler`    | `{ compile }`     | —                   | Inject a compiler `{ compile(source) => { code, diagnostics } }`. Skips wasm loading entirely (used by tests / custom builds). |
+| `wasmPkgPath` | `string`          | —                   | Path to the `wasm-pack --target nodejs` build of the `lunas_wasm` crate (its `pkg` dir or entry file). Overrides `LUNAS_WASM_PKG` and the in-repo default. |
+
+### Compiler loading
+
+The plugin needs a compiler exposing `compile(source) -> { code, diagnostics }`.
+
+1. If `options.compiler` is given, it is used directly (no wasm is loaded).
+2. Otherwise the plugin lazy-loads the `lunas_wasm` wasm-pack (`--target nodejs`)
+   build on the first `.lunas` transform, searching in order:
+   1. `options.wasmPkgPath`
+   2. the `LUNAS_WASM_PKG` environment variable
+   3. `crates/lunas_wasm/pkg` (the in-repo dev default)
+
+Build the wasm compiler with:
+
+```sh
+cd crates/lunas_wasm
+wasm-pack build --target nodejs
+```
+
+(A published `@lunas/compiler-wasm`-style package could replace step 2's default
+in the future; the option/env override keeps that a drop-in change.)
+
+## Diagnostics
+
+Compiler **errors** abort the build via Rollup's `this.error`, with a
+file/line/column and a one-line code frame. **Warnings** and **hints** surface
+via `this.warn` and do not stop compilation. Positions are computed from the
+compiler's UTF-8 byte offsets.
+
+## HMR
+
+A change to a `.lunas`/`.lun` file triggers a full page reload of the modules
+that import it. Finer-grained HMR (patching a live component in place without a
+reload) is future work.
+
+## Development
+
+```sh
+npm test   # node --test unit suite (mock compiler) + opt-in wasm integration
+```
+
+The unit tests inject a mock compiler and need no wasm build. The
+`wasm-integration.test.mjs` file builds and runs the real `lunas_wasm` compiler
+when `wasm-pack` is available, and skips gracefully otherwise.

--- a/packages/vite-plugin-lunas/package.json
+++ b/packages/vite-plugin-lunas/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "vite-plugin-lunas",
+  "version": "0.0.1-beta.11-alpha.0",
+  "description": "Vite plugin that compiles .lunas / .lun single-file components with the Lunas compiler.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lunasrun/lunas.git",
+    "directory": "packages/vite-plugin-lunas"
+  },
+  "homepage": "https://github.com/lunasrun/lunas/tree/main/packages/vite-plugin-lunas#readme",
+  "bugs": {
+    "url": "https://github.com/lunasrun/lunas/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./src/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./src/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "vite": ">=5"
+  },
+  "scripts": {
+    "test": "node test/run-all.mjs"
+  }
+}

--- a/packages/vite-plugin-lunas/src/compiler.mjs
+++ b/packages/vite-plugin-lunas/src/compiler.mjs
@@ -1,0 +1,119 @@
+// compiler.mjs — resolves the compiler the plugin uses.
+//
+// The plugin needs an object with a `compile(source) -> { code, diagnostics }`
+// method. Two ways to provide it:
+//
+//   1. Inject one via `options.compiler` (used by tests and by anyone wiring a
+//      custom / published compiler build). Takes priority — no wasm is loaded.
+//
+//   2. Default: lazy-load the `wasm-pack --target nodejs` build of the
+//      `lunas_wasm` crate. We look for it, in order:
+//        a. `options.wasmPkgPath`   — explicit path to the pkg dir or its entry
+//        b. `process.env.LUNAS_WASM_PKG`
+//        c. the in-repo build at `crates/lunas_wasm/pkg` (dev default)
+//
+// Loading is lazy (first `.lunas` transform) and cached, so a project that
+// injects a compiler never touches the filesystem for wasm.
+
+import { createRequire } from "node:module";
+import { existsSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+// crates/lunas_wasm/pkg relative to this file
+// (packages/vite-plugin-lunas/src -> repo root -> crates/lunas_wasm/pkg).
+const REPO_DEFAULT_PKG = resolve(here, "..", "..", "..", "crates", "lunas_wasm", "pkg");
+
+// Candidate entry-file names inside a wasm-pack `--target nodejs` output dir.
+const ENTRY_CANDIDATES = ["lunas_wasm.js", "lunas_wasm.cjs"];
+
+// Resolve a user-supplied path (dir or file) to a require-able entry file.
+function resolveEntry(p) {
+  const abs = isAbsolute(p) ? p : resolve(process.cwd(), p);
+  if (!existsSync(abs)) return null;
+  if (statSync(abs).isDirectory()) {
+    for (const name of ENTRY_CANDIDATES) {
+      const candidate = join(abs, name);
+      if (existsSync(candidate)) return candidate;
+    }
+    return null;
+  }
+  return abs;
+}
+
+function firstExistingEntry(candidates) {
+  for (const c of candidates) {
+    if (!c) continue;
+    const entry = resolveEntry(c);
+    if (entry) return entry;
+  }
+  return null;
+}
+
+// Build a compiler backed by the wasm-pack nodejs build. Throws a helpful error
+// if the pkg cannot be found or loaded.
+function loadWasmCompiler(wasmPkgPath) {
+  const entry = firstExistingEntry([
+    wasmPkgPath,
+    process.env.LUNAS_WASM_PKG,
+    REPO_DEFAULT_PKG,
+  ]);
+
+  if (!entry) {
+    throw new Error(
+      "[vite-plugin-lunas] could not find the lunas_wasm build. Build it with " +
+        "`wasm-pack build --target nodejs` in crates/lunas_wasm, then point the " +
+        "plugin at it via the `wasmPkgPath` option or the LUNAS_WASM_PKG env var. " +
+        "(Looked at: " +
+        [wasmPkgPath, process.env.LUNAS_WASM_PKG, REPO_DEFAULT_PKG]
+          .filter(Boolean)
+          .join(", ") +
+        ")"
+    );
+  }
+
+  let mod;
+  try {
+    mod = require(entry);
+  } catch (err) {
+    throw new Error(
+      "[vite-plugin-lunas] failed to load the lunas_wasm build at " +
+        entry +
+        ": " +
+        (err && err.message ? err.message : String(err))
+    );
+  }
+
+  if (typeof mod.compile !== "function") {
+    throw new Error(
+      "[vite-plugin-lunas] the module at " +
+        entry +
+        " does not export a `compile` function."
+    );
+  }
+  return { compile: (source) => mod.compile(source) };
+}
+
+// Returns a getter that resolves the compiler once and caches it.
+// `options.compiler` short-circuits everything (no lazy loading).
+export function makeCompilerLoader(options) {
+  const injected = options && options.compiler;
+  if (injected) {
+    if (typeof injected.compile !== "function") {
+      throw new Error(
+        "[vite-plugin-lunas] `options.compiler` must have a `compile(source)` method."
+      );
+    }
+    return () => injected;
+  }
+
+  let cached = null;
+  const wasmPkgPath = options && options.wasmPkgPath;
+  return () => {
+    if (!cached) cached = loadWasmCompiler(wasmPkgPath);
+    return cached;
+  };
+}

--- a/packages/vite-plugin-lunas/src/diagnostics.mjs
+++ b/packages/vite-plugin-lunas/src/diagnostics.mjs
@@ -1,0 +1,66 @@
+// diagnostics.mjs — map compiler diagnostics to Vite/Rollup error positions.
+//
+// The compiler reports spans as UTF-8 *byte* offsets into the source. Rollup's
+// error `loc` wants 1-based line and 1-based column (in characters). We build a
+// small line index over the source and convert.
+
+// Convert a UTF-8 byte offset to a { line, column, character } position.
+// `line` is 1-based, `column` is 1-based, both suitable for Rollup's `loc`.
+function byteOffsetToPosition(source, byteOffset) {
+  // Walk the string by code point, tracking the running UTF-8 byte length,
+  // until we reach the target byte offset. This is O(n) per lookup but n is a
+  // single component file, and there are only a handful of diagnostics.
+  let bytes = 0;
+  let line = 1;
+  let column = 1;
+  let character = 0;
+
+  if (byteOffset <= 0) return { line, column, character };
+
+  for (const ch of source) {
+    if (bytes >= byteOffset) break;
+    if (ch === "\n") {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+    // UTF-8 byte length of this code point.
+    bytes += utf8Len(ch.codePointAt(0));
+    character += 1;
+  }
+  return { line, column, character };
+}
+
+function utf8Len(codePoint) {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+// Format a single diagnostic into a Rollup-style error payload:
+// `{ message, id, loc: { file, line, column }, frame }`.
+export function toRollupError(diag, id, source) {
+  const pos = byteOffsetToPosition(source, diag.start);
+  const frame = codeFrame(source, pos.line, pos.column);
+  return {
+    message: diag.message,
+    id,
+    loc: { file: id, line: pos.line, column: pos.column },
+    frame,
+  };
+}
+
+// A one-line code frame: the offending source line plus a caret under the
+// column. Kept dependency-free and intentionally minimal.
+export function codeFrame(source, line, column) {
+  const lines = source.split(/\r\n|\r|\n/);
+  const text = lines[line - 1] != null ? lines[line - 1] : "";
+  const gutter = String(line);
+  const pad = " ".repeat(gutter.length);
+  const caret = " ".repeat(Math.max(0, column - 1)) + "^";
+  return `${gutter} | ${text}\n${pad} | ${caret}`;
+}
+
+export { byteOffsetToPosition };

--- a/packages/vite-plugin-lunas/src/index.mjs
+++ b/packages/vite-plugin-lunas/src/index.mjs
@@ -1,0 +1,110 @@
+// vite-plugin-lunas — compile .lunas / .lun single-file components with Vite.
+//
+// The plugin runs each .lunas/.lun module through the Lunas compiler (via the
+// wasm bindings, or an injected compiler) and hands Vite the emitted ES module,
+// which imports its runtime from the `lunas` package.
+//
+// Options:
+//   extensions  string[]  file extensions to handle. Default [".lunas", ".lun"].
+//   compiler    object     inject `{ compile(source) -> { code, diagnostics } }`
+//                          (tests / custom builds). Skips wasm loading entirely.
+//   wasmPkgPath string     path to the `wasm-pack --target nodejs` output dir of
+//                          the lunas_wasm crate (or its entry file). Overrides
+//                          the LUNAS_WASM_PKG env var and the in-repo default.
+//
+// Diagnostics: compiler errors abort the transform via `this.error` (with a
+// file/line/column + code frame); warnings/hints surface via `this.warn`.
+//
+// HMR: a change to a .lunas/.lun file triggers a full reload of the modules
+// that import it (see `handleHotUpdate`). Finer-grained HMR (patching a live
+// component without a reload) is future work.
+
+import { makeCompilerLoader } from "./compiler.mjs";
+import { toRollupError } from "./diagnostics.mjs";
+
+const DEFAULT_EXTENSIONS = [".lunas", ".lun"];
+
+// Strip a Vite query suffix (`?import`, `?t=...`) before extension matching.
+function cleanId(id) {
+  const q = id.indexOf("?");
+  return q === -1 ? id : id.slice(0, q);
+}
+
+function makeMatcher(extensions) {
+  const exts = extensions && extensions.length ? extensions : DEFAULT_EXTENSIONS;
+  return (id) => {
+    const path = cleanId(id);
+    return exts.some((ext) => path.endsWith(ext));
+  };
+}
+
+export default function lunas(options = {}) {
+  const matches = makeMatcher(options.extensions);
+  const getCompiler = makeCompilerLoader(options);
+
+  return {
+    name: "vite-plugin-lunas",
+    enforce: "pre",
+
+    transform(code, id) {
+      if (!matches(id)) return null;
+
+      const path = cleanId(id);
+      let result;
+      try {
+        result = getCompiler().compile(code);
+      } catch (err) {
+        // Loading/invoking the compiler itself failed (e.g. wasm build absent).
+        this.error({
+          message: err && err.message ? err.message : String(err),
+          id: path,
+        });
+        return null;
+      }
+
+      const diagnostics = (result && result.diagnostics) || [];
+      const errors = diagnostics.filter((d) => d.severity === "error");
+      const nonErrors = diagnostics.filter((d) => d.severity !== "error");
+
+      // Surface warnings/hints (non-fatal).
+      for (const d of nonErrors) {
+        this.warn(toRollupError(d, path, code));
+      }
+
+      if (errors.length > 0 || result == null || result.code == null) {
+        // Prefer a real diagnostic; otherwise a generic failure.
+        const first = errors[0];
+        if (first) {
+          this.error(toRollupError(first, path, code));
+        } else {
+          this.error({
+            message: `[vite-plugin-lunas] failed to compile ${path} (no output produced).`,
+            id: path,
+          });
+        }
+        return null;
+      }
+
+      return {
+        code: result.code,
+        // No source map yet: the emitted module is generated, not a
+        // line-preserving transform of the input. Returning null keeps Vite
+        // from fabricating a misleading map.
+        map: null,
+      };
+    },
+
+    handleHotUpdate(ctx) {
+      if (!matches(ctx.file)) return;
+      // Minimal HMR: full-reload the modules that import this component. Vite
+      // reloads the importers when we return the affected module set.
+      const mods = ctx.modules;
+      if (mods && mods.length) {
+        ctx.server.ws.send({ type: "full-reload" });
+        return mods;
+      }
+    },
+  };
+}
+
+export { makeCompilerLoader, toRollupError };

--- a/packages/vite-plugin-lunas/test/diagnostics.test.mjs
+++ b/packages/vite-plugin-lunas/test/diagnostics.test.mjs
@@ -1,0 +1,51 @@
+// diagnostics.test.mjs — byte-offset → line/column mapping and code frames.
+// Run: node packages/vite-plugin-lunas/test/diagnostics.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert";
+
+import { byteOffsetToPosition, codeFrame, toRollupError } from "../src/diagnostics.mjs";
+
+test("offset 0 is line 1, column 1", () => {
+  const p = byteOffsetToPosition("hello", 0);
+  assert.deepStrictEqual(p, { line: 1, column: 1, character: 0 });
+});
+
+test("maps an offset on the second line", () => {
+  const src = "html:\nX";
+  const p = byteOffsetToPosition(src, 6); // just after the newline
+  assert.strictEqual(p.line, 2);
+  assert.strictEqual(p.column, 1);
+});
+
+test("column counts characters within a line", () => {
+  const src = "abcde";
+  assert.strictEqual(byteOffsetToPosition(src, 3).column, 4);
+});
+
+test("multi-byte UTF-8 offsets account for byte length", () => {
+  // "あ" is 3 UTF-8 bytes. A diagnostic at byte 3 lands after it (column 2).
+  const src = "あx";
+  const p = byteOffsetToPosition(src, 3);
+  assert.strictEqual(p.line, 1);
+  assert.strictEqual(p.column, 2);
+});
+
+test("codeFrame shows the offending line and a caret", () => {
+  const frame = codeFrame("html:\n  <bad", 2, 3);
+  assert.ok(frame.includes("  <bad"));
+  assert.ok(frame.includes("^"));
+});
+
+test("toRollupError builds a loc + frame", () => {
+  const src = "html:\n  <p>${x}</p>";
+  const e = toRollupError(
+    { message: "x is not reactive", severity: "warning", start: 8, end: 9 },
+    "/src/App.lunas",
+    src
+  );
+  assert.strictEqual(e.message, "x is not reactive");
+  assert.strictEqual(e.id, "/src/App.lunas");
+  assert.strictEqual(e.loc.line, 2);
+  assert.ok(e.frame.includes("^"));
+});

--- a/packages/vite-plugin-lunas/test/run-all.mjs
+++ b/packages/vite-plugin-lunas/test/run-all.mjs
@@ -1,0 +1,41 @@
+// run-all.mjs — test driver: discovers every *.test.mjs in this directory,
+// runs each in its own child process (node <file>), and fails the whole run if
+// any of them exits nonzero. Mirrors packages/lunas/test/run-all.mjs.
+//
+// No dependencies beyond node's builtin modules.
+
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const files = readdirSync(here)
+  .filter((f) => f.endsWith(".test.mjs"))
+  .sort();
+
+if (files.length === 0) {
+  console.error("run-all: no *.test.mjs files found in " + here);
+  process.exit(1);
+}
+
+let failed = 0;
+
+for (const file of files) {
+  const full = join(here, file);
+  console.log("\n> node test/" + file);
+  const res = spawnSync(process.execPath, [full], { stdio: "inherit" });
+  if (res.status !== 0) {
+    failed++;
+    console.error("FAIL  " + file + " (exit " + res.status + ")");
+  }
+}
+
+console.log("");
+if (failed > 0) {
+  console.error(failed + "/" + files.length + " test file(s) failed.");
+  process.exit(1);
+}
+
+console.log("all " + files.length + " test file(s) passed.");

--- a/packages/vite-plugin-lunas/test/transform.test.mjs
+++ b/packages/vite-plugin-lunas/test/transform.test.mjs
@@ -1,0 +1,162 @@
+// transform.test.mjs — unit tests for the plugin's transform hook with an
+// injected mock compiler (no wasm, no Vite server needed).
+// Run: node packages/vite-plugin-lunas/test/transform.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert";
+
+import lunas from "../src/index.mjs";
+
+// A minimal Rollup/Vite plugin-context stand-in. `this.error` throws (as Rollup
+// does); `this.warn` records the warning.
+function makeCtx() {
+  const warnings = [];
+  return {
+    warnings,
+    warn(w) {
+      warnings.push(w);
+    },
+    error(e) {
+      const err = new Error(typeof e === "string" ? e : e.message);
+      err.payload = e;
+      throw err;
+    },
+  };
+}
+
+// Run the plugin's transform hook with a given plugin instance + context.
+function runTransform(plugin, ctx, code, id) {
+  return plugin.transform.call(ctx, code, id);
+}
+
+// A mock compiler that returns fixed output / diagnostics.
+function mockCompiler({ code = null, diagnostics = [] } = {}) {
+  const calls = [];
+  return {
+    calls,
+    compile(source) {
+      calls.push(source);
+      return { code, diagnostics };
+    },
+  };
+}
+
+test("ignores non-.lunas files (returns null, compiler not called)", () => {
+  const compiler = mockCompiler({ code: "export default 1;" });
+  const plugin = lunas({ compiler });
+  const ctx = makeCtx();
+  assert.strictEqual(runTransform(plugin, ctx, "whatever", "/a/foo.js"), null);
+  assert.strictEqual(runTransform(plugin, ctx, "whatever", "/a/foo.ts"), null);
+  assert.strictEqual(compiler.calls.length, 0);
+});
+
+test("compiles .lunas and passes the emitted code through", () => {
+  const emitted = 'import { component } from "lunas";\nexport default 42;';
+  const compiler = mockCompiler({ code: emitted });
+  const plugin = lunas({ compiler });
+  const ctx = makeCtx();
+  const out = runTransform(plugin, ctx, "html:\n  <p>hi</p>", "/src/App.lunas");
+  assert.ok(out);
+  assert.strictEqual(out.code, emitted);
+  assert.strictEqual(out.map, null);
+  assert.strictEqual(compiler.calls.length, 1);
+});
+
+test("compiles .lun files too", () => {
+  const compiler = mockCompiler({ code: "export default 1;" });
+  const plugin = lunas({ compiler });
+  const out = runTransform(plugin, makeCtx(), "x", "/src/Widget.lun");
+  assert.ok(out);
+  assert.strictEqual(out.code, "export default 1;");
+});
+
+test("strips query suffixes when matching ids", () => {
+  const compiler = mockCompiler({ code: "export default 1;" });
+  const plugin = lunas({ compiler });
+  const out = runTransform(
+    plugin,
+    makeCtx(),
+    "x",
+    "/src/App.lunas?vue&type=script"
+  );
+  assert.ok(out, "an id with a query suffix should still be handled");
+});
+
+test("custom extensions option is honored", () => {
+  const compiler = mockCompiler({ code: "export default 1;" });
+  const plugin = lunas({ compiler, extensions: [".lx"] });
+  const ctx = makeCtx();
+  assert.strictEqual(runTransform(plugin, ctx, "x", "/src/App.lunas"), null);
+  assert.ok(runTransform(plugin, ctx, "x", "/src/App.lx"));
+});
+
+test("error diagnostics abort the transform via this.error with position", () => {
+  const compiler = mockCompiler({
+    code: null,
+    diagnostics: [
+      { message: "unexpected token", severity: "error", start: 6, end: 7 },
+    ],
+  });
+  const plugin = lunas({ compiler });
+  const ctx = makeCtx();
+  // source: "html:\nX" -> byte 6 is line 2, column 1
+  assert.throws(
+    () => runTransform(plugin, ctx, "html:\nX", "/src/App.lunas"),
+    (err) => {
+      assert.strictEqual(err.message, "unexpected token");
+      assert.strictEqual(err.payload.loc.line, 2);
+      assert.strictEqual(err.payload.loc.column, 1);
+      assert.ok(err.payload.frame.includes("^"));
+      return true;
+    }
+  );
+});
+
+test("warning diagnostics surface via this.warn but still emit code", () => {
+  const compiler = mockCompiler({
+    code: "export default 1;",
+    diagnostics: [
+      { message: "unsupported construct voided", severity: "warning", start: 0, end: 1 },
+    ],
+  });
+  const plugin = lunas({ compiler });
+  const ctx = makeCtx();
+  const out = runTransform(plugin, ctx, "html:\n  <p></p>", "/src/App.lunas");
+  assert.ok(out);
+  assert.strictEqual(out.code, "export default 1;");
+  assert.strictEqual(ctx.warnings.length, 1);
+  assert.strictEqual(ctx.warnings[0].message, "unsupported construct voided");
+});
+
+test("null code with no error diagnostics still errors (nothing emitted)", () => {
+  const compiler = mockCompiler({ code: null, diagnostics: [] });
+  const plugin = lunas({ compiler });
+  assert.throws(
+    () => runTransform(plugin, makeCtx(), "html:\n  <p></p>", "/src/App.lunas"),
+    /no output produced/
+  );
+});
+
+test("compiler load/throw failures surface as this.error", () => {
+  const plugin = lunas({
+    compiler: {
+      compile() {
+        throw new Error("boom loading wasm");
+      },
+    },
+  });
+  assert.throws(
+    () => runTransform(plugin, makeCtx(), "html:\n  <p></p>", "/src/App.lunas"),
+    /boom loading wasm/
+  );
+});
+
+test("rejects an injected compiler without a compile method", () => {
+  assert.throws(() => lunas({ compiler: {} }), /must have a `compile/);
+});
+
+test("plugin metadata: name and enforce", () => {
+  const plugin = lunas({ compiler: mockCompiler() });
+  assert.strictEqual(plugin.name, "vite-plugin-lunas");
+  assert.strictEqual(plugin.enforce, "pre");
+});

--- a/packages/vite-plugin-lunas/test/wasm-integration.test.mjs
+++ b/packages/vite-plugin-lunas/test/wasm-integration.test.mjs
@@ -1,0 +1,87 @@
+// wasm-integration.test.mjs — opt-in end-to-end test: build the real
+// lunas_wasm compiler (if wasm-pack is available), then run a fixture .lunas
+// through the plugin's default (wasm-backed) path.
+//
+// Skips gracefully — never fails — when:
+//   - wasm-pack is not installed, or the pkg build is absent, or
+//   - the local node cannot load the wasm module (older node without
+//     reference-types support; CI's node 22 handles it).
+//
+// Run: node packages/vite-plugin-lunas/test/wasm-integration.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+import lunas from "../src/index.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+const wasmCrate = resolve(repoRoot, "crates", "lunas_wasm");
+const pkgEntry = resolve(wasmCrate, "pkg", "lunas_wasm.js");
+const templateApp = resolve(
+  repoRoot,
+  "packages",
+  "create-lunas",
+  "template",
+  "src",
+  "App.lunas"
+);
+
+function hasWasmPack() {
+  const r = spawnSync("wasm-pack", ["--version"], { encoding: "utf8" });
+  return r.status === 0;
+}
+
+// Ensure the pkg exists; build it once if wasm-pack is available.
+function ensurePkg() {
+  if (existsSync(pkgEntry)) return true;
+  if (!hasWasmPack()) return false;
+  const r = spawnSync("wasm-pack", ["build", "--target", "nodejs"], {
+    cwd: wasmCrate,
+    stdio: "inherit",
+  });
+  return r.status === 0 && existsSync(pkgEntry);
+}
+
+test("real wasm compiler compiles the scaffold template via the plugin", async (t) => {
+  if (!ensurePkg()) {
+    t.skip("lunas_wasm pkg unavailable (wasm-pack not installed / build failed)");
+    return;
+  }
+
+  // The default plugin path lazy-loads crates/lunas_wasm/pkg. Guard the load:
+  // an older node may reject the wasm (reference-types), which is an
+  // environment limitation, not a plugin bug — skip in that case.
+  let plugin;
+  try {
+    // Touch the module once to surface a load error before running transform.
+    require(pkgEntry);
+    plugin = lunas();
+  } catch (err) {
+    t.skip("node cannot load the wasm module: " + (err && err.message));
+    return;
+  }
+
+  const source = readFileSync(templateApp, "utf8");
+  const ctx = {
+    warn() {},
+    error(e) {
+      throw new Error(typeof e === "string" ? e : e.message);
+    },
+  };
+
+  const out = plugin.transform.call(ctx, source, templateApp);
+  assert.ok(out, "transform should return output");
+  assert.ok(typeof out.code === "string" && out.code.length > 0);
+  assert.ok(
+    out.code.includes('from "lunas"'),
+    "emitted module should import the lunas runtime"
+  );
+});

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -108,7 +108,7 @@ tree:
         - { id: a-store, title: "Global state / stores", status: done }
     - id: tooling
       title: Tooling
-      status: todo
+      status: done
       children:
-        - { id: to-plugin, title: "Bundler plugin (Vite)", status: todo }
-        - { id: to-cli, title: "Project scaffolding CLI", status: todo }
+        - { id: to-plugin, title: "Bundler plugin (Vite)", status: done }
+        - { id: to-cli, title: "Project scaffolding CLI", status: done }


### PR DESCRIPTION
Adds the tooling layer: wasm compiler bindings, a Vite plugin, and a scaffolding CLI. Closes roadmap `to-plugin` and `to-cli`.

## What's here

### `crates/lunas_wasm` — wasm-bindgen bindings
- Thin bindings over `lunas_compiler::compile`: `compile(source) -> { code: string | null, diagnostics: [{ message, severity, start, end }] }` (severity lowercased; span flattened to UTF-8 byte offsets) via `serde-wasm-bindgen`. Plus a `version()` helper.
- No compiler logic — serialization shim only. `crate-type = ["cdylib", "rlib"]` so host `cargo test --workspace` exercises the pure-Rust adapter without a wasm runtime; wasm32 build stays green.
- README documents `wasm-pack build --target nodejs` / `--target web`. `pkg/` is git-ignored.

### `packages/vite-plugin-lunas` — the Vite plugin
- `transform` hook for `.lunas`/`.lun` → compiled ES module (imports runtime from `lunas`).
- **Compiler loading:** `options.compiler` injection (tests/custom builds) short-circuits everything; otherwise lazy-loads the `lunas_wasm` wasm-pack `--target nodejs` build, resolved from `options.wasmPkgPath` → `LUNAS_WASM_PKG` env → in-repo `crates/lunas_wasm/pkg`.
- Diagnostics: errors → `this.error` (file/line/column + one-line code frame from byte offsets); warnings/hints → `this.warn`.
- HMR: full reload on `.lunas` change (finer HMR noted as future work).
- ESM, `peerDependencies: { vite: ">=5" }`, otherwise dependency-free.
- Tests (`node --test`): transform unit tests with a mock compiler (id filtering, code passthrough, error/warning surfacing), diagnostics position mapping, and an **opt-in** real-wasm integration test that builds the pkg via `wasm-pack` and compiles a fixture end-to-end (skips gracefully when `wasm-pack`/wasm is unavailable).

### `packages/create-lunas` — scaffolding CLI
- Dependency-free node ESM `bin` (`create-lunas`): copies a bundled `template/` into the target dir (refuses a non-empty one) and rewrites the package name; project name via arg or interactive prompt (non-TTY fallback).
- Template: minimal Vite app (`package.json` with real semver ranges — `file:` note lives in the README, `vite.config.mjs`, `index.html`, `src/main.mjs` using `attach`, `src/App.lunas` — a counter showcasing state + event + `:if`/`:elseif`/`:else` + `:for`).
- Tests: scaffold into a temp dir asserting the file set + name rewrite. Template `App.lunas` validity is guarded Rust-side by `crates/lunas_compiler/tests/scaffold_template.rs` (compiles with zero error diagnostics) so a compiler change can't silently break the starter.

## CI
New `tooling` job (node 22 + `wasm-pack`) builds `lunas_wasm` and runs both new package suites, isolated from the existing `runtime` job so the `wasm-pack` install cost stays contained. Existing `wasm32 build` and `cargo test --workspace` jobs keep passing (the new crate compiles for both targets).

## Quality gates (all green locally)
`cargo fmt --all --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` (incl. 3 `lunas_wasm` + `scaffold_template`) · `cargo check --workspace --target wasm32-unknown-unknown` · node suites: vite-plugin-lunas (11 transform + 6 diagnostics + 1 wasm integration) and create-lunas (6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)