### PR TITLE
chore(ci): squash-aware release PR script (replaces git-pr-release)

### DIFF
--- a/.github/pr-release-templates/release-template.erb
+++ b/.github/pr-release-templates/release-template.erb
@@ -1,3 +1,7 @@
+<%# NOTE: This template is no longer used at runtime. The git-pr-release gem %>
+<%# was replaced by .github/scripts/release-pr.mjs, which owns the release-PR %>
+<%# body format now (buildBody()). Kept here as a reference for the original %>
+<%# layout; edits to the live format must go in release-pr.mjs. %>
 🚀 Release (<%= Time.now.strftime('%Y-%m-%d') %> - <%= ENV['GIT_PR_RELEASE_BRANCH_PRODUCTION'] %>)
 ## 🛠 Fixes
 <%- pull_requests.each do |pr| -%>

--- a/.github/scripts/release-pr.mjs
+++ b/.github/scripts/release-pr.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+// Squash-merge-aware release-PR generator (replaces the git-pr-release gem).
+//
+// Determines which PRs are contained in `main` but not `beta`, then creates or
+// updates the open release PR (base=beta, head=main) with a categorized,
+// checkbox-preserving body.
+//
+// Detection strategy
+// ------------------
+// git-pr-release detected released PRs ONLY via `Merge pull request #N` merge
+// commits. This repo squash-merges, so those commits never exist. Instead we:
+//   1. `GET /compare/beta...main` to list the commits in main-not-beta.
+//   2. For each commit, first try to extract the PR number from the subject
+//      (`... (#N)` for squash commits, `Merge pull request #N` for merges) —
+//      this avoids an API round-trip for the common case.
+//   3. For commits without a recognizable subject, fall back to
+//      `GET /commits/{sha}/pulls`, which reports the associated PR(s) for both
+//      squash and merge commits.
+//   4. Dedupe by PR number and fetch each PR's metadata (labels, author).
+//
+// Dependency-free: Node >= 20, global fetch, GITHUB_TOKEN env.
+//
+// Usage:
+//   node .github/scripts/release-pr.mjs            # create/update the release PR
+//   node .github/scripts/release-pr.mjs --dry-run  # print body, no writes
+
+const PRODUCTION_BRANCH = "beta";
+const STAGING_BRANCH = "main";
+const RELEASE_LABEL = "beta";
+
+// Category sections, in output order. Each has a heading and the label that
+// selects PRs into it. `others` is the catch-all for PRs matching no category.
+const CATEGORIES = [
+  { key: "fix", label: "fix", heading: "## 🛠 Fixes" },
+  { key: "feature", label: "feature", heading: "## ✨ New Features" },
+  { key: "refactor", label: "refactor", heading: "## 🔨 Refactoring" },
+  { key: "version", label: "version", heading: "## 📌 Version Updates" },
+  { key: "chore", label: "chore", heading: "## 🔧 Chore" },
+];
+const CATEGORY_LABELS = CATEGORIES.map((c) => c.label);
+const OTHERS_HEADING = "## 👻 Others";
+
+// ---------------------------------------------------------------------------
+// Pure, unit-testable body generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Today's date in Asia/Tokyo as YYYY-MM-DD.
+ * @param {Date} [now]
+ */
+export function tokyoDate(now = new Date()) {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+/**
+ * Parse the set of already-checked PR numbers from an existing PR body.
+ * Matches `- [x] #123` (case-insensitive on the x).
+ * @param {string} body
+ * @returns {Set<number>}
+ */
+export function parseCheckedNumbers(body) {
+  const checked = new Set();
+  if (!body) return checked;
+  const re = /^- \[x\] #(\d+)\b/gim;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    checked.add(Number(m[1]));
+  }
+  return checked;
+}
+
+/**
+ * Build the release PR body from a list of PRs.
+ *
+ * @param {Array<{number: number, login: string, labels: string[]}>} pulls
+ * @param {object} [opts]
+ * @param {string} [opts.date]            YYYY-MM-DD (defaults to Tokyo today)
+ * @param {Set<number>} [opts.checked]    PR numbers to render checked
+ * @returns {string}
+ */
+export function buildBody(pulls, opts = {}) {
+  const date = opts.date ?? tokyoDate();
+  const checked = opts.checked ?? new Set();
+
+  // Sort ascending by PR number for stable output.
+  const sorted = [...pulls].sort((a, b) => a.number - b.number);
+
+  const line = (pr) =>
+    `- [${checked.has(pr.number) ? "x" : " "}] #${pr.number} @${pr.login}`;
+
+  const out = [`🚀 Release (${date} - ${PRODUCTION_BRANCH})`];
+
+  for (const cat of CATEGORIES) {
+    out.push(cat.heading);
+    for (const pr of sorted) {
+      if (pr.labels.includes(cat.label)) out.push(line(pr));
+    }
+  }
+
+  out.push(OTHERS_HEADING);
+  for (const pr of sorted) {
+    if (!pr.labels.some((l) => CATEGORY_LABELS.includes(l))) out.push(line(pr));
+  }
+
+  // Trailing newline to match the ERB template output.
+  return out.join("\n") + "\n";
+}
+
+/**
+ * Extract a PR number from a commit subject.
+ * Handles squash subjects (`... (#123)`) and merge subjects
+ * (`Merge pull request #123 from ...`).
+ * @param {string} subject
+ * @returns {number|null}
+ */
+export function prNumberFromSubject(subject) {
+  if (!subject) return null;
+  const merge = subject.match(/^Merge pull request #(\d+)\b/);
+  if (merge) return Number(merge[1]);
+  const squash = subject.match(/\(#(\d+)\)\s*$/);
+  if (squash) return Number(squash[1]);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub REST helpers
+// ---------------------------------------------------------------------------
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+class GitHub {
+  constructor(token, repo) {
+    this.token = token;
+    this.repo = repo; // "owner/name"
+    this.base = "https://api.github.com";
+  }
+
+  async request(method, path, body) {
+    const url = path.startsWith("http") ? path : `${this.base}${path}`;
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "lunas-release-pr-script",
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `GitHub API ${method} ${url} failed: ${res.status} ${res.statusText}\n${text}`,
+      );
+    }
+    return res;
+  }
+
+  async json(method, path, body) {
+    const res = await this.request(method, path, body);
+    return res.json();
+  }
+
+  /**
+   * Follow RFC 5988 `Link: rel="next"` pagination, yielding each parsed page.
+   */
+  async *paginate(path) {
+    let next = `${this.base}${path}`;
+    while (next) {
+      const res = await this.request("GET", next);
+      yield await res.json();
+      next = parseNextLink(res.headers.get("link"));
+    }
+  }
+}
+
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const m = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Detection: PRs in main but not beta
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all commits in `beta...main` via the compare API, paginating.
+ * Returns an array of { sha, subject }.
+ */
+async function compareCommits(gh) {
+  const commits = [];
+  const path = `/repos/${gh.repo}/compare/${PRODUCTION_BRANCH}...${STAGING_BRANCH}?per_page=100`;
+  for await (const page of gh.paginate(path)) {
+    for (const c of page.commits ?? []) {
+      const subject = (c.commit?.message ?? "").split("\n", 1)[0];
+      commits.push({ sha: c.sha, subject });
+    }
+  }
+  return commits;
+}
+
+/**
+ * Given compare commits, resolve the set of PR numbers.
+ * Subject-first (no API call), falling back to /commits/{sha}/pulls.
+ */
+async function resolvePrNumbers(gh, commits) {
+  const numbers = new Set();
+  for (const c of commits) {
+    const fromSubject = prNumberFromSubject(c.subject);
+    if (fromSubject !== null) {
+      numbers.add(fromSubject);
+      continue;
+    }
+    // Fallback: ask GitHub which PR(s) this commit belongs to.
+    const pulls = await gh.json(
+      "GET",
+      `/repos/${gh.repo}/commits/${c.sha}/pulls?per_page=100`,
+    );
+    for (const p of pulls) {
+      // Only count PRs that merged into the staging branch.
+      if (p.number) numbers.add(p.number);
+    }
+  }
+  return numbers;
+}
+
+/**
+ * Fetch metadata (author login, label names) for each PR number.
+ */
+async function fetchPullDetails(gh, numbers) {
+  const pulls = [];
+  for (const number of numbers) {
+    const pr = await gh.json("GET", `/repos/${gh.repo}/pulls/${number}`);
+    pulls.push({
+      number: pr.number,
+      login: pr.user?.login ?? "unknown",
+      labels: (pr.labels ?? []).map((l) => l.name),
+    });
+  }
+  return pulls;
+}
+
+/**
+ * Find the single open release PR (base=beta, head=main), if any.
+ */
+async function findReleasePr(gh) {
+  const owner = gh.repo.split("/")[0];
+  const list = await gh.json(
+    "GET",
+    `/repos/${gh.repo}/pulls?state=open&base=${PRODUCTION_BRANCH}&head=${owner}:${STAGING_BRANCH}&per_page=100`,
+  );
+  return list[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const token = requireEnv("GITHUB_TOKEN");
+  const repo = requireEnv("GITHUB_REPOSITORY");
+  const gh = new GitHub(token, repo);
+
+  console.log(`Comparing ${PRODUCTION_BRANCH}...${STAGING_BRANCH} in ${repo}`);
+  const commits = await compareCommits(gh);
+  console.log(`Found ${commits.length} commit(s) ahead of ${PRODUCTION_BRANCH}.`);
+
+  const numbers = await resolvePrNumbers(gh, commits);
+  console.log(`Resolved ${numbers.size} unique PR(s).`);
+
+  if (numbers.size === 0) {
+    console.log("No PRs in beta..main — nothing to release. Exiting cleanly.");
+    return;
+  }
+
+  const pulls = await fetchPullDetails(gh, numbers);
+
+  const existing = await findReleasePr(gh);
+  const checked = parseCheckedNumbers(existing?.body ?? "");
+  const body = buildBody(pulls, { checked });
+  const title = body.split("\n", 1)[0];
+
+  if (dryRun) {
+    console.log("\n--- DRY RUN: generated PR body ---\n");
+    console.log(body);
+    console.log("--- end DRY RUN ---");
+    return;
+  }
+
+  if (existing) {
+    console.log(`Updating existing release PR #${existing.number}.`);
+    await gh.json("PATCH", `/repos/${gh.repo}/pulls/${existing.number}`, {
+      title,
+      body,
+    });
+    console.log(`Updated ${existing.html_url}`);
+  } else {
+    console.log("Creating new release PR.");
+    const created = await gh.json("POST", `/repos/${gh.repo}/pulls`, {
+      title,
+      body,
+      base: PRODUCTION_BRANCH,
+      head: STAGING_BRANCH,
+    });
+    // Add the release label (best effort — labeling is separate from creation).
+    await gh.json("POST", `/repos/${gh.repo}/issues/${created.number}/labels`, {
+      labels: [RELEASE_LABEL],
+    });
+    console.log(`Created ${created.html_url}`);
+  }
+}
+
+// Only run main when executed directly (not when imported by tests).
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("release-pr.mjs");
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/release-pr.test.mjs
+++ b/.github/scripts/release-pr.test.mjs
@@ -1,0 +1,98 @@
+// Dependency-free unit tests for the release-PR body generator.
+// Run: node .github/scripts/release-pr.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildBody,
+  parseCheckedNumbers,
+  prNumberFromSubject,
+} from "./release-pr.mjs";
+
+const FIXTURE = [
+  { number: 142, login: "alice", labels: ["feature"] },
+  { number: 133, login: "bob", labels: ["fix"] },
+  { number: 140, login: "carol", labels: ["refactor"] },
+  { number: 138, login: "dave", labels: ["version"] },
+  { number: 135, login: "erin", labels: ["chore"] },
+  { number: 136, login: "frank", labels: ["documentation"] }, // -> Others
+  { number: 137, login: "grace", labels: [] }, // -> Others
+];
+
+test("buildBody categorizes into all sections, sorted ascending", () => {
+  const body = buildBody(FIXTURE, { date: "2026-07-05" });
+  const expected = [
+    "🚀 Release (2026-07-05 - beta)",
+    "## 🛠 Fixes",
+    "- [ ] #133 @bob",
+    "## ✨ New Features",
+    "- [ ] #142 @alice",
+    "## 🔨 Refactoring",
+    "- [ ] #140 @carol",
+    "## 📌 Version Updates",
+    "- [ ] #138 @dave",
+    "## 🔧 Chore",
+    "- [ ] #135 @erin",
+    "## 👻 Others",
+    "- [ ] #136 @frank",
+    "- [ ] #137 @grace",
+    "",
+  ].join("\n");
+  assert.equal(body, expected);
+});
+
+test("empty categories still render their heading (matches ERB)", () => {
+  const body = buildBody([{ number: 1, login: "x", labels: ["feature"] }], {
+    date: "2026-01-01",
+  });
+  assert.match(body, /## 🛠 Fixes\n## ✨ New Features\n- \[ \] #1 @x/);
+  assert.match(body, /## 👻 Others\n$/);
+});
+
+test("parseCheckedNumbers extracts checked PR numbers", () => {
+  const body = [
+    "🚀 Release (2026-07-05 - beta)",
+    "## ✨ New Features",
+    "- [x] #142 @alice",
+    "- [ ] #133 @bob",
+    "- [X] #140 @carol",
+  ].join("\n");
+  const checked = parseCheckedNumbers(body);
+  assert.deepEqual([...checked].sort((a, b) => a - b), [140, 142]);
+});
+
+test("buildBody preserves checked checkboxes", () => {
+  const checked = parseCheckedNumbers("- [x] #142 @alice\n- [ ] #133 @bob");
+  const body = buildBody(FIXTURE, { date: "2026-07-05", checked });
+  assert.match(body, /- \[x\] #142 @alice/);
+  assert.match(body, /- \[ \] #133 @bob/);
+});
+
+test("parseCheckedNumbers on empty/undefined body is empty", () => {
+  assert.equal(parseCheckedNumbers("").size, 0);
+  assert.equal(parseCheckedNumbers(undefined).size, 0);
+});
+
+test("prNumberFromSubject handles squash and merge subjects", () => {
+  assert.equal(
+    prNumberFromSubject("feat(runtime): async components + suspense (#142)"),
+    142,
+  );
+  assert.equal(
+    prNumberFromSubject("Merge pull request #124 from lunasrun/rewrite"),
+    124,
+  );
+  assert.equal(prNumberFromSubject("chore: no pr number here"), null);
+  assert.equal(prNumberFromSubject(""), null);
+});
+
+test("PR with multiple category labels appears in each matching section", () => {
+  const body = buildBody([{ number: 5, login: "z", labels: ["fix", "chore"] }], {
+    date: "2026-07-05",
+  });
+  const fixes = body.indexOf("## 🛠 Fixes");
+  const chore = body.indexOf("## 🔧 Chore");
+  assert.ok(body.slice(fixes, chore).includes("- [ ] #5 @z"));
+  assert.ok(body.slice(chore).includes("- [ ] #5 @z"));
+  // Not in Others.
+  assert.ok(!body.slice(body.indexOf("## 👻 Others")).includes("#5"));
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
         working-directory: crates/lunas_wasm
         run: wasm-pack build --target nodejs
 
+      - name: release-pr script tests
+        run: node --test .github/scripts/release-pr.test.mjs
+
       - name: vite-plugin-lunas tests
         working-directory: packages/vite-plugin-lunas
         run: node test/run-all.mjs

--- a/.github/workflows/pr-release-beta.yml
+++ b/.github/workflows/pr-release-beta.yml
@@ -8,18 +8,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # The script is API-only (uses the compare + commits/{sha}/pulls REST
+      # endpoints), so a shallow checkout is enough — we don't walk git history.
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-      - run: gem install --no-document git-pr-release
-      - run: git-pr-release
+          node-version: 22
+      - name: Generate / update release PR
+        run: node .github/scripts/release-pr.mjs
         env:
-          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_PR_RELEASE_BRANCH_PRODUCTION: beta
-          GIT_PR_RELEASE_BRANCH_STAGING: main
-          GIT_PR_RELEASE_LABELS: beta
-          GIT_PR_RELEASE_TEMPLATE: .github/pr-release-templates/release-template.erb
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_REPOSITORY is provided automatically by GitHub Actions.
           TZ: Asia/Tokyo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,12 @@ Claude drives development from the roadmap autonomously:
      `add-labels.yml`): `feat/` features, `fix/` bug fixes, `refactor/`
      refactors, `chore/` chores, `docs/` documentation, `version/` release
      version bumps. Those same labels categorize PRs into the auto-generated
-     beta release PR (`pr-release-beta.yml`, `git-pr-release` from `main`
-     into `beta`), so picking the right prefix keeps the release notes
-     accurate.
+     beta release PR (`pr-release-beta.yml`, which runs
+     `.github/scripts/release-pr.mjs` to build a release PR from `main` into
+     `beta`), so picking the right prefix keeps the release notes accurate.
+     The script is squash-merge aware: it detects released PRs from the
+     `beta...main` compare (squash commit `(#N)` subjects, with a
+     `commits/{sha}/pulls` API fallback), not merge commits.
 4. **Quality gate before any PR:** `cargo fmt --check`, `cargo clippy
    --workspace -D warnings`, `cargo test --workspace` (run inside `crates/`),
    plus the runtime test driver (`node packages/lunas/test/run-all.mjs`) for


### PR DESCRIPTION
## What

Replaces the `git-pr-release` gem with a dependency-free Node script,
`.github/scripts/release-pr.mjs`, that builds/updates the beta release PR.

## Why

`git-pr-release` detects released PRs **only** via `Merge pull request #N`
merge commits. This repo now squash-merges everything, so squash commits
(subjects ending `(#N)`) were invisible to it — PRs #133+ never showed up in
the release PR body (#124).

## Detection change

The new script determines PRs in `main` but not `beta` via:

1. `GET /compare/beta...main` (paginated) → commits ahead of `beta`.
2. Subject-first: extract `(#N)` (squash) or `Merge pull request #N` (merge)
   from each commit subject — no API call in the common case.
3. Fallback for unrecognized subjects: `GET /commits/{sha}/pulls`, which works
   for both squash and merge commits.
4. Dedupe by PR number, then fetch labels/author per PR.

## Format & checkbox preservation

- `buildBody()` reproduces the old ERB layout byte-for-byte: title
  `🚀 Release (YYYY-MM-DD - beta)` (Asia/Tokyo date) and the same six sections
  (`🛠 Fixes` / `✨ New Features` / `🔨 Refactoring` / `📌 Version Updates` /
  `🔧 Chore` / `👻 Others`), each entry `- [ ] #N @login`.
- Existing `- [x] #N` checkboxes are parsed from the current PR body and kept
  checked when the body is regenerated.
- The old `release-template.erb` is kept as reference with a note pointing at
  the script.

## Workflow / tests

- `pr-release-beta.yml`: same `push: [main]` trigger and `pull-requests: write`
  perms; drops ruby/gem steps for `checkout` + `setup-node@22` +
  `node .github/scripts/release-pr.mjs`.
- Adds `--dry-run` mode and a pure, unit-testable `buildBody()`. Tests
  (`release-pr.test.mjs`, `node --test`) cover all sections, checkbox
  preservation, subject parsing, and multi-label PRs — wired into the CI
  `tooling` job.
- Verified against the live repo in `--dry-run`: correctly surfaces the
  previously-missing squash-merged PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)