### PR TITLE
test(e2e): end-to-end snapshots + browser smoke — roadmap complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,44 @@ jobs:
       - name: create-lunas tests
         working-directory: packages/create-lunas
         run: node test/run-all.mjs
+
+  smoke:
+    name: e2e browser smoke (headless Chrome)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install toolchain (from rust-toolchain.toml)
+        working-directory: crates
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            crates/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('crates/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # Ubuntu runners ship a headless-capable Chrome via this action; export its
+      # path so the smoke harness drives the real engine (it skips loudly if
+      # CHROME is unset and no Chrome is found on PATH).
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+
+      # The browser smoke suite compiles fixtures, serves them with a tiny node
+      # server, and asserts the post-interaction DOM in real Chrome. `node` on
+      # PATH (setup-node) satisfies the harness's server; CHROME points it at the
+      # installed engine.
+      - name: End-to-end browser smoke tests
+        working-directory: crates
+        env:
+          CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: cargo test -p lunas_compiler --test browser_smoke -- --nocapture

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -236,6 +236,14 @@ struct Emitter<'a> {
     n_html: usize,   // HTML_{n}
     n_child: usize,  // c{n} (child-component instance handle)
     n_slots: usize,  // s{n} (per-child slots object)
+    n_target: usize, // g{n} (pristine anchor-target snapshot node)
+    /// Stack of pre-captured anchor-target local names, one deque per fragment
+    /// currently being emitted. `emit_fragment` snapshots every slot's anchor
+    /// target against the *pristine* parse (before any content is inserted) and
+    /// pushes the resulting locals here; `emit_anchor` pops them in slot order.
+    /// This makes positional anchor navigation immune to sibling index shifts
+    /// caused by earlier dynamic insertions into the same parent.
+    anchor_target_stack: Vec<std::collections::VecDeque<String>>,
 }
 
 impl<'a> Emitter<'a> {
@@ -332,6 +340,8 @@ impl<'a> Emitter<'a> {
             n_html: 0,
             n_child: 0,
             n_slots: 0,
+            n_target: 0,
+            anchor_target_stack: Vec::new(),
         }
     }
 
@@ -383,6 +393,11 @@ impl<'a> Emitter<'a> {
         let n = self.n_anchor;
         self.n_anchor += 1;
         format!("a{n}")
+    }
+    fn alloc_target(&mut self) -> String {
+        let n = self.n_target;
+        self.n_target += 1;
+        format!("g{n}")
     }
     fn alloc_root(&mut self) -> String {
         let n = self.n_root;
@@ -551,8 +566,61 @@ impl<'a> Emitter<'a> {
         diags: &mut Vec<Diagnostic>,
     ) {
         let ref_names = self.emit_refs(b, &skeleton.dynamic_elements, frag);
+        self.emit_anchor_targets(b, &skeleton.slots, frag);
         self.emit_slots(b, &skeleton.slots, frag, diags);
+        self.anchor_target_stack.pop();
         self.emit_attr_and_event_wiring(b, &skeleton.dynamic_elements, &ref_names, frag, diags);
+    }
+
+    /// Snapshots every slot's anchor-target node against the *pristine* fragment
+    /// tree (before any content is inserted) and pushes the resulting locals as
+    /// a fresh deque for this fragment. Consumed in slot order by `emit_anchor`.
+    ///
+    /// Without this, a positional navigation like `base.childNodes[0].childNodes[2]`
+    /// re-evaluated after an earlier sibling slot inserted content would resolve
+    /// to the wrong node — inserted siblings shift `childNodes` indices. Capturing
+    /// the target node reference once, up front, keeps every anchor stable.
+    fn emit_anchor_targets(&mut self, b: &mut String, slots: &[Slot], frag: &Frag) {
+        let paths: Vec<&[u32]> = slots
+            .iter()
+            .map(|s| match &s.pos {
+                InsertPos::Before(p)
+                | InsertPos::BeforeSplit { path: p, .. }
+                | InsertPos::Append(p) => strip_path(p, frag.strip),
+            })
+            .collect();
+
+        let mut names = std::collections::VecDeque::with_capacity(paths.len());
+        if paths.is_empty() {
+            self.anchor_target_stack.push(names);
+            return;
+        }
+
+        self.use_helper("refs");
+        let refs_fn = self.helper("refs").to_string();
+        let locals: Vec<String> = paths.iter().map(|_| self.alloc_target()).collect();
+        push_indent(b, frag.indent);
+        b.push_str("const [");
+        for (i, name) in locals.iter().enumerate() {
+            if i > 0 {
+                b.push_str(", ");
+            }
+            b.push_str(name);
+        }
+        b.push_str("] = ");
+        b.push_str(&refs_fn);
+        b.push('(');
+        b.push_str(frag.base);
+        b.push_str(", [");
+        for (i, path) in paths.iter().enumerate() {
+            if i > 0 {
+                b.push_str(", ");
+            }
+            push_path(b, path);
+        }
+        b.push_str("]);\n");
+        names.extend(locals);
+        self.anchor_target_stack.push(names);
     }
 
     // --- refs -------------------------------------------------------------
@@ -661,41 +729,45 @@ impl<'a> Emitter<'a> {
     /// Emits the anchor-creation statement for a slot, binding it to a local
     /// const named `name`.
     fn emit_anchor(&mut self, b: &mut String, name: &str, pos: &InsertPos, frag: &Frag) {
+        // The anchor's target node was pre-captured against the pristine tree in
+        // `emit_anchor_targets`; consume the next snapshot local in slot order.
+        // (Fallback to live positional navigation if — defensively — the queue is
+        // empty, though `emit_fragment` always fills one per slot.)
+        let target = self
+            .anchor_target_stack
+            .last_mut()
+            .and_then(|q| q.pop_front());
+
         push_indent(b, frag.indent);
-        match pos {
-            InsertPos::Before(path) => {
-                self.use_helper("anchorBefore");
-                b.push_str("const ");
-                b.push_str(name);
-                b.push_str(" = ");
-                b.push_str(self.helper("anchorBefore"));
-                b.push('(');
-                push_node_at(b, frag.base, strip_path(path, frag.strip));
-                b.push_str(");\n");
+        let (helper, split_offset) = match pos {
+            InsertPos::Before(_) => ("anchorBefore", None),
+            InsertPos::BeforeSplit { utf16_offset, .. } => {
+                ("anchorBeforeSplit", Some(*utf16_offset))
             }
-            InsertPos::BeforeSplit { path, utf16_offset } => {
-                self.use_helper("anchorBeforeSplit");
-                b.push_str("const ");
-                b.push_str(name);
-                b.push_str(" = ");
-                b.push_str(self.helper("anchorBeforeSplit"));
-                b.push('(');
+            InsertPos::Append(_) => ("anchorAppend", None),
+        };
+        self.use_helper(helper);
+        b.push_str("const ");
+        b.push_str(name);
+        b.push_str(" = ");
+        b.push_str(self.helper(helper));
+        b.push('(');
+        match &target {
+            Some(local) => b.push_str(local),
+            None => {
+                let path = match pos {
+                    InsertPos::Before(p)
+                    | InsertPos::BeforeSplit { path: p, .. }
+                    | InsertPos::Append(p) => p,
+                };
                 push_node_at(b, frag.base, strip_path(path, frag.strip));
-                b.push_str(", ");
-                b.push_str(&utf16_offset.to_string());
-                b.push_str(");\n");
-            }
-            InsertPos::Append(path) => {
-                self.use_helper("anchorAppend");
-                b.push_str("const ");
-                b.push_str(name);
-                b.push_str(" = ");
-                b.push_str(self.helper("anchorAppend"));
-                b.push('(');
-                push_node_at(b, frag.base, strip_path(path, frag.strip));
-                b.push_str(");\n");
             }
         }
+        if let Some(off) = split_offset {
+            b.push_str(", ");
+            b.push_str(&off.to_string());
+        }
+        b.push_str(");\n");
     }
 
     // --- child components -------------------------------------------------

--- a/crates/lunas_compiler/tests/browser/serve.mjs
+++ b/crates/lunas_compiler/tests/browser/serve.mjs
@@ -1,0 +1,44 @@
+// serve.mjs — a dependency-free static file server for the browser smoke test.
+//
+// Usage: node serve.mjs <rootDir> <port>
+// Serves files under <rootDir> with correct MIME for .mjs/.js/.html so a real
+// browser can load the compiled ES modules + runtime. Prints "READY <port>" to
+// stdout once listening (the Rust harness waits for that line), then serves
+// until killed.
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+
+const rootDir = process.argv[2];
+const port = Number(process.argv[3] || 0);
+
+const MIME = {
+  ".mjs": "text/javascript; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    let path = decodeURIComponent(new URL(req.url, "http://x").pathname);
+    if (path === "/") path = "/index.html";
+    // Contain the path within rootDir (no traversal).
+    const full = normalize(join(rootDir, path));
+    if (!full.startsWith(normalize(rootDir))) {
+      res.writeHead(403).end("forbidden");
+      return;
+    }
+    const body = await readFile(full);
+    const type = MIME[extname(full)] || "application/octet-stream";
+    res.writeHead(200, { "content-type": type }).end(body);
+  } catch {
+    res.writeHead(404).end("not found");
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  const actual = server.address().port;
+  process.stdout.write("READY " + actual + "\n");
+});

--- a/crates/lunas_compiler/tests/browser_smoke.rs
+++ b/crates/lunas_compiler/tests/browser_smoke.rs
@@ -1,0 +1,630 @@
+//! Browser smoke test: verifies compiled components in a REAL browser engine
+//! (headless Chrome), not the node dom-shim — closing the loop that the shim
+//! can only approximate.
+//!
+//! Pipeline, with ZERO npm dependencies:
+//!   1. Compile a set of fixtures with the real compiler (`lunas_compiler::compile`).
+//!   2. Stage a serve dir: the compiled modules + a *copy of the real runtime*
+//!      (`packages/lunas/src/*.mjs`) + a self-contained `index.html` that imports
+//!      the app, mounts it via the runtime's `attach`, runs an inline interaction
+//!      script (real clicks / input events), and writes completion markers into
+//!      the DOM.
+//!   3. Serve the dir with a tiny node http server (`tests/browser/serve.mjs`).
+//!   4. Run `chrome --headless=new --virtual-time-budget=… --dump-dom <url>` and
+//!      assert the serialized post-interaction DOM contains the expected markers.
+//!
+//! ## What the browser layer proves
+//!
+//! It proves the compiled output + real runtime render and *react* correctly on
+//! a real DOM + real event loop + real microtask timing — the parts the shim
+//! fakes. Concretely, each fixture's inline script performs an interaction
+//! (click, list mutation, `:if` toggle, two-way input) and stamps a
+//! `data-result` marker the harness asserts, so both initial render AND
+//! post-interaction state are verified in-engine.
+//!
+//! ## Graceful skip
+//!
+//! When Chrome or node is absent the test logs loudly and returns (does not
+//! fail), so contributors without a browser still get a green suite. CI wires
+//! Chrome in explicitly (ubuntu runners ship it), so the smoke path runs there.
+
+use std::io::{BufRead, BufReader};
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+
+/// First index where `needle` occurs in `haystack` (tiny substring search over
+/// bytes — the dumped DOM is small).
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+const NODE_PINNED: &str = concat!(env!("HOME"), "/.nvm/versions/node/v22.18.0/bin/node");
+
+/// Resolves the node binary: `LUNAS_NODE` env override, then the pinned NVM
+/// path (dev machine), then `node` on PATH (CI runners with setup-node).
+fn node_bin() -> Option<String> {
+    if let Some(env) = std::env::var_os("LUNAS_NODE") {
+        let p = PathBuf::from(&env);
+        if p.exists() {
+            return Some(p.to_string_lossy().into_owned());
+        }
+    }
+    if std::path::Path::new(NODE_PINNED).exists() {
+        return Some(NODE_PINNED.to_string());
+    }
+    if Command::new("node")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+    {
+        return Some("node".to_string());
+    }
+    None
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    manifest_dir().join("tests/fixtures")
+}
+
+/// Locates a Chrome/Chromium executable across common macOS and Linux paths, or
+/// the `CHROME` / `CHROME_BIN` env override CI can set.
+fn find_chrome() -> Option<String> {
+    if let Some(env) = std::env::var_os("CHROME").or_else(|| std::env::var_os("CHROME_BIN")) {
+        let p = PathBuf::from(&env);
+        if p.exists() {
+            return Some(p.to_string_lossy().into_owned());
+        }
+    }
+    let candidates = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ];
+    for c in candidates {
+        if std::path::Path::new(c).exists() {
+            return Some(c.to_string());
+        }
+    }
+    // Fall back to PATH lookup.
+    for name in [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ] {
+        if Command::new(name)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+fn compile_fixture(rel: &str) -> String {
+    let src = std::fs::read_to_string(fixtures_dir().join(rel))
+        .unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let (js, diags) = lunas_compiler::compile(&src);
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "compile `{rel}` diagnostics: {diags:?}"
+    );
+    js.unwrap_or_else(|| panic!("`{rel}` emitted no module"))
+}
+
+/// Copies the real runtime (`packages/lunas/src/*.mjs`) into `<serve>/lunas/`,
+/// so compiled modules can `import … from "./lunas/index.mjs"` in-browser.
+fn stage_runtime(serve: &std::path::Path) {
+    let src = repo_root().join("packages/lunas/src");
+    let dst = serve.join("lunas");
+    std::fs::create_dir_all(&dst).unwrap();
+    for entry in std::fs::read_dir(&src).unwrap() {
+        let p = entry.unwrap().path();
+        if p.extension().is_some_and(|e| e == "mjs") {
+            let name = p.file_name().unwrap();
+            std::fs::copy(&p, dst.join(name)).unwrap();
+        }
+    }
+}
+
+/// Writes a compiled module into the serve dir, rewriting `from "lunas"` to the
+/// staged runtime and each `@use` child import to a generated sibling.
+fn write_module(serve: &std::path::Path, base: &str, mut js: String, children: &[&str]) {
+    js = js.replace("from \"lunas\";", "from \"./lunas/index.mjs\";");
+    for child in children {
+        js = js.replace(
+            &format!("from \"./{child}.lunas\";"),
+            &format!("from \"./{child}.gen.mjs\";"),
+        );
+    }
+    std::fs::write(serve.join(format!("{base}.gen.mjs")), js).unwrap();
+}
+
+/// Starts the node static server on an ephemeral port; returns (child, port).
+/// Waits for the `READY <port>` line the server prints once listening.
+fn start_server(node: &str, serve: &std::path::Path) -> (Child, u16) {
+    let serve_script = manifest_dir().join("tests/browser/serve.mjs");
+    let mut child = Command::new(node)
+        .arg(&serve_script)
+        .arg(serve)
+        .arg("0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn node server");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read server READY line");
+    let port: u16 = line
+        .trim()
+        .strip_prefix("READY ")
+        .unwrap_or_else(|| panic!("unexpected server line: {line:?}"))
+        .parse()
+        .expect("parse port");
+    (child, port)
+}
+
+/// Runs headless Chrome against `url` and returns the dumped, post-interaction
+/// DOM. Uses a throwaway `--user-data-dir` so no profile is touched.
+///
+/// Chrome's `--dump-dom` flushes the serialized DOM to stdout as soon as the
+/// page settles (our `--virtual-time-budget` bound), but the headless process
+/// then frequently *lingers* instead of exiting — waiting on it with
+/// `Command::output()` would stall the suite for minutes. So we drain stdout on
+/// a reader thread and enforce a hard deadline: once the process either exits or
+/// the deadline elapses, we kill it and use whatever DOM was flushed (which is
+/// the complete dump — it is emitted well before the linger).
+fn dump_dom(chrome: &str, url: &str, profile: &std::path::Path) -> String {
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new(chrome)
+        .args([
+            "--headless=new",
+            "--no-sandbox",
+            "--disable-gpu",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-extensions",
+            "--disable-dev-shm-usage",
+            // Bound the page's virtual clock so the inline interaction script +
+            // microtasks all run, then the DOM is dumped.
+            "--virtual-time-budget=2500",
+            "--dump-dom",
+        ])
+        .arg(format!("--user-data-dir={}", profile.display()))
+        .arg(url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .process_group(0) // own process group: killing it reaps Chrome's whole tree
+        .spawn()
+        .expect("spawn chrome");
+    let pgid = child.id() as i32;
+
+    // Drain stdout incrementally on a thread into a shared buffer, so we can
+    // both avoid a full-pipe deadlock AND detect the completion marker to kill
+    // Chrome early (it flushes the whole DOM before it lingers).
+    let mut stdout = child.stdout.take().unwrap();
+    let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let (done_tx, done_rx) = mpsc::channel();
+    let reader = {
+        let buf = std::sync::Arc::clone(&buf);
+        std::thread::spawn(move || {
+            let mut chunk = [0u8; 8192];
+            loop {
+                match std::io::Read::read(&mut stdout, &mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let mut b = buf.lock().unwrap();
+                        b.extend_from_slice(&chunk[..n]);
+                        if find_subslice(&b, b"data-done=\\\"1\\\"").is_some()
+                            || find_subslice(&b, b"data-done=\"1\"").is_some()
+                        {
+                            let _ = done_tx.send(());
+                        }
+                    }
+                }
+            }
+        })
+    };
+
+    // Kill as soon as the dump carries the completion marker, else on a hard
+    // deadline (defensive — a hung/failed page still terminates the test).
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if done_rx.recv_timeout(Duration::from_millis(100)).is_ok() {
+            break;
+        }
+        if matches!(child.try_wait(), Ok(Some(_))) || Instant::now() >= deadline {
+            break;
+        }
+    }
+    // Kill the whole process group so Chrome's renderer/GPU/zygote helpers are
+    // reaped too — killing just the parent leaks dozens of child processes.
+    kill_group(pgid);
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+    let out = buf.lock().unwrap().clone();
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Sends SIGKILL to an entire process group (negative pid) via the portable
+/// `kill` utility — no extra crate dependency. Best-effort.
+fn kill_group(pgid: i32) {
+    let _ = Command::new("kill")
+        .arg("-9")
+        .arg(format!("-{pgid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// The reusable page shell: imports `mod`, mounts it, then runs `interaction`
+/// (an async function body given `root`, `mount`, `tick`), and finally stamps
+/// `<body data-result="…">` markers the harness asserts. On any error it stamps
+/// `data-result="ERROR: …"` so a broken run is visible in the dumped DOM.
+fn page_html(module_file: &str, mount_expr: &str, interaction: &str) -> String {
+    format!(
+        r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>lunas smoke</title></head>
+<body>
+<div id="app"></div>
+<div id="portal"></div>
+<script type="module">
+  import * as L from "./lunas/index.mjs";
+  import factory from "./{module_file}";
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  const host = document.getElementById("app");
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+  const btn = (label, root = document) =>
+    $$("button", root).find((b) => b.textContent.trim() === label);
+  (async () => {{
+    try {{
+      const built = {mount_expr};
+      const root = L.attach(built, host);
+      {interaction}
+      document.body.setAttribute("data-done", "1");
+    }} catch (err) {{
+      document.body.setAttribute("data-result", "ERROR: " + (err && err.stack || err));
+      document.body.setAttribute("data-done", "1");
+    }}
+  }})();
+</script>
+</body></html>
+"#
+    )
+}
+
+/// Extracts the value of `data-result="…"` from the dumped DOM (Chrome
+/// serializes attributes with double quotes; entities are decoded minimally).
+fn result_marker(dom: &str) -> Option<String> {
+    let needle = "data-result=\"";
+    let start = dom.find(needle)? + needle.len();
+    let rest = &dom[start..];
+    let end = rest.find('"')?;
+    Some(
+        rest[..end]
+            .replace("&quot;", "\"")
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">"),
+    )
+}
+
+fn assert_done(dom: &str) {
+    assert!(
+        dom.contains("data-done=\"1\""),
+        "page did not finish (no data-done). Dumped DOM:\n{dom}"
+    );
+    if let Some(r) = result_marker(dom) {
+        assert!(!r.starts_with("ERROR:"), "page threw: {r}\nDOM:\n{dom}");
+    }
+}
+
+/// One self-contained smoke scenario runner: stages the given modules, serves,
+/// drives Chrome, and returns the dumped DOM.
+struct Scenario {
+    chrome: String,
+    node: String,
+    serve: PathBuf,
+    profile: PathBuf,
+    _tmp: TempGuard,
+}
+
+impl Scenario {
+    fn new(env: &SmokeEnv, name: &str) -> Self {
+        let tmp = std::env::temp_dir().join(format!("lunas_smoke_{name}_{}", std::process::id()));
+        let serve = tmp.join("serve");
+        let profile = tmp.join("profile");
+        std::fs::create_dir_all(&serve).unwrap();
+        std::fs::create_dir_all(&profile).unwrap();
+        stage_runtime(&serve);
+        Scenario {
+            chrome: env.chrome.clone(),
+            node: env.node.clone(),
+            serve,
+            profile,
+            _tmp: TempGuard(tmp),
+        }
+    }
+
+    fn run(&self, page: &str) -> String {
+        std::fs::write(self.serve.join("index.html"), page).unwrap();
+        let (mut server, port) = start_server(&self.node, &self.serve);
+        let url = format!("http://127.0.0.1:{port}/index.html");
+        let dom = dump_dom(&self.chrome, &url, &self.profile);
+        let _ = server.kill();
+        let _ = server.wait();
+        dom
+    }
+}
+
+/// Removes the temp dir on drop (best-effort).
+struct TempGuard(PathBuf);
+impl Drop for TempGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct SmokeEnv {
+    chrome: String,
+    node: String,
+}
+
+fn preflight() -> Option<SmokeEnv> {
+    let Some(node) = node_bin() else {
+        eprintln!(
+            "SKIP browser_smoke: no node found (pinned NVM path, LUNAS_NODE, or PATH `node`)."
+        );
+        return None;
+    };
+    let Some(chrome) = find_chrome() else {
+        eprintln!(
+            "SKIP browser_smoke: no Chrome/Chromium found. \
+             Set CHROME=/path/to/chrome to enable the browser smoke layer."
+        );
+        return None;
+    };
+    Some(SmokeEnv { chrome, node })
+}
+
+// --- scenarios --------------------------------------------------------------
+
+/// Single-file component: initial render + a click that bumps a counter and
+/// updates bound text/attr — proves reactive text/attr binds fire in-engine.
+#[test]
+fn smoke_text_attr_event_in_chrome() {
+    let Some(env) = preflight() else { return };
+    let sc = Scenario::new(&env, "text");
+    write_module(
+        &sc.serve,
+        "App",
+        compile_fixture("text_attr_event.lunas"),
+        &[],
+    );
+
+    let page = page_html(
+        "App.gen.mjs",
+        "factory({})",
+        r#"
+        const h1 = $("h1", root);
+        const p = $$("p", root)[0];
+        const before = p.textContent.trim();
+        btn("bump", root).click(); await tick();
+        btn("bump", root).click(); await tick();
+        const after = p.textContent.trim();
+        const title = h1.getAttribute("title");
+        document.body.setAttribute(
+          "data-result",
+          `head=${h1.textContent.trim()}|title=${title}|before=${before}|after=${after}`
+        );
+        "#,
+    );
+    let dom = sc.run(&page);
+    assert_done(&dom);
+    let r = result_marker(&dom).expect("result marker present");
+    assert!(r.contains("head=hello, world!"), "initial text bind: {r}");
+    assert!(r.contains("title=the heading"), "attr bind: {r}");
+    assert!(r.contains("before=count is 0"), "initial interp: {r}");
+    assert!(
+        r.contains("after=count is 2"),
+        "reactive text after two clicks: {r}"
+    );
+}
+
+/// `:if`/`:elseif`/`:else` cascade driven by clicks — proves branch swapping in
+/// a real engine.
+#[test]
+fn smoke_if_cascade_in_chrome() {
+    let Some(env) = preflight() else { return };
+    let sc = Scenario::new(&env, "if");
+    write_module(&sc.serve, "App", compile_fixture("if_cascade.lunas"), &[]);
+
+    let page = page_html(
+        "App.gen.mjs",
+        "factory({})",
+        r#"
+        const cur = () => $$("p", root).map((p) => p.textContent.trim()).join("");
+        const step = btn("step", root);
+        const initial = cur();
+        step.click(); step.click(); await tick();   // n = 2 -> small 2
+        const small = cur();
+        step.click(); step.click(); await tick();    // n = 4 -> big 4
+        const big = cur();
+        document.body.setAttribute("data-result", `init=${initial}|small=${small}|big=${big}`);
+        "#,
+    );
+    let dom = sc.run(&page);
+    assert_done(&dom);
+    let r = result_marker(&dom).expect("result marker");
+    assert!(r.contains("init=zero"), ":if branch initially: {r}");
+    assert!(
+        r.contains("small=small 2"),
+        ":else branch after 2 steps: {r}"
+    );
+    assert!(r.contains("big=big 4"), ":elseif branch after 4 steps: {r}");
+}
+
+/// Keyed + nested `:for` with an array push — proves list reconciliation and
+/// nested item wiring in a real engine.
+#[test]
+fn smoke_for_nested_in_chrome() {
+    let Some(env) = preflight() else { return };
+    let sc = Scenario::new(&env, "for");
+    write_module(
+        &sc.serve,
+        "App",
+        compile_fixture("for_keyed_nested.lunas"),
+        &[],
+    );
+
+    let page = page_html(
+        "App.gen.mjs",
+        "factory({})",
+        r#"
+        const groups = () => $$("ul > li", root).map((li) => $("b", li).textContent.trim()).join(",");
+        const innerTags = () => $$("ol li", root).map((li) => li.textContent.trim()).join(",");
+        const before = groups();
+        const tagsBefore = innerTags();
+        btn("add", root).click(); await tick();
+        const after = groups();
+        document.body.setAttribute(
+          "data-result",
+          `before=${before}|after=${after}|tags=${tagsBefore}`
+        );
+        "#,
+    );
+    let dom = sc.run(&page);
+    assert_done(&dom);
+    let r = result_marker(&dom).expect("result marker");
+    assert!(r.contains("before=a,b"), "outer :for initial: {r}");
+    assert!(r.contains("after=a,b,n"), "outer :for grows on push: {r}");
+    assert!(r.contains("tags=x,y,z"), "nested :for rendered: {r}");
+}
+
+/// The full multi-component app in a real engine: mounts, then exercises the
+/// child Counter, the `:if` page cascade, the keyed `:for` of Badge children,
+/// and the two-way note input — the same journey the node integration runs, but
+/// through Blink's real DOM and event loop.
+#[test]
+fn smoke_full_app_in_chrome() {
+    let Some(env) = preflight() else { return };
+    let sc = Scenario::new(&env, "app");
+    let children = ["Counter", "Card", "Badge"];
+    write_module(
+        &sc.serve,
+        "App",
+        compile_fixture("app/App.lunas"),
+        &children,
+    );
+    write_module(
+        &sc.serve,
+        "Counter",
+        compile_fixture("app/Counter.lunas"),
+        &[],
+    );
+    write_module(&sc.serve, "Card", compile_fixture("app/Card.lunas"), &[]);
+    write_module(&sc.serve, "Badge", compile_fixture("app/Badge.lunas"), &[]);
+
+    let page = page_html(
+        "App.gen.mjs",
+        "factory({})",
+        r#"
+        const badges = () => $$(".badge", root).map((b) => b.textContent.trim()).join(",");
+        const counterVal = () => $(".counter .value", root).textContent.trim();
+        const cardHead = () => $(".card header", root).textContent.trim();
+        const cardFoot = () => $(".card footer", root).textContent.trim();
+        const pageText = () =>
+          $$("main > p", root).map((p) => p.textContent.trim()).filter(Boolean).join("");
+
+        const head = cardHead();
+        const foot = cardFoot();
+        const counterInit = counterVal();
+        const badgesInit = badges();
+        const pageInit = pageText();
+
+        // Counter + twice.
+        const plus = $$(".counter button", root).find((b) => b.textContent.trim() === "+");
+        plus.click(); plus.click(); await tick();
+        const counterAfter = counterVal();
+
+        // Navigate the page cascade.
+        btn("two", root).click(); await tick();
+        const pageTwo = pageText();
+
+        // Grow the keyed :for badge list.
+        btn("add tag", root).click(); await tick();
+        const badgesAfter = badges();
+
+        // Two-way edit the Counter note input.
+        const note = $(".counter input", root);
+        note.value = "edited";
+        note.dispatchEvent(new Event("input", { bubbles: true }));
+        await tick();
+        const noteAfter = $(".counter .note", root).textContent.trim();
+
+        document.body.setAttribute(
+          "data-result",
+          [
+            `head=${head}`, `foot=${foot}`, `cInit=${counterInit}`, `cAfter=${counterAfter}`,
+            `pInit=${pageInit}`, `pTwo=${pageTwo}`, `bInit=${badgesInit}`, `bAfter=${badgesAfter}`,
+            `note=${noteAfter}`,
+          ].join("|")
+        );
+        "#,
+    );
+    let dom = sc.run(&page);
+    assert_done(&dom);
+    let r = result_marker(&dom).expect("result marker");
+    assert!(r.contains("head=Dashboard for ada"), "named slot: {r}");
+    assert!(r.contains("foot=rows: 3"), "scoped slot: {r}");
+    assert!(r.contains("cInit=10"), "counter prop seed: {r}");
+    assert!(r.contains("cAfter=12"), "counter reacts to clicks: {r}");
+    assert!(r.contains("pInit=Page one is active."), "initial page: {r}");
+    assert!(
+        r.contains("pTwo=Page two is active."),
+        "page navigation: {r}"
+    );
+    assert!(
+        r.contains("bInit=[alpha],[beta],[ada]"),
+        "initial badges (:for + :is): {r}"
+    );
+    assert!(
+        r.contains("bAfter=[alpha],[beta],[extra],[ada]"),
+        "badges grow on push: {r}"
+    );
+    assert!(r.contains("note=note: edited"), "two-way write-back: {r}");
+}

--- a/crates/lunas_compiler/tests/codegen_app.rs
+++ b/crates/lunas_compiler/tests/codegen_app.rs
@@ -1,0 +1,264 @@
+//! Full-app **integration** test: compiles a realistic multi-component app
+//! (parent `App` + `Counter` / `Card` / `Badge` children, wired through `@use`,
+//! exercising `@input` props, default/named/scoped slots, keyed `:for` of child
+//! components, an `:if`/`:elseif`/`:else` page cascade, two-way binding, and a
+//! `<component :is>`) and runs the emitted ES modules against the REAL runtime
+//! (`packages/lunas/src`) under the dependency-free node dom-shim.
+//!
+//! It then drives an app-sized journey — mount, read initial DOM, fire events,
+//! mutate an array (`:for` grows), navigate the `:if` cascade, two-way-edit a
+//! child input — and asserts the rendered DOM at each step. This extends the
+//! `codegen_exec.rs` single-/two-file patterns to a whole app graph.
+//!
+//! Skipped gracefully (with an eprintln) when node is not at the pinned path, so
+//! CI without that toolchain still passes.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+const NODE: &str = concat!(env!("HOME"), "/.nvm/versions/node/v22.18.0/bin/node");
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn node_available() -> bool {
+    std::path::Path::new(NODE).exists()
+}
+
+fn compile_fixture(rel: &str) -> String {
+    let src = std::fs::read_to_string(fixtures_dir().join(rel))
+        .unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let (js, diags) = lunas_compiler::compile(&src);
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "compile `{rel}` diagnostics: {diags:?}"
+    );
+    js.unwrap_or_else(|| panic!("`{rel}` emitted no module"))
+        .replace("from \"lunas\";", "from \"./src/index.mjs\";")
+}
+
+/// Compiles the whole app graph and runs `driver_body` against it.
+///
+/// Every module's `@use`/`import … from "./Foo.lunas"` is rewritten to a
+/// generated sibling file so node resolves the graph with no package install;
+/// the runtime `from "lunas"` import is rewritten to the runtime index.
+fn run_app(name: &str, driver_body: &str) -> String {
+    let root = repo_root();
+    let test_dir = root.join("packages/lunas");
+
+    // (fixture path, generated basename, the `@use` path other modules import it by)
+    let modules = [
+        ("app/App.lunas", "App", None),
+        ("app/Counter.lunas", "Counter", Some("./Counter.lunas")),
+        ("app/Card.lunas", "Card", Some("./Card.lunas")),
+        ("app/Badge.lunas", "Badge", Some("./Badge.lunas")),
+    ];
+
+    let mut written = Vec::new();
+    for (fixture, base, _) in modules {
+        let mut js = compile_fixture(fixture);
+        // Rewrite every child import to the generated sibling file.
+        for (_, dep_base, dep_use) in modules {
+            if let Some(use_path) = dep_use {
+                js = js.replace(
+                    &format!("from \"{use_path}\";"),
+                    &format!("from \"./__app_{name}_{dep_base}.gen.mjs\";"),
+                );
+            }
+        }
+        let path = test_dir.join(format!("__app_{name}_{base}.gen.mjs"));
+        std::fs::write(&path, &js).unwrap();
+        written.push(path);
+    }
+
+    let driver = format!(
+        "import {{ installDom }} from \"./test/dom-shim.mjs\";\n\
+         import factory from \"./__app_{name}_App.gen.mjs\";\n\
+         const tick = () => new Promise((r) => setTimeout(r, 0));\n\
+         installDom();\n\
+         {driver_body}\n"
+    );
+    let drv_path = test_dir.join(format!("__app_{name}.drv.mjs"));
+    std::fs::write(&drv_path, driver).unwrap();
+
+    let out = Command::new(NODE)
+        .arg(&drv_path)
+        .current_dir(&test_dir)
+        .output()
+        .expect("spawn node");
+
+    for p in &written {
+        let _ = std::fs::remove_file(p);
+    }
+    let _ = std::fs::remove_file(&drv_path);
+
+    if !out.status.success() {
+        std::io::stderr().write_all(&out.stderr).unwrap();
+        panic!("node exited with failure for app `{name}`");
+    }
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A realistic journey through the whole app graph. The driver walks the DOM by
+/// role/tag helpers (robust to structural churn) and logs a labelled line per
+/// step; the Rust side asserts each.
+#[test]
+fn app_journey_mount_events_navigate_list_two_way() {
+    if !node_available() {
+        eprintln!("skipping codegen_app: node not found at {NODE}");
+        return;
+    }
+
+    let driver = r#"
+        // A #portal target for any teleport (App uses none, but harmless).
+        const portal = document.createElement('div');
+        portal.setAttribute('id', 'portal');
+        document.body.appendChild(portal);
+
+        const root = factory({});
+        document.body.appendChild(root);
+
+        // --- DOM navigation helpers (depth-first) ---
+        const all = (pred, from = root) => {
+          const out = [];
+          const walk = (n) => {
+            for (const ch of n.childNodes) {
+              if (ch.kind === 'element' && pred(ch)) out.push(ch);
+              walk(ch);
+            }
+          };
+          walk(from);
+          return out;
+        };
+        const byTag = (t, from) => all((e) => e.tag === t, from);
+        const byClass = (cls, from) =>
+          all((e) => (e.getAttribute('class') || '').split(/\s+/).includes(cls), from);
+        const text = (n) => n.innerHTMLString();
+        const btnByLabel = (lbl) =>
+          byTag('button').find((b) => text(b).trim() === lbl);
+
+        // --- initial render assertions ---
+        console.log('H1:' + text(byTag('h1')[0]));
+
+        // Card default slot: parent content + a Counter child rendered inside it.
+        const card = byClass('card')[0];
+        console.log('CARD_CLASS:[' + card.getAttribute('class') + ']');
+        console.log('CARD_HEAD:' + text(byTag('header', card)[0]).trim());
+        console.log('CARD_FOOT:' + text(byTag('footer', card)[0]).trim());
+
+        // Counter (child inside the Card default slot).
+        const counterValue = () => text(byClass('value')[0]);
+        console.log('COUNTER_INIT:' + counterValue());
+
+        // The :if page cascade (starts on 'one').
+        const pageText = () => {
+          const ps = byTag('p').map(text);
+          return ps.find((t) => t.includes('Page') || t.includes('No page')) || '';
+        };
+        console.log('PAGE_INIT:' + pageText());
+
+        // Badge list from the keyed :for + the <component :is="Badge">.
+        const badges = () => byClass('badge').map((b) => text(b).trim());
+        console.log('BADGES_INIT:' + badges().join(','));
+
+        // --- interactions ---
+        // 1) Counter +: local child state updates, parent untouched.
+        const plus = byTag('button', byClass('counter')[0]).find((b) => text(b).trim() === '+');
+        plus.dispatch('click'); await tick();
+        plus.dispatch('click'); await tick();
+        console.log('COUNTER_AFTER_PLUS:' + counterValue());
+
+        // 2) Navigate the page cascade: one -> two -> (n>... falls to else via unknown).
+        btnByLabel('two').dispatch('click'); await tick();
+        console.log('PAGE_TWO:' + pageText());
+        btnByLabel('one').dispatch('click'); await tick();
+        console.log('PAGE_ONE:' + pageText());
+
+        // 3) Grow the keyed :for list (array push -> new Badge child mounts).
+        btnByLabel('add tag').dispatch('click'); await tick();
+        console.log('BADGES_AFTER_ADD:' + badges().join(','));
+
+        // 4) Two-way edit the Counter's note input; the mirrored <p> updates.
+        const noteInput = byTag('input', byClass('counter')[0])[0];
+        noteInput.value = 'edited';
+        noteInput.dispatch('input'); await tick();
+        console.log('NOTE_AFTER_EDIT:' + text(byClass('note')[0]).trim());
+    "#;
+
+    let out = run_app("journey", driver);
+    let line = |prefix: &str| {
+        out.lines()
+            .find(|l| l.starts_with(prefix))
+            .unwrap_or_else(|| panic!("missing `{prefix}` in output:\n{out}"))
+            .strip_prefix(prefix)
+            .unwrap()
+            .to_string()
+    };
+
+    // Initial render.
+    assert_eq!(line("H1:"), "Lunas E2E App", "app title renders");
+    assert!(
+        line("CARD_CLASS:").contains("lead"),
+        "Card `tone` prop reached its `:class` interpolation"
+    );
+    assert_eq!(
+        line("CARD_HEAD:"),
+        "Dashboard for ada",
+        "named #head slot routed + read parent `user` state"
+    );
+    assert_eq!(
+        line("CARD_FOOT:"),
+        "rows: 3",
+        "scoped #foot slot received the child's `:count` (rows=3)"
+    );
+    assert_eq!(
+        line("COUNTER_INIT:"),
+        "10",
+        "Counter seeded from the `:start` prop (seed=10)"
+    );
+    assert!(
+        line("PAGE_INIT:").contains("Page one"),
+        "initial :if branch is page one"
+    );
+    assert_eq!(
+        line("BADGES_INIT:"),
+        "[alpha],[beta],[ada]",
+        "two :for badges + the <component :is> badge (user=ada)"
+    );
+
+    // Interactions.
+    assert_eq!(
+        line("COUNTER_AFTER_PLUS:"),
+        "12",
+        "child-local +1 twice updates only the child value"
+    );
+    assert!(
+        line("PAGE_TWO:").contains("Page two"),
+        ":elseif branch selected after navigating to two"
+    );
+    assert!(
+        line("PAGE_ONE:").contains("Page one"),
+        ":if branch reselected after navigating back to one"
+    );
+    assert_eq!(
+        line("BADGES_AFTER_ADD:"),
+        "[alpha],[beta],[extra],[ada]",
+        "array push mounts a new keyed Badge; :is badge stays last"
+    );
+    assert_eq!(
+        line("NOTE_AFTER_EDIT:"),
+        "note: edited",
+        "two-way input write-back updated the mirrored text in the child"
+    );
+}

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -22,14 +22,15 @@ fn plain_text_bind() {
     assert_eq!(
         js,
         "\
-import { component, anchorAppend, bind, box } from \"lunas\";
+import { component, anchorAppend, bind, box, refs } from \"lunas\";
 
 const HTML = \"<p></p>\";
 
 export default component(\"div\", {}, HTML, (c, props) => {
   const count = box(c, 0, 0)
   function inc(){ count.v++ }
-  const t0 = anchorAppend(c.root.childNodes[0]);
+  const [g0] = refs(c.root, [[0]]);
+  const t0 = anchorAppend(g0);
   bind(c, [0], () => { t0.data = `${count.v}`; });
 });
 "
@@ -136,7 +137,7 @@ fn props_seeded_from_input() {
         js.contains("const count = box(c, 0, start.v)"),
         "script read of the prop rewritten through the box: {js}"
     );
-    assert!(js.contains(", prop }"), "prop helper imported: {js}");
+    assert!(js.contains(", prop,"), "prop helper imported: {js}");
 }
 
 #[test]
@@ -150,7 +151,7 @@ fn deep_mutation_uses_deepbox() {
         "deep mutation -> deepBox: {js}"
     );
     assert!(
-        js.contains("import { component, anchorAppend, bind, deepBox }"),
+        js.contains("import { component, anchorAppend, bind, deepBox, refs }"),
         "{js}"
     );
     // The template read is rewritten through the box.
@@ -203,9 +204,15 @@ fn plain_if_emits_ifblock() {
     );
     // The branch skeleton is hoisted and built by its own fromHTML when shown.
     assert!(js.contains("const HTML_1 = \"<span>y</span>\";"), "{js}");
+    // The anchor target (the host <div>) is snapshotted against the pristine
+    // tree up front, so the anchor is stable under sibling insertions.
     assert!(
-        js.contains("const a0 = anchorAppend(c.root.childNodes[0]);"),
-        "{js}"
+        js.contains("const [g0] = refs(c.root, [[0]]);"),
+        "anchor target pre-captured: {js}"
+    );
+    assert!(
+        js.contains("const a0 = anchorAppend(g0);"),
+        "anchor created from the captured target: {js}"
     );
     assert!(
         js.contains("ifBlock(c, a0, [0], () => (show.v), () => {"),
@@ -372,8 +379,9 @@ fn simple_child_mounts_at_anchor() {
         "child module imported from @use, path as written: {js}"
     );
     assert!(
-        js.contains("const a0 = anchorAppend(c.root.childNodes[0]);"),
-        "anchor created inside the host element: {js}"
+        js.contains("const [g0] = refs(c.root, [[0]]);")
+            && js.contains("const a0 = anchorAppend(g0);"),
+        "anchor created inside the host element (target pre-captured): {js}"
     );
     assert!(
         js.contains("const ch0 = mountChild(c, a0, Child, {});"),

--- a/crates/lunas_compiler/tests/codegen_snapshot.rs
+++ b/crates/lunas_compiler/tests/codegen_snapshot.rs
@@ -1,0 +1,204 @@
+//! End-to-end **snapshot** suite: compiles a set of representative `.lunas`
+//! fixtures that together exercise the whole feature matrix (text/attr/event
+//! binds, two-way, `:if` cascades, keyed/nested `:for`, child components +
+//! `@input` props, slots, `:class`/`:style`, `:ref`, `:html`, `<component :is>`,
+//! `<teleport>`, multi-root fragments, `@use` imports) and locks the emitted JS
+//! against on-disk snapshots under `tests/snapshots/`.
+//!
+//! The emitted module text IS the contract with the runtime, so a change should
+//! surface as a reviewable snapshot diff.
+//!
+//! ## Regenerating snapshots
+//!
+//! When an intentional emitter change moves the output, regenerate every
+//! snapshot in one shot:
+//!
+//! ```text
+//! UPDATE_SNAPSHOTS=1 cargo test -p lunas_compiler --test codegen_snapshot
+//! ```
+//!
+//! With `UPDATE_SNAPSHOTS` set the test writes the current output to disk and
+//! passes; review the resulting `git diff` before committing. Without it (the
+//! default, and in CI) each fixture is compiled and byte-compared to its stored
+//! snapshot; a mismatch fails with a unified-ish diff and the regen hint.
+//!
+//! Diagnostics are asserted per fixture: none may be errors, and the set of
+//! warning messages must match the fixture's declared expectation exactly.
+
+use std::path::{Path, PathBuf};
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn snapshots_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/snapshots")
+}
+
+fn update_mode() -> bool {
+    std::env::var_os("UPDATE_SNAPSHOTS").is_some()
+}
+
+/// Compiles `<fixtures>/<rel>.lunas`, asserts diagnostics, then snapshots the
+/// emitted JS to `<snapshots>/<snapshot>.js`.
+///
+/// `expected_warnings` are substrings; each must match exactly one warning
+/// message, and there must be no *unexpected* warnings and no errors.
+fn snapshot(rel: &str, snapshot: &str, expected_warnings: &[&str]) {
+    let src_path = fixtures_dir().join(format!("{rel}.lunas"));
+    let source = std::fs::read_to_string(&src_path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", src_path.display()));
+
+    let (js, diags) = lunas_compiler::compile(&source);
+
+    // No errors, ever.
+    let errors: Vec<&str> = diags
+        .iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message.as_str())
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "fixture `{rel}` produced error diagnostics: {errors:?}"
+    );
+
+    // Warnings must match the declared expectation exactly (order-independent).
+    let mut warnings: Vec<&str> = diags
+        .iter()
+        .filter(|d| !d.is_error())
+        .map(|d| d.message.as_str())
+        .collect();
+    let mut unmatched_expected = Vec::new();
+    for want in expected_warnings {
+        if let Some(pos) = warnings.iter().position(|w| w.contains(want)) {
+            warnings.remove(pos);
+        } else {
+            unmatched_expected.push(*want);
+        }
+    }
+    assert!(
+        unmatched_expected.is_empty(),
+        "fixture `{rel}`: expected warning(s) not found: {unmatched_expected:?}"
+    );
+    assert!(
+        warnings.is_empty(),
+        "fixture `{rel}`: unexpected warning diagnostics: {warnings:?}"
+    );
+
+    let js = js.unwrap_or_else(|| panic!("fixture `{rel}` emitted no module"));
+
+    let snap_path = snapshots_dir().join(format!("{snapshot}.js"));
+    if update_mode() {
+        std::fs::create_dir_all(snapshots_dir()).unwrap();
+        std::fs::write(&snap_path, &js)
+            .unwrap_or_else(|e| panic!("write snapshot {}: {e}", snap_path.display()));
+        return;
+    }
+
+    let stored = std::fs::read_to_string(&snap_path).unwrap_or_else(|_| {
+        panic!(
+            "snapshot missing for `{rel}` at {}.\n\
+             Run `UPDATE_SNAPSHOTS=1 cargo test -p lunas_compiler --test codegen_snapshot` to create it.",
+            snap_path.display()
+        )
+    });
+
+    if stored != js {
+        panic!(
+            "snapshot mismatch for `{rel}` ({}).\n{}\n\
+             Run `UPDATE_SNAPSHOTS=1 cargo test -p lunas_compiler --test codegen_snapshot` \
+             to regenerate, then review the diff.",
+            snap_path.display(),
+            first_diff(&stored, &js)
+        );
+    }
+}
+
+/// A compact first-divergence report between the stored snapshot and the new
+/// output — enough to see *where* the emitter changed without pulling in a diff
+/// crate.
+fn first_diff(old: &str, new: &str) -> String {
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+    let max = old_lines.len().max(new_lines.len());
+    for i in 0..max {
+        let o = old_lines.get(i).copied().unwrap_or("<eof>");
+        let n = new_lines.get(i).copied().unwrap_or("<eof>");
+        if o != n {
+            return format!(
+                "first divergence at line {}:\n  - stored: {o}\n  + actual: {n}",
+                i + 1
+            );
+        }
+    }
+    "content differs only in trailing whitespace/length".to_string()
+}
+
+fn assert_fixtures_exist() {
+    assert!(
+        Path::new(&fixtures_dir()).is_dir(),
+        "fixtures dir missing: {}",
+        fixtures_dir().display()
+    );
+}
+
+#[test]
+fn text_attr_event() {
+    assert_fixtures_exist();
+    snapshot("text_attr_event", "text_attr_event", &[]);
+}
+
+#[test]
+fn two_way() {
+    snapshot("two_way", "two_way", &[]);
+}
+
+#[test]
+fn if_cascade() {
+    snapshot("if_cascade", "if_cascade", &[]);
+}
+
+#[test]
+fn for_keyed_nested() {
+    snapshot("for_keyed_nested", "for_keyed_nested", &[]);
+}
+
+#[test]
+fn class_style() {
+    snapshot("class_style", "class_style", &[]);
+}
+
+#[test]
+fn ref_html() {
+    snapshot("ref_html", "ref_html", &[]);
+}
+
+#[test]
+fn dynamic_teleport() {
+    snapshot("dynamic_teleport", "dynamic_teleport", &[]);
+}
+
+#[test]
+fn multi_root() {
+    snapshot("multi_root", "multi_root", &[]);
+}
+
+#[test]
+fn app_badge() {
+    snapshot("app/Badge", "app_Badge", &[]);
+}
+
+#[test]
+fn app_counter() {
+    snapshot("app/Counter", "app_Counter", &[]);
+}
+
+#[test]
+fn app_card() {
+    snapshot("app/Card", "app_Card", &[]);
+}
+
+#[test]
+fn app_root() {
+    snapshot("app/App", "app_App", &[]);
+}

--- a/crates/lunas_compiler/tests/fixtures/Notice.lunas
+++ b/crates/lunas_compiler/tests/fixtures/Notice.lunas
@@ -1,0 +1,4 @@
+@input label:string = ""
+
+html:
+    <aside class="notice">!${label}!</aside>

--- a/crates/lunas_compiler/tests/fixtures/Panel.lunas
+++ b/crates/lunas_compiler/tests/fixtures/Panel.lunas
@@ -1,0 +1,4 @@
+@input label:string = ""
+
+html:
+    <section class="panel">${label}</section>

--- a/crates/lunas_compiler/tests/fixtures/README.md
+++ b/crates/lunas_compiler/tests/fixtures/README.md
@@ -1,0 +1,30 @@
+# E2E fixtures
+
+Representative `.lunas` components exercising the whole compiler feature matrix.
+Each fixture is compiled by:
+
+- `codegen_snapshot.rs` — emits the JS and diffs it against `tests/snapshots/<name>.js`.
+- `codegen_app.rs` — for the multi-file app fixtures, runs the emitted modules
+  against the real runtime under the node dom-shim.
+- `browser_smoke.rs` — pre-compiles a subset, inlines runtime + compiled JS, and
+  drives them in real headless Chrome.
+
+Single-file fixtures live at the top level. Multi-file app fixtures live under
+`app/` (a parent + its children, wired through `@use`).
+
+## Feature coverage map
+
+| fixture              | features exercised                                           |
+| -------------------- | ------------------------------------------------------------ |
+| `text_attr_event`    | text bind, mixed text run, bound attr, static-interp attr, event listener |
+| `two_way`            | `::value` (input) + `::checked` (change) two-way bindings    |
+| `if_cascade`         | `:if` / `:elseif` / `:else` chain, nested reactive text      |
+| `for_keyed_nested`   | keyed `:for`, nested `:for`, nested `:if` inside an item     |
+| `class_style`        | `:class` object + static merge, `:style` object              |
+| `ref_html`           | `:ref` element handle, `:html` raw insertion                 |
+| `dynamic_teleport`   | `<component :is>`, `<teleport>` portal                       |
+| `multi_root`         | fragment / multi-root component with a top-level `:if`       |
+| `app/App`            | parent: child components, `@input` props, slots, `<component :is>`, `@use` |
+| `app/Counter`        | `@input` prop, local state, event, two-way                  |
+| `app/Card`           | default + named + scoped slots, slot fallback                |
+| `app/Badge`          | tiny leaf child (`@input`), used through `:is` and in `:for` |

--- a/crates/lunas_compiler/tests/fixtures/app/App.lunas
+++ b/crates/lunas_compiler/tests/fixtures/app/App.lunas
@@ -1,0 +1,47 @@
+@use Counter from "./Counter.lunas"
+@use Card from "./Card.lunas"
+@use Badge from "./Badge.lunas"
+
+html:
+    <main class="app">
+        <h1>${title}</h1>
+
+        <nav>
+            <button @click="show('one')">one</button>
+            <button @click="show('two')">two</button>
+            <button @click="addTag()">add tag</button>
+        </nav>
+
+        <Card tone="lead">
+            <template #head>Dashboard for ${user}</template>
+            The counter starts at ${seed}.
+            <Counter :start="seed"/>
+            <template #foot="s">rows: ${s.count}</template>
+        </Card>
+
+        <p :if="page == 'one'">Page one is active.</p>
+        <p :elseif="page == 'two'">Page two is active.</p>
+        <p :else>No page selected.</p>
+
+        <ul class="tags">
+            <li :for="tag of tags" :key="tag.id">
+                <Badge :text="tag.label"/>
+            </li>
+        </ul>
+
+        <component :is="Badge" :text="user"/>
+    </main>
+
+script:
+    let title = "Lunas E2E App"
+    let user = "ada"
+    let seed = 10
+    let page = "one"
+    let tags = [
+        { id: 1, label: "alpha" },
+        { id: 2, label: "beta" }
+    ]
+    function show(p) { page = p }
+    function addTag() {
+        tags.push({ id: tags.length + 1, label: "extra" })
+    }

--- a/crates/lunas_compiler/tests/fixtures/app/Badge.lunas
+++ b/crates/lunas_compiler/tests/fixtures/app/Badge.lunas
@@ -1,0 +1,4 @@
+@input text:string = "?"
+
+html:
+    <span class="badge">[${text}]</span>

--- a/crates/lunas_compiler/tests/fixtures/app/Card.lunas
+++ b/crates/lunas_compiler/tests/fixtures/app/Card.lunas
@@ -1,0 +1,11 @@
+@input tone:string = "plain"
+
+html:
+    <section class="card ${tone}">
+        <header><slot name="head">untitled</slot></header>
+        <main><slot>empty</slot></main>
+        <footer><slot name="foot" :count="rows"></slot></footer>
+    </section>
+
+script:
+    let rows = 3

--- a/crates/lunas_compiler/tests/fixtures/app/Counter.lunas
+++ b/crates/lunas_compiler/tests/fixtures/app/Counter.lunas
@@ -1,0 +1,16 @@
+@input start:number = 0
+
+html:
+    <div class="counter">
+        <button @click="dec()">-</button>
+        <span class="value">${value}</span>
+        <button @click="inc()">+</button>
+        <input ::value="note">
+        <p class="note">note: ${note}</p>
+    </div>
+
+script:
+    let value = start
+    let note = "x"
+    function inc() { value = value + 1 }
+    function dec() { value = value - 1 }

--- a/crates/lunas_compiler/tests/fixtures/class_style.lunas
+++ b/crates/lunas_compiler/tests/fixtures/class_style.lunas
@@ -1,0 +1,12 @@
+html:
+    <div class="box" :class="{ active: on, big: huge }" :style="{ color: hue, fontWeight: weight }" @click="go()"></div>
+
+script:
+    let on = false
+    let huge = true
+    let hue = "red"
+    let weight = "bold"
+    function go() {
+        on = !on
+        hue = "blue"
+    }

--- a/crates/lunas_compiler/tests/fixtures/dynamic_teleport.lunas
+++ b/crates/lunas_compiler/tests/fixtures/dynamic_teleport.lunas
@@ -1,0 +1,17 @@
+@use Panel from "./Panel.lunas"
+@use Notice from "./Notice.lunas"
+
+html:
+    <div>
+        <component :is="view" :label="title"/>
+        <teleport to="#portal">
+            <p @click="grow()">${msg}</p>
+        </teleport>
+    </div>
+
+script:
+    let view = Panel
+    let title = "hi"
+    let msg = "in portal"
+    function swap() { view = Notice }
+    function grow() { msg = "grew" }

--- a/crates/lunas_compiler/tests/fixtures/for_keyed_nested.lunas
+++ b/crates/lunas_compiler/tests/fixtures/for_keyed_nested.lunas
@@ -1,0 +1,24 @@
+html:
+    <div>
+        <button @click="add()">add</button>
+        <button @click="toggleFirst()">toggle</button>
+        <ul>
+            <li :for="group of groups" :key="group.id">
+                <b>${group.name}</b>
+                <em :if="group.open">(open)</em>
+                <ol>
+                    <li :for="tag of group.tags" :key="tag">${tag}</li>
+                </ol>
+            </li>
+        </ul>
+    </div>
+
+script:
+    let groups = [
+        { id: 1, name: "a", open: true, tags: ["x", "y"] },
+        { id: 2, name: "b", open: false, tags: ["z"] }
+    ]
+    function add() {
+        groups.push({ id: groups.length + 1, name: "n", open: false, tags: ["t"] })
+    }
+    function toggleFirst() { groups[0].open = !groups[0].open }

--- a/crates/lunas_compiler/tests/fixtures/if_cascade.lunas
+++ b/crates/lunas_compiler/tests/fixtures/if_cascade.lunas
@@ -1,0 +1,11 @@
+html:
+    <div>
+        <button @click="bump()">step</button>
+        <p :if="n == 0">zero</p>
+        <p :elseif="n > 3">big ${n}</p>
+        <p :else>small ${n}</p>
+    </div>
+
+script:
+    let n = 0
+    function bump() { n = n + 1 }

--- a/crates/lunas_compiler/tests/fixtures/multi_root.lunas
+++ b/crates/lunas_compiler/tests/fixtures/multi_root.lunas
@@ -1,0 +1,12 @@
+html:
+    <h1 @click="rename()">${title}</h1>
+    <p :if="show">visible ${title}</p>
+    <footer>end</footer>
+
+script:
+    let title = "T"
+    let show = true
+    function rename() {
+        title = "T2"
+        show = !show
+    }

--- a/crates/lunas_compiler/tests/fixtures/ref_html.lunas
+++ b/crates/lunas_compiler/tests/fixtures/ref_html.lunas
@@ -1,0 +1,14 @@
+html:
+    <div>
+        <input :ref="field">
+        <article :html="markup"></article>
+        <button @click="fill()">fill</button>
+    </div>
+
+script:
+    let field
+    let markup = "<b>bold</b>"
+    function fill() {
+        field.value = "typed"
+        markup = "<i>italic</i>"
+    }

--- a/crates/lunas_compiler/tests/fixtures/text_attr_event.lunas
+++ b/crates/lunas_compiler/tests/fixtures/text_attr_event.lunas
@@ -1,0 +1,14 @@
+html:
+    <div>
+        <h1 :title="label">${greeting}, ${name}!</h1>
+        <p class="tag ${flavor} end">count is ${count}</p>
+        <button @click="inc()">bump</button>
+    </div>
+
+script:
+    let greeting = "hello"
+    let name = "world"
+    let label = "the heading"
+    let flavor = "sweet"
+    let count = 0
+    function inc() { count = count + 1 }

--- a/crates/lunas_compiler/tests/fixtures/two_way.lunas
+++ b/crates/lunas_compiler/tests/fixtures/two_way.lunas
@@ -1,0 +1,10 @@
+html:
+    <form>
+        <input ::value="name">
+        <input type="checkbox" ::checked="agree">
+        <p>name=${name} agree=${agree}</p>
+    </form>
+
+script:
+    let name = "ada"
+    let agree = false

--- a/crates/lunas_compiler/tests/snapshots/app_App.js
+++ b/crates/lunas_compiler/tests/snapshots/app_App.js
@@ -1,0 +1,94 @@
+import { component, anchorAppend, anchorBefore, bind, box, deepBox, dynamicBlock, forBlock, fromHTML, ifChain, mountChild, on, refs, slotContent } from "lunas";
+import Badge from "./Badge.lunas";
+import Card from "./Card.lunas";
+import Counter from "./Counter.lunas";
+
+const HTML = "<main class=\"app\"><h1></h1><nav><button>one</button><button>two</button><button>add tag</button></nav><ul class=\"tags\"></ul></main>";
+const HTML_1 = "";
+const HTML_2 = "";
+const HTML_3 = "";
+const HTML_4 = "<p>Page one is active.</p>";
+const HTML_5 = "<p>Page two is active.</p>";
+const HTML_6 = "<p>No page selected.</p>";
+const HTML_7 = "<li></li>";
+
+export default component("div", {}, HTML, (c, props) => {
+  let title = "Lunas E2E App"
+  let user = "ada"
+  let seed = 10
+  const page = box(c, 0, "one")
+  const tags = deepBox(c, 1, [
+      { id: 1, label: "alpha" },
+      { id: 2, label: "beta" }
+  ])
+  function show(p) { page.v = p }
+  function addTag() {
+      tags.v.push({ id: tags.v.length + 1, label: "extra" })
+  }
+  const [e0, e1, e2] = refs(c.root, [[0, 1, 0], [0, 1, 1], [0, 1, 2]]);
+  const [g0, g1, g2, g3, g4] = refs(c.root, [[0, 0], [0, 2], [0, 2], [0, 2], [0]]);
+  const t0 = anchorAppend(g0);
+  t0.data = `${title}`;
+  const a0 = anchorBefore(g1);
+  const s0 = {
+    default: (slotProps, onCleanup) => slotContent(c, (slotProps) => {
+      const r0 = fromHTML(HTML_1, c.root);
+      const [g5, g6] = refs(r0, [[], []]);
+      const t1 = anchorAppend(g5);
+      t1.data = `
+            The counter starts at ${seed}.
+            `;
+      const a1 = anchorAppend(g6);
+      const ch0 = mountChild(c, a1, Counter, { start: () => (seed) });
+      return Array.from(r0.childNodes);
+    }, slotProps, onCleanup),
+    head: (slotProps, onCleanup) => slotContent(c, (slotProps) => {
+      const r1 = fromHTML(HTML_2, c.root);
+      const [g7] = refs(r1, [[]]);
+      const t2 = anchorAppend(g7);
+      t2.data = `Dashboard for ${user}`;
+      return Array.from(r1.childNodes);
+    }, slotProps, onCleanup),
+    foot: (slotProps, onCleanup) => slotContent(c, (s) => {
+      const r2 = fromHTML(HTML_3, c.root);
+      const [g8] = refs(r2, [[]]);
+      const t3 = anchorAppend(g8);
+      t3.data = `rows: ${s.count}`;
+      return Array.from(r2.childNodes);
+    }, slotProps, onCleanup),
+  };
+  const ch1 = mountChild(c, a0, Card, { tone: `lead`, $slots: s0 });
+  const a2 = anchorBefore(g2);
+  ifChain(c, a2, [0], () => (page.v == 'one') ? 0 : (page.v == 'two') ? 1 : 2, [
+    () => {
+      const r3 = fromHTML(HTML_4, a2);
+      return r3.childNodes[0];
+    },
+    () => {
+      const r4 = fromHTML(HTML_5, a2);
+      return r4.childNodes[0];
+    },
+    () => {
+      const r5 = fromHTML(HTML_6, a2);
+      return r5.childNodes[0];
+    },
+  ]);
+  const a3 = anchorAppend(g3);
+  forBlock(c, a3, [1], () => Array.from((tags.v) || []), {
+    html: HTML_7,
+    wire: (r6, d0) => {
+      let tag = d0;
+      const [g9] = refs(r6, [[]]);
+      const a4 = anchorAppend(g9);
+      const ch2 = mountChild(c, a4, Badge, { text: () => (tag.label) });
+      bind(c, [], () => { ch2.setProp("text", tag.label); });
+      return (d1) => { (tag = d1); };
+    },
+    keyOf: (d2) => { const tag = d2; return (tag.id); },
+  });
+  const a5 = anchorAppend(g4);
+  const ch3 = dynamicBlock(c, a5, [], () => (Badge), { text: () => (user) });
+  on(e0, "click", () => { show('one'); });
+  on(e1, "click", () => { show('two'); });
+  on(e2, "click", () => { addTag(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/app_Badge.js
+++ b/crates/lunas_compiler/tests/snapshots/app_Badge.js
@@ -1,0 +1,10 @@
+import { component, anchorAppend, bind, prop, refs } from "lunas";
+
+const HTML = "<span class=\"badge\"></span>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const text = prop(c, "text", 0, props.text, ("?"));
+  const [g0] = refs(c.root, [[0]]);
+  const t0 = anchorAppend(g0);
+  bind(c, [0], () => { t0.data = `[${text.v}]`; });
+});

--- a/crates/lunas_compiler/tests/snapshots/app_Card.js
+++ b/crates/lunas_compiler/tests/snapshots/app_Card.js
@@ -1,0 +1,25 @@
+import { component, anchorAppend, bind, fromHTML, prop, refs, slotBlock } from "lunas";
+
+const HTML = "<section><header></header><main></main><footer></footer></section>";
+const HTML_1 = "untitled";
+const HTML_2 = "empty";
+
+export default component("div", {}, HTML, (c, props) => {
+  const tone = prop(c, "tone", 0, props.tone, ("plain"));
+  let rows = 3
+  const [e0] = refs(c.root, [[0]]);
+  const [g0, g1, g2] = refs(c.root, [[0, 0], [0, 1], [0, 2]]);
+  const a0 = anchorAppend(g0);
+  slotBlock(c, a0, props.$slots && props.$slots["head"], (slotProps) => {
+    const r0 = fromHTML(HTML_1, a0);
+    return Array.from(r0.childNodes);
+  });
+  const a1 = anchorAppend(g1);
+  slotBlock(c, a1, props.$slots && props.$slots["default"], (slotProps) => {
+    const r1 = fromHTML(HTML_2, a1);
+    return Array.from(r1.childNodes);
+  });
+  const a2 = anchorAppend(g2);
+  slotBlock(c, a2, props.$slots && props.$slots["foot"], null, () => ({ count: (rows) }));
+  bind(c, [0], () => { e0.setAttribute("class", `card ${tone.v}`); });
+});

--- a/crates/lunas_compiler/tests/snapshots/app_Counter.js
+++ b/crates/lunas_compiler/tests/snapshots/app_Counter.js
@@ -1,0 +1,21 @@
+import { component, anchorAppend, bind, box, on, prop, refs } from "lunas";
+
+const HTML = "<div class=\"counter\"><button>-</button><span class=\"value\"></span><button>+</button><input><p class=\"note\"></p></div>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const start = prop(c, "start", 2, props.start, (0));
+  const value = box(c, 0, start.v)
+  const note = box(c, 1, "x")
+  function inc() { value.v = value.v + 1 }
+  function dec() { value.v = value.v - 1 }
+  const [e0, e1, e2] = refs(c.root, [[0, 0], [0, 2], [0, 3]]);
+  const [g0, g1] = refs(c.root, [[0, 1], [0, 4]]);
+  const t0 = anchorAppend(g0);
+  bind(c, [0], () => { t0.data = `${value.v}`; });
+  const t1 = anchorAppend(g1);
+  bind(c, [1], () => { t1.data = `note: ${note.v}`; });
+  on(e0, "click", () => { dec(); });
+  on(e1, "click", () => { inc(); });
+  bind(c, [1], () => { e2.value = note.v; });
+  on(e2, "input", () => { note.v = e2.value; });
+});

--- a/crates/lunas_compiler/tests/snapshots/class_style.js
+++ b/crates/lunas_compiler/tests/snapshots/class_style.js
@@ -1,0 +1,18 @@
+import { component, bind, box, on as $on, refs, setClass, setStyle } from "lunas";
+
+const HTML = "<div class=\"box\"></div>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const on = box(c, 0, false)
+  let huge = true
+  const hue = box(c, 1, "red")
+  let weight = "bold"
+  function go() {
+      on.v = !on.v
+      hue.v = "blue"
+  }
+  const [e0] = refs(c.root, [[0]]);
+  bind(c, [0], () => { setClass(e0, "box", { active: on.v, big: huge }); });
+  bind(c, [1], () => { setStyle(e0, "", { color: hue.v, fontWeight: weight }); });
+  $on(e0, "click", () => { go(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/dynamic_teleport.js
+++ b/crates/lunas_compiler/tests/snapshots/dynamic_teleport.js
@@ -1,0 +1,27 @@
+import { component, anchorAppend, bind, box, dynamicBlock, fromHTML, on, refs, teleportBlock } from "lunas";
+import Notice from "./Notice.lunas";
+import Panel from "./Panel.lunas";
+
+const HTML = "<div></div>";
+const HTML_1 = "<p></p>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const view = box(c, 0, Panel)
+  let title = "hi"
+  const msg = box(c, 1, "in portal")
+  function swap() { view.v = Notice }
+  function grow() { msg.v = "grew" }
+  const [g0, g1] = refs(c.root, [[0], [0]]);
+  const a0 = anchorAppend(g0);
+  const ch0 = dynamicBlock(c, a0, [0], () => (view.v), { label: () => (title) });
+  const a1 = anchorAppend(g1);
+  teleportBlock(c, a1, () => (`#portal`), () => {
+    const r0 = fromHTML(HTML_1, a1);
+    const [e0] = refs(r0, [[0]]);
+    const [g2] = refs(r0, [[0]]);
+    const t0 = anchorAppend(g2);
+    bind(c, [1], () => { t0.data = `${msg.v}`; });
+    on(e0, "click", () => { grow(); });
+    return Array.from(r0.childNodes);
+  });
+});

--- a/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
+++ b/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
@@ -1,0 +1,50 @@
+import { component, anchorAppend, anchorBefore, bind, deepBox, forBlock, fromHTML, ifBlock, on, refs } from "lunas";
+
+const HTML = "<div><button>add</button><button>toggle</button><ul></ul></div>";
+const HTML_1 = "<li><b></b><ol></ol></li>";
+const HTML_2 = "<em>(open)</em>";
+const HTML_3 = "<li></li>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const groups = deepBox(c, 0, [
+      { id: 1, name: "a", open: true, tags: ["x", "y"] },
+      { id: 2, name: "b", open: false, tags: ["z"] }
+  ])
+  function add() {
+      groups.v.push({ id: groups.v.length + 1, name: "n", open: false, tags: ["t"] })
+  }
+  function toggleFirst() { groups.v[0].open = !groups.v[0].open }
+  const [e0, e1] = refs(c.root, [[0, 0], [0, 1]]);
+  const [g0] = refs(c.root, [[0, 2]]);
+  const a0 = anchorAppend(g0);
+  forBlock(c, a0, [0], () => Array.from((groups.v) || []), {
+    html: HTML_1,
+    wire: (r0, d0) => {
+      let group = d0;
+      const [g1, g2, g3] = refs(r0, [[0], [1], [1]]);
+      const t0 = anchorAppend(g1);
+      bind(c, [], () => { t0.data = `${group.name}`; });
+      const a1 = anchorBefore(g2);
+      ifBlock(c, a1, [], () => (group.open), () => {
+        const r1 = fromHTML(HTML_2, a1);
+        return r1.childNodes[0];
+      });
+      const a2 = anchorAppend(g3);
+      forBlock(c, a2, [], () => Array.from((group.tags) || []), {
+        html: HTML_3,
+        wire: (r2, d2) => {
+          let tag = d2;
+          const [g4] = refs(r2, [[]]);
+          const t1 = anchorAppend(g4);
+          bind(c, [], () => { t1.data = `${tag}`; });
+          return (d3) => { (tag = d3); };
+        },
+        keyOf: (d4) => { const tag = d4; return (tag); },
+      });
+      return (d1) => { (group = d1); };
+    },
+    keyOf: (d5) => { const group = d5; return (group.id); },
+  });
+  on(e0, "click", () => { add(); });
+  on(e1, "click", () => { toggleFirst(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/if_cascade.js
+++ b/crates/lunas_compiler/tests/snapshots/if_cascade.js
@@ -1,0 +1,35 @@
+import { component, anchorAppend, bind, box, fromHTML, ifChain, on, refs } from "lunas";
+
+const HTML = "<div><button>step</button></div>";
+const HTML_1 = "<p>zero</p>";
+const HTML_2 = "<p></p>";
+const HTML_3 = "<p></p>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const n = box(c, 0, 0)
+  function bump() { n.v = n.v + 1 }
+  const [e0] = refs(c.root, [[0, 0]]);
+  const [g0] = refs(c.root, [[0]]);
+  const a0 = anchorAppend(g0);
+  ifChain(c, a0, [0], () => (n.v == 0) ? 0 : (n.v > 3) ? 1 : 2, [
+    () => {
+      const r0 = fromHTML(HTML_1, a0);
+      return r0.childNodes[0];
+    },
+    () => {
+      const r1 = fromHTML(HTML_2, a0);
+      const [g1] = refs(r1, [[0]]);
+      const t0 = anchorAppend(g1);
+      bind(c, [0], () => { t0.data = `big ${n.v}`; });
+      return r1.childNodes[0];
+    },
+    () => {
+      const r2 = fromHTML(HTML_3, a0);
+      const [g2] = refs(r2, [[0]]);
+      const t1 = anchorAppend(g2);
+      bind(c, [0], () => { t1.data = `small ${n.v}`; });
+      return r2.childNodes[0];
+    },
+  ]);
+  on(e0, "click", () => { bump(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/multi_root.js
+++ b/crates/lunas_compiler/tests/snapshots/multi_root.js
@@ -1,0 +1,26 @@
+import { fragment, anchorAppend, anchorBefore, bind, box, fromHTML, ifBlock, on, refs } from "lunas";
+
+const HTML = "<h1></h1><footer>end</footer>";
+const HTML_1 = "<p></p>";
+
+export default fragment({}, HTML, (c, props) => {
+  const title = box(c, 0, "T")
+  const show = box(c, 1, true)
+  function rename() {
+      title.v = "T2"
+      show.v = !show.v
+  }
+  const [e0] = refs(c.root, [[0]]);
+  const [g0, g1] = refs(c.root, [[0], [1]]);
+  const t0 = anchorAppend(g0);
+  bind(c, [0], () => { t0.data = `${title.v}`; });
+  const a0 = anchorBefore(g1);
+  ifBlock(c, a0, [1], () => (show.v), () => {
+    const r0 = fromHTML(HTML_1, a0);
+    const [g2] = refs(r0, [[0]]);
+    const t1 = anchorAppend(g2);
+    bind(c, [0], () => { t1.data = `visible ${title.v}`; });
+    return r0.childNodes[0];
+  });
+  on(e0, "click", () => { rename(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/ref_html.js
+++ b/crates/lunas_compiler/tests/snapshots/ref_html.js
@@ -1,0 +1,16 @@
+import { component, bind, box, deepBox, on, refs } from "lunas";
+
+const HTML = "<div><input><article></article><button>fill</button></div>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const field = deepBox(c, 0, undefined)
+  const markup = box(c, 1, "<b>bold</b>")
+  function fill() {
+      field.v.value = "typed"
+      markup.v = "<i>italic</i>"
+  }
+  const [e0, e1, e2] = refs(c.root, [[0, 0], [0, 1], [0, 2]]);
+  field.v = e0;
+  bind(c, [1], () => { e1.innerHTML = markup.v; });
+  on(e2, "click", () => { fill(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/text_attr_event.js
+++ b/crates/lunas_compiler/tests/snapshots/text_attr_event.js
@@ -1,0 +1,21 @@
+import { component, anchorAppend, bind, box, on, refs } from "lunas";
+
+const HTML = "<div><h1></h1><p></p><button>bump</button></div>";
+
+export default component("div", {}, HTML, (c, props) => {
+  let greeting = "hello"
+  let name = "world"
+  let label = "the heading"
+  let flavor = "sweet"
+  const count = box(c, 0, 0)
+  function inc() { count.v = count.v + 1 }
+  const [e0, e1, e2] = refs(c.root, [[0, 0], [0, 1], [0, 2]]);
+  const [g0, g1] = refs(c.root, [[0, 0], [0, 1]]);
+  const t0 = anchorAppend(g0);
+  t0.data = `${greeting}, ${name}!`;
+  const t1 = anchorAppend(g1);
+  bind(c, [0], () => { t1.data = `count is ${count.v}`; });
+  e0.setAttribute("title", label);
+  e1.setAttribute("class", `tag ${flavor} end`);
+  on(e2, "click", () => { inc(); });
+});

--- a/crates/lunas_compiler/tests/snapshots/two_way.js
+++ b/crates/lunas_compiler/tests/snapshots/two_way.js
@@ -1,0 +1,16 @@
+import { component, anchorAppend, bind, box, on, refs } from "lunas";
+
+const HTML = "<form><input><input type=\"checkbox\"><p></p></form>";
+
+export default component("div", {}, HTML, (c, props) => {
+  const name = box(c, 0, "ada")
+  const agree = box(c, 1, false)
+  const [e0, e1] = refs(c.root, [[0, 0], [0, 1]]);
+  const [g0] = refs(c.root, [[0, 2]]);
+  const t0 = anchorAppend(g0);
+  bind(c, [0, 1], () => { t0.data = `name=${name.v} agree=${agree.v}`; });
+  bind(c, [0], () => { e0.value = name.v; });
+  on(e0, "input", () => { name.v = e0.value; });
+  bind(c, [1], () => { e1.checked = !!(agree.v); });
+  on(e1, "change", () => { agree.v = e1.checked; });
+});

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -15,7 +15,7 @@ statuses: [done, in_progress, todo, deferred]
 tree:
   id: lunas
   title: Lunas — web front-end framework
-  status: in_progress
+  status: done
   children:
     - id: foundation
       title: Compiler foundation
@@ -36,7 +36,7 @@ tree:
         - { id: reactivity-design, title: "Adjacency dispatch; no BigInt; Proxy floor", status: done }
     - id: codegen
       title: Code generator (ResolvedComponent → JS)
-      status: in_progress
+      status: done
       children:
         - { id: cg-scaffold, title: "Codegen module + JS emitter utils", status: done }
         - { id: cg-static-html, title: "Static skeleton emission (escaped, minified)", status: done }
@@ -50,7 +50,7 @@ tree:
         - { id: cg-for, title: "List rendering (keyed :for)", status: done }
         - { id: cg-components, title: "Child component mounting", status: done }
         - { id: cg-inputs, title: "@input props handling", status: done }
-        - { id: cg-e2e, title: "End-to-end snapshot + browser smoke tests", status: todo }
+        - { id: cg-e2e, title: "End-to-end snapshot + browser smoke tests", status: done }
     - id: runtime
       title: Runtime (ES2015 + Proxy floor)
       status: done
@@ -99,7 +99,7 @@ tree:
         - { id: c-keepalive, title: "Keep-alive (component caching)", status: done }
     - id: app
       title: Application layer
-      status: todo
+      status: done
       children:
         - { id: a-router, title: "Router runtime (matching, history, outlet, guards)", status: done }
         - { id: a-ssr, title: "SSR + client hydration", status: deferred }


### PR DESCRIPTION
Final roadmap item **cg-e2e**. Three E2E layers over the whole feature matrix, one real compiler bug found and fixed, and the roadmap flipped to complete.

## Test layers

### 1. Snapshot suite — `crates/lunas_compiler/tests/codegen_snapshot.rs`
12 representative `.lunas` fixtures compiled via `lunas_compiler::compile` and byte-diffed against stored snapshots under `tests/snapshots/`. Diagnostics asserted per fixture (no errors; warnings must match exactly). Regeneration path: `UPDATE_SNAPSHOTS=1 cargo test -p lunas_compiler --test codegen_snapshot` (documented in the module header).

Fixture matrix (`tests/fixtures/`): text/attr binds · mixed text runs · events · two-way (`::value` input + `::checked` change) · `:if`/`:elseif`/`:else` cascades · keyed `:for` + nested `:for` + nested `:if` in an item · child components + `@input` props · default/named/scoped slots + fallback · `:class`/`:style` objects · `:ref` · `:html` · `<component :is>` · `<teleport>` · multi-root fragments · `@use` imports.

### 2. Full-app integration (node) — `crates/lunas_compiler/tests/codegen_app.rs`
A realistic multi-component app (`App` + `Counter`/`Card`/`Badge`, wired through `@use`) compiled and run against the **real runtime** (`packages/lunas/src`) under the node dom-shim. Drives an app-sized journey — mount, child counter events, `:if` page navigation, keyed `:for` growth (array push), scoped/named slots, two-way input write-back — asserting the DOM at each step. Extends the `codegen_exec.rs` patterns to a full app graph.

### 3. Browser smoke (real engine) — `crates/lunas_compiler/tests/browser_smoke.rs`
Compiles fixtures, stages the **real runtime** + a self-contained page, serves it with a tiny dependency-free node http server (`tests/browser/serve.mjs`), and drives **real headless Chrome** (`--headless=new --dump-dom`). An inline page script performs real clicks / input events and stamps `data-result` markers the harness asserts. **Zero npm dependencies.** Skips loudly when Chrome/node are absent; wired into CI as a new `smoke` job using `browser-actions/setup-chrome`.

**What the browser layer proves:** the compiled output + real runtime render *and react* correctly on Blink's real DOM + real event loop + real microtask timing — the parts the node dom-shim only fakes. Four scenarios: reactive text/attr binds, `:if` cascade swapping, keyed+nested `:for` reconciliation, and the full multi-component app journey (slots, props, `:is`, two-way).

## Bug found & fixed (`fix(codegen)`)
The E2E app surfaced a real emitter bug. Positional anchor navigation (`c.root.childNodes[0].childNodes[2]`) was re-evaluated **live** per dynamic slot. When one parent element hosts several dynamic insertion points as siblings (the app's `<main>` hosts a child component, an `:if` cascade, and a keyed `:for`), inserting content for an earlier slot shifted `childNodes` indices, so a later slot resolved to the **wrong node** — the badge list landed inside the page `<p>` and the `<ul>` disappeared.

**Fix:** snapshot every slot's anchor-target node up front via `refs()` against the pristine parse (before any insertion), then create anchors from those stable references. Applies uniformly to the top-level fragment and every nested `:if`/`:for` fragment. The Chrome layer confirms the fix in a real engine, not just the shim.

## Roadmap
`cg-e2e` → done · `codegen` parent → done (all children done) · `app` parent → done (all non-deferred children done) · root `lunas` → done. `a-ssr` stays `deferred` as intended. `updated:` left untouched.

## Verification (all green locally)
- `cargo fmt --all --check` · `cargo clippy --workspace --all-targets -D warnings`
- `cargo test --workspace` — 592 tests pass (incl. 12 snapshot, 1 app integration, 4 browser smoke, 25 existing exec)
- `node packages/lunas/test/run-all.mjs` — 17 files pass
- vite-plugin + create-lunas node suites pass
- Browser smoke: 4/4 pass in real Chrome 149 (~9s total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)