### PR TITLE
test(runtime): expand reactivity edge-case suite

### DIFF
--- a/packages/lunas/test/batch.edge.test.mjs
+++ b/packages/lunas/test/batch.edge.test.mjs
@@ -1,0 +1,188 @@
+// batch.edge.test.mjs — batch/nextTick edge cases beyond batch.test.mjs:
+// return value passthrough, batch+pending-microtask interplay, batch
+// exceptions still flush, empty batch, three-level nesting, nextTick
+// scheduled from inside a batch, sequential (non-nested) batches,
+// independent contexts, batchDepth bookkeeping.
+// Run: node packages/lunas/test/batch.edge.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { nextTick, batch } from "../src/batch.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("batch(c, fn) returns fn's return value", () => {
+  const c = createContext(null);
+  const result = batch(c, () => 42);
+  assert.strictEqual(result, 42);
+});
+
+await test("batch with zero writes is a harmless no-op (fn still runs, no flush error)", () => {
+  const c = createContext(null);
+  let ran = false;
+  assert.doesNotThrow(() => {
+    batch(c, () => {
+      ran = true;
+    });
+  });
+  assert.strictEqual(ran, true);
+});
+
+await test("batch that throws still flushes synchronously (finally block runs)", () => {
+  const c = createContext(null);
+  const d = box(c, 0, 0);
+  let paints = 0;
+  bind(c, [0], () => paints++);
+  paints = 0;
+  assert.throws(() => {
+    batch(c, () => {
+      d.v = 1;
+      throw new Error("fail");
+    });
+  }, /fail/);
+  assert.strictEqual(paints, 1, "the write before the throw is still flushed via finally");
+  assert.strictEqual(d.v, 1);
+});
+
+await test("batchDepth: absent before first use, resets to 0 after the outermost batch completes", () => {
+  const c = createContext(null);
+  assert.strictEqual(c.batchDepth, undefined, "field does not exist until first batch() call");
+  batch(c, () => {});
+  assert.strictEqual(c.batchDepth, 0, "back to 0 after outermost batch, ready for reuse");
+});
+
+await test("three-level nested batch: only the outermost call triggers a flush", () => {
+  const c = createContext(null);
+  const b = box(c, 0, 0);
+  let paints = 0;
+  bind(c, [0], () => paints++);
+  paints = 0;
+  batch(c, () => {
+    b.v = 1;
+    batch(c, () => {
+      b.v = 2;
+      batch(c, () => {
+        b.v = 3;
+      });
+      assert.strictEqual(paints, 0, "innermost batch exit does not flush");
+    });
+    assert.strictEqual(paints, 0, "mid-level batch exit does not flush either");
+  });
+  assert.strictEqual(paints, 1, "single flush only when the outermost batch call returns");
+  assert.strictEqual(b.v, 3, "final value from the deepest write");
+});
+
+await test("sequential (non-nested) batches on the same context each flush independently", () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let paints = 0;
+  bind(c, [0], () => paints++);
+  paints = 0;
+  batch(c, () => {
+    a.v = 1;
+  });
+  assert.strictEqual(paints, 1, "first batch flushed on its own exit");
+  batch(c, () => {
+    a.v = 2;
+  });
+  assert.strictEqual(paints, 2, "second (unrelated) batch flushed independently");
+});
+
+await test("batch interacts correctly with an already-pending microtask flush from a write made before it", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let paints = 0;
+  bind(c, [0], () => paints++);
+  paints = 0;
+  a.v = 1; // schedules a microtask flush that hasn't run yet
+  batch(c, () => {
+    a.v = 2; // synchronous batch flush happens at batch() exit, consuming the queue
+  });
+  assert.strictEqual(paints, 1, "batch's synchronous flush already drained the queue");
+  await tick();
+  assert.strictEqual(paints, 1, "the earlier-scheduled microtask flush finds an empty queue: harmless no-op");
+});
+
+await test("nextTick scheduled from inside a batch resolves after the batch's synchronous flush has landed", async () => {
+  const c = createContext(null);
+  const d = box(c, 0, 0);
+  let painted = -1;
+  bind(c, [0], () => {
+    painted = d.v;
+  });
+  let ntResolved = false;
+  batch(c, () => {
+    d.v = 9;
+    nextTick(c).then(() => {
+      ntResolved = true;
+    });
+    assert.strictEqual(painted, 0, "write not yet visible mid-batch: flush happens at batch exit");
+  });
+  assert.strictEqual(painted, 9, "flushed synchronously by the time batch() returns");
+  assert.strictEqual(ntResolved, false, "nextTick's promise callback is still a pending microtask continuation");
+  await tick();
+  assert.strictEqual(ntResolved, true);
+});
+
+await test("batches on two different contexts nest independently even when interleaved (c2's batch closes inside c1's)", () => {
+  const c1 = createContext(null);
+  const c2 = createContext(null);
+  const a1 = box(c1, 0, 0);
+  const a2 = box(c2, 0, 0);
+  let p1 = 0;
+  let p2 = 0;
+  bind(c1, [0], () => {
+    p1++;
+    void a1.v;
+  });
+  bind(c2, [0], () => {
+    p2++;
+    void a2.v;
+  });
+  p1 = 0;
+  p2 = 0;
+  batch(c1, () => {
+    a1.v = 1;
+    batch(c2, () => {
+      a2.v = 1;
+      batch(c2, () => {
+        a2.v = 2;
+      });
+      assert.strictEqual(p2, 0, "c2's inner nested batch hasn't closed yet");
+    });
+    assert.strictEqual(p2, 1, "c2 flushed fully on its own outermost batch exit, independent of c1 still being open");
+    assert.strictEqual(p1, 0, "c1 not yet flushed: still inside its own batch");
+  });
+  assert.strictEqual(p1, 1, "c1 flushed once its own outermost batch exits");
+});
+
+await test("multiple nextTick calls with no pending writes each still resolve, in call order", async () => {
+  const c = createContext(null);
+  const order = [];
+  const p1 = nextTick(c).then(() => order.push("a"));
+  const p2 = nextTick(c).then(() => order.push("b"));
+  const p3 = nextTick(c).then(() => order.push("c"));
+  await Promise.all([p1, p2, p3]);
+  assert.deepStrictEqual(order, ["a", "b", "c"]);
+});
+
+await test("nextTick does not itself trigger any bind reruns beyond what was already pending", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  runs = 0;
+  await nextTick(c); // nothing was written; should not cause any bind to run
+  assert.strictEqual(runs, 0, "nextTick alone never marks any var dirty");
+  void a;
+});
+
+console.log("batch.edge.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/boxes.deep.test.mjs
+++ b/packages/lunas/test/boxes.deep.test.mjs
@@ -1,0 +1,332 @@
+// boxes.deep.test.mjs — box/deepBox/shared edge cases beyond boxes.test.mjs:
+// identity no-ops, NaN semantics, deep array method coverage, nested-depth
+// mutation, Proxy identity stability, Map/Set limitations, whole-value
+// replacement, re-entrant writes.
+// Run: node packages/lunas/test/boxes.deep.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind } from "../src/core.mjs";
+import { box, deepBox, shared } from "../src/boxes.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// ---------------------------------------------------------------------------
+// box(): identity, NaN, undefined, rapid coalescing, re-entrant writes.
+// ---------------------------------------------------------------------------
+
+await test("box: identical object reference write is a no-op (=== check, not deep equal)", async () => {
+  const c = createContext(null);
+  const obj = { a: 1 };
+  const b = box(c, 0, obj);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  b.v = obj; // same reference
+  await tick();
+  assert.strictEqual(runs, 1, "no flush: x === v short-circuits in the setter");
+});
+
+await test("box: NaN -> NaN always triggers (NaN !== NaN, so the box's === guard never treats it as unchanged)", async () => {
+  const c = createContext(null);
+  const b = box(c, 0, NaN);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  b.v = NaN;
+  await tick();
+  assert.strictEqual(runs, 2, "every NaN write flushes, even setting NaN to NaN");
+  b.v = NaN;
+  await tick();
+  assert.strictEqual(runs, 3, "still triggers on a second identical NaN write");
+});
+
+await test("box: undefined -> concrete value transitions correctly", async () => {
+  const c = createContext(null);
+  const b = box(c, 0, undefined);
+  let seen;
+  bind(c, [0], () => {
+    seen = b.v;
+  });
+  assert.strictEqual(seen, undefined);
+  b.v = "x";
+  await tick();
+  assert.strictEqual(seen, "x");
+});
+
+await test("box: undefined -> undefined write is a no-op", async () => {
+  const c = createContext(null);
+  const b = box(c, 0, undefined);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  b.v = undefined;
+  await tick();
+  assert.strictEqual(runs, 1, "undefined === undefined -> no flush");
+});
+
+await test("box: rapid multi-set coalescing observes only the final value", async () => {
+  const c = createContext(null);
+  const b = box(c, 0, 0);
+  const seenEach = [];
+  bind(c, [0], () => seenEach.push(b.v));
+  seenEach.length = 0;
+  b.v = 1;
+  b.v = 2;
+  b.v = 3;
+  assert.deepStrictEqual(seenEach, [], "nothing runs synchronously");
+  await tick();
+  assert.deepStrictEqual(seenEach, [3], "single coalesced flush sees only the last write");
+});
+
+await test("box: set from inside a bind (re-entrant write to a different var) is delivered next flush", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const other = box(c, 1, 100);
+  const log = [];
+  bind(c, [0], () => {
+    log.push("a:" + a.v);
+    if (a.v === 1) other.v = 999;
+  });
+  bind(c, [1], () => log.push("other:" + other.v));
+  log.length = 0;
+  a.v = 1;
+  await tick();
+  assert.deepStrictEqual(log, ["a:1", "other:999"], "write inside a bind schedules its own flush entry");
+});
+
+await test("box: set inside a bind for the SAME var re-queues itself rather than looping synchronously in one flush pass", async () => {
+  // Note: bind(c, deps, fn) invokes fn() once immediately at registration,
+  // before deps are wired into c.deps[] -- so any self-write guarded only by
+  // the box's own value would already fire during that registration call
+  // (deps not yet wired -> markVar is a same-tick no-op there). Use an
+  // external "armed" flag so the self-write only happens on a run triggered
+  // by a real external write, isolating the behavior under test: does a
+  // write-to-self inside a bind's fn get delivered, and when?
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  let runs = 0;
+  let armed = false;
+  bind(c, [0], () => {
+    runs++;
+    if (armed) {
+      armed = false;
+      a.v = a.v + 1; // one guarded self-write, schedules exactly one more run
+    }
+  });
+  runs = 0;
+  armed = true;
+  a.v = 10;
+  await tick();
+  // flush()'s `for (const s of q)` iterates a snapshot array taken before
+  // running any fn, so the self-write's markVar pushes into a *new*
+  // c.queue rather than the one currently mid-iteration -- but that new
+  // push still happens via a fresh queueMicrotask, which fully drains
+  // (it's still a microtask) before our setTimeout-based tick() resolves.
+  assert.strictEqual(runs, 2, "external write's run, then the self-write's own run, both land in this tick()");
+  assert.strictEqual(a.v, 11, "self-write applied: 10 -> 11");
+});
+
+// ---------------------------------------------------------------------------
+// deepBox(): nested mutation depths, array methods, delete, length
+// truncation, whole-value replace, Proxy identity, NaN-through-proxy.
+// ---------------------------------------------------------------------------
+
+await test("deepBox: deeply nested (3+ levels) mutation triggers", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { a: { b: { c: { d: 1 } } } });
+  let val;
+  bind(c, [0], () => {
+    val = d.v.a.b.c.d;
+  });
+  assert.strictEqual(val, 1);
+  d.v.a.b.c.d = 2;
+  await tick();
+  assert.strictEqual(val, 2);
+});
+
+await test("deepBox: array of objects, mutating an element's field triggers", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [{ n: 1 }, { n: 2 }]);
+  let total;
+  bind(c, [0], () => {
+    total = d.v[0].n + d.v[1].n;
+  });
+  assert.strictEqual(total, 3);
+  d.v[0].n = 10;
+  await tick();
+  assert.strictEqual(total, 12);
+});
+
+await test("deepBox: sort() and reverse() both trigger and produce correct order", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [3, 1, 2]);
+  let snap;
+  bind(c, [0], () => {
+    snap = Array.from(d.v);
+  });
+  d.v.sort();
+  await tick();
+  assert.deepStrictEqual(snap, [1, 2, 3]);
+  d.v.reverse();
+  await tick();
+  assert.deepStrictEqual(snap, [3, 2, 1]);
+});
+
+await test("deepBox: shift() and unshift() both trigger", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [1, 2, 3]);
+  let snap;
+  bind(c, [0], () => {
+    snap = Array.from(d.v);
+  });
+  d.v.unshift(0);
+  await tick();
+  assert.deepStrictEqual(snap, [0, 1, 2, 3]);
+  d.v.shift();
+  await tick();
+  assert.deepStrictEqual(snap, [1, 2, 3]);
+});
+
+await test("deepBox: pop() triggers and returns the removed element", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [1, 2, 3]);
+  let snap;
+  bind(c, [0], () => {
+    snap = Array.from(d.v);
+  });
+  const popped = d.v.pop();
+  assert.strictEqual(popped, 3);
+  await tick();
+  assert.deepStrictEqual(snap, [1, 2]);
+});
+
+await test("deepBox: length truncation (arr.length = n) triggers", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [1, 2, 3, 4, 5]);
+  let snap;
+  bind(c, [0], () => {
+    snap = Array.from(d.v);
+  });
+  d.v.length = 2;
+  await tick();
+  assert.deepStrictEqual(snap, [1, 2]);
+});
+
+await test("deepBox: replacing the whole value swaps the underlying proxy target entirely", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { a: 1 });
+  let snap;
+  bind(c, [0], () => {
+    snap = { ...d.v };
+  });
+  assert.deepStrictEqual(snap, { a: 1 });
+  d.v = { b: 2 };
+  await tick();
+  assert.deepStrictEqual(snap, { b: 2 }, "old key gone entirely, not merged");
+});
+
+await test("deepBox: whole-value replace with the same reference is a no-op", async () => {
+  const c = createContext(null);
+  const obj = { a: 1 };
+  const d = deepBox(c, 0, obj);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  d.v = obj;
+  await tick();
+  assert.strictEqual(runs, 1, "x === v guard applies to deepBox's raw value too");
+});
+
+await test("deepBox: proxy identity stable across repeated reads of the same nested path", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { list: [1, 2, 3] });
+  assert.strictEqual(d.v.list, d.v.list, "nested array wrapper is cached, not rebuilt per read");
+});
+
+await test("deepBox: proxy identity differs after whole-value replacement", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { a: 1 });
+  const first = d.v;
+  d.v = { a: 1 }; // different underlying object, deep-equal but not ===
+  assert.notStrictEqual(d.v, first, "new raw object -> freshly wrapped proxy");
+});
+
+await test("deepBox: delete on a nested (not top-level) key triggers", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { outer: { a: 1, b: 2 } });
+  let keys;
+  bind(c, [0], () => {
+    keys = Object.keys(d.v.outer).sort().join(",");
+  });
+  assert.strictEqual(keys, "a,b");
+  delete d.v.outer.b;
+  await tick();
+  assert.strictEqual(keys, "a");
+});
+
+await test("deepBox: deleting a non-existent key does not trigger (had=false guard)", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { a: 1 });
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  delete d.v.doesNotExist;
+  await tick();
+  assert.strictEqual(runs, 1, "no spurious flush for deleting an absent key");
+});
+
+await test("deepBox: setting a nested field to NaN always triggers (NaN !== NaN check inside the proxy set trap)", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { n: NaN });
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  d.v.n = NaN;
+  await tick();
+  assert.strictEqual(runs, 2, "nested NaN write always reports as changed");
+});
+
+await test("deepBox: setting a nested field to the SAME primitive value is a no-op", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { n: 5 });
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  d.v.n = 5;
+  await tick();
+  assert.strictEqual(runs, 1, "old === new for a primitive -> proxy set trap skips notify");
+});
+
+await test("deepBox: primitive (non-object) values pass through the wrapper untouched", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, 42);
+  assert.strictEqual(d.v, 42);
+  const dNull = deepBox(c, 1, null);
+  assert.strictEqual(dNull.v, null);
+});
+
+await test("deepBox: two different deepBox instances wrapping equal-shaped objects have independent proxy caches", () => {
+  const c = createContext(null);
+  const d1 = deepBox(c, 0, { a: 1 });
+  const d2 = deepBox(c, 1, { a: 1 });
+  assert.notStrictEqual(d1.v, d2.v, "distinct underlying objects -> distinct proxies");
+});
+
+await test("deepBox: Map/Set values are NOT safely deep-reactive -- accessing native accessors through the plain Proxy throws (TODO: needs a dedicated collection handler, cross-module change, not fixed here)", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1]]));
+  // Reading `.size` (an accessor with internal slots) through the generic
+  // get-trap's Reflect.get(target, key, receiver=proxy) fails because Map's
+  // internal [[MapData]] slot isn't on the proxy receiver. This documents a
+  // real limitation of the current Proxy-based deep wrap rather than a
+  // regression: fixing it needs a collection-aware handler (unwrap-and-bind
+  // methods, or special-case Map/Set in makeWrap), which is a cross-module
+  // design change out of scope for this test-only pass.
+  assert.throws(
+    () => d.v.size,
+    /incompatible receiver/,
+    "Map accessors break through the generic Proxy handler"
+  );
+});
+
+console.log("boxes.deep.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/computed.edge.test.mjs
+++ b/packages/lunas/test/computed.edge.test.mjs
@@ -1,0 +1,218 @@
+// computed.edge.test.mjs — lazy derived values: chained computed, diamond
+// deps, multi-dep coalescing, laziness across never-read paths, read-inside-
+// bind tracking edge cases beyond computed.test.mjs.
+// Run: node packages/lunas/test/computed.edge.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { computed } from "../src/computed.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("computed never read: fn never runs, even across multiple dep changes", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let computes = 0;
+  computed(c, 1, [0], () => {
+    computes++;
+    return a.v;
+  });
+  a.v = 2;
+  await tick();
+  a.v = 3;
+  await tick();
+  assert.strictEqual(computes, 0, "no read anywhere -> fn body never executes");
+});
+
+await test("chained computed: computed-of-computed recomputes exactly once per upstream change", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 2);
+  let doubleRuns = 0;
+  let quadRuns = 0;
+  const double = computed(c, 1, [0], () => {
+    doubleRuns++;
+    return a.v * 2;
+  });
+  const quad = computed(c, 2, [1], () => {
+    quadRuns++;
+    return double.v * 2;
+  });
+  assert.strictEqual(quad.v, 8);
+  assert.strictEqual(doubleRuns, 1);
+  assert.strictEqual(quadRuns, 1);
+  a.v = 3;
+  await tick();
+  assert.strictEqual(quad.v, 12, "chain recomputed with fresh upstream value");
+  assert.strictEqual(doubleRuns, 2, "double recomputed exactly once");
+  assert.strictEqual(quadRuns, 2, "quad recomputed exactly once");
+});
+
+await test("chained computed: reading only the outer one still recomputes the inner exactly once", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let innerRuns = 0;
+  const inner = computed(c, 1, [0], () => {
+    innerRuns++;
+    return a.v + 1;
+  });
+  const outer = computed(c, 2, [1], () => inner.v * 10);
+  assert.strictEqual(outer.v, 20);
+  a.v = 5;
+  await tick();
+  assert.strictEqual(outer.v, 60, "reading outer pulls a fresh inner value");
+  assert.strictEqual(innerRuns, 2, "inner recomputed once per read-through, not per dep-change alone");
+});
+
+await test("diamond dependency: two computeds derive from one base, a third combines both, each recomputes once", async () => {
+  const c = createContext(null);
+  const base = box(c, 0, 1);
+  let leftRuns = 0;
+  let rightRuns = 0;
+  let combineRuns = 0;
+  const left = computed(c, 1, [0], () => {
+    leftRuns++;
+    return base.v + 1;
+  });
+  const right = computed(c, 2, [0], () => {
+    rightRuns++;
+    return base.v * 10;
+  });
+  const combined = computed(c, 3, [1, 2], () => {
+    combineRuns++;
+    return left.v + right.v;
+  });
+  assert.strictEqual(combined.v, 1 + 1 + 1 * 10);
+  assert.strictEqual(leftRuns, 1);
+  assert.strictEqual(rightRuns, 1);
+  assert.strictEqual(combineRuns, 1);
+  base.v = 2;
+  await tick();
+  assert.strictEqual(combined.v, 2 + 1 + 2 * 10);
+  assert.strictEqual(leftRuns, 2, "left recomputed exactly once despite two paths to base");
+  assert.strictEqual(rightRuns, 2, "right recomputed exactly once");
+  assert.strictEqual(combineRuns, 2, "combine recomputed exactly once, not twice for two upstream changes");
+});
+
+await test("multiple deps changed in the same tick -> exactly one recompute", async () => {
+  const c = createContext(null);
+  const x = box(c, 0, 1);
+  const y = box(c, 1, 1);
+  let sumRuns = 0;
+  const sum = computed(c, 2, [0, 1], () => {
+    sumRuns++;
+    return x.v + y.v;
+  });
+  assert.strictEqual(sum.v, 2);
+  assert.strictEqual(sumRuns, 1);
+  x.v = 5;
+  y.v = 5;
+  await tick();
+  assert.strictEqual(sum.v, 10, "both writes reflected");
+  assert.strictEqual(sumRuns, 2, "exactly one recompute for the whole coalesced flush, not two");
+});
+
+await test("dep changes but the computed is never read again before a further change: still exactly one recompute on next read", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let computes = 0;
+  const d = computed(c, 1, [0], () => {
+    computes++;
+    return a.v;
+  });
+  assert.strictEqual(d.v, 1);
+  a.v = 2;
+  await tick(); // stale, not read
+  a.v = 3;
+  await tick(); // stale again, still not read -- only one flag flip, no compounding
+  assert.strictEqual(computes, 1, "no recompute happened without a read");
+  assert.strictEqual(d.v, 3, "first read after two skipped changes sees the latest value");
+  assert.strictEqual(computes, 2, "exactly one recompute for the catch-up read");
+});
+
+await test("reading a computed inside a bind subscribes the bind via the computed's own index (not its upstream deps)", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const d = computed(c, 1, [0], () => a.v * 3);
+  let bindRuns = 0;
+  // The bind only declares index 1 (the computed), matching what the
+  // compiler emits for a template part reading a derived value -- it does
+  // NOT need to know about index 0 directly.
+  bind(c, [1], () => {
+    bindRuns++;
+    void d.v;
+  });
+  assert.strictEqual(bindRuns, 1);
+  a.v = 2; // upstream write marks index 1 dirty via the computed's internal bind
+  await tick();
+  assert.strictEqual(bindRuns, 2, "bind re-ran because the computed's own index was marked");
+});
+
+await test("computed with an empty deps list never recomputes after the first read (no upstream can mark it stale)", () => {
+  const c = createContext(null);
+  let computes = 0;
+  const d = computed(c, 0, [], () => {
+    computes++;
+    return 42;
+  });
+  assert.strictEqual(d.v, 42);
+  assert.strictEqual(d.v, 42);
+  assert.strictEqual(computes, 1, "memoized forever: nothing can invalidate it");
+});
+
+await test("computed fn can throw: laziness means the throw happens at read time, not registration", () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const d = computed(c, 1, [0], () => {
+    if (a.v === 0) throw new Error("boom");
+    return a.v;
+  });
+  assert.throws(() => d.v, /boom/);
+});
+
+await test("computed fn recovers on next read after a dep change, even if the previous read threw", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 0);
+  const d = computed(c, 1, [0], () => {
+    if (a.v === 0) throw new Error("boom");
+    return a.v * 2;
+  });
+  assert.throws(() => d.v);
+  a.v = 5;
+  await tick();
+  assert.strictEqual(d.v, 10, "fresh read after the dep changed recomputes cleanly");
+});
+
+await test("two independent computed instances over the same box do not share memoized state", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runsX = 0;
+  let runsY = 0;
+  const x = computed(c, 1, [0], () => {
+    runsX++;
+    return a.v + 100;
+  });
+  const y = computed(c, 2, [0], () => {
+    runsY++;
+    return a.v + 200;
+  });
+  assert.strictEqual(x.v, 101);
+  assert.strictEqual(y.v, 201);
+  assert.strictEqual(runsX, 1);
+  assert.strictEqual(runsY, 1);
+  a.v = 2;
+  await tick();
+  // Read only x this time.
+  assert.strictEqual(x.v, 102);
+  assert.strictEqual(runsX, 2);
+  assert.strictEqual(runsY, 1, "y untouched: laziness is per-computed, no shared read");
+});
+
+console.log("computed.edge.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/core.edge.test.mjs
+++ b/packages/lunas/test/core.edge.test.mjs
@@ -1,0 +1,333 @@
+// core.edge.test.mjs — adjacency dispatch edge cases beyond core.test.mjs:
+// multi-bind fan-out/fan-in, dedup nuances, unbind/bind mutations mid-flush,
+// nested scope teardown ordering, afterFlush semantics.
+// Run: node packages/lunas/test/core.edge.test.mjs
+
+import assert from "node:assert";
+import {
+  createContext,
+  bind,
+  markVar,
+  flush,
+  unbind,
+  afterFlush,
+  beginScope,
+  endScope,
+  dropScope,
+  runScope,
+} from "../src/core.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("multiple binds on one var: all run, each exactly once per flush", async () => {
+  const c = createContext(null);
+  let a = 0;
+  let b = 0;
+  let d = 0;
+  bind(c, [0], () => a++);
+  bind(c, [0], () => b++);
+  bind(c, [0], () => d++);
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(a, 2);
+  assert.strictEqual(b, 2);
+  assert.strictEqual(d, 2);
+});
+
+await test("one bind on many vars: fan-in, each markVar dedups to one run per flush", async () => {
+  const c = createContext(null);
+  let runs = 0;
+  bind(c, [0, 1, 2, 3], () => runs++);
+  markVar(c, 0);
+  markVar(c, 1);
+  markVar(c, 2);
+  markVar(c, 3);
+  await tick();
+  assert.strictEqual(runs, 2, "initial + exactly one coalesced run");
+});
+
+await test("markVar on a var with no binds is a harmless no-op", async () => {
+  const c = createContext(null);
+  // deps[5] was never populated by any bind() call.
+  assert.doesNotThrow(() => markVar(c, 5));
+  await tick();
+});
+
+await test("markVar on an index that only ever had unbound binds", async () => {
+  const c = createContext(null);
+  const s = bind(c, [0], () => {});
+  unbind(c, s);
+  assert.doesNotThrow(() => markVar(c, 0));
+  await tick();
+});
+
+await test("flush() can be called directly/synchronously (bypassing markVar scheduling)", () => {
+  const c = createContext(null);
+  let runs = 0;
+  const s = bind(c, [0], () => runs++);
+  c.queue.push(s);
+  s.q = true;
+  flush(c);
+  assert.strictEqual(runs, 2);
+  assert.strictEqual(c.queue.length, 0, "queue drained");
+  assert.strictEqual(c.pending, false);
+});
+
+await test("flush() with empty queue is a safe no-op and does not touch onUpdate", () => {
+  const c = createContext(null);
+  let updates = 0;
+  c.onUpdate = () => updates++;
+  flush(c);
+  assert.strictEqual(updates, 0, "onUpdate only fires when something actually ran");
+});
+
+await test("bind added during a flush: new bind is registered in deps[i] before the outer bind finishes registering", async () => {
+  // bind(c, deps, fn) runs fn() BEFORE pushing itself into c.deps[i]. So if
+  // s1's own fn synchronously registers s2 (also on var 0), s2 gets pushed
+  // into c.deps[0] first (during s1's registration-time run), and s1 is only
+  // pushed once its own bind() call returns. That flips adjacency order for
+  // this one var: c.deps[0] === [s2, s1], not [s1, s2].
+  const c = createContext(null);
+  const log = [];
+  let added = null;
+  bind(c, [0], () => {
+    log.push("first");
+    if (!added) {
+      added = bind(c, [0], () => log.push("second"));
+    }
+  });
+  assert.deepStrictEqual(c.deps[0].map((s) => s === added), [true, false], "s2 precedes s1 in deps[0]");
+  log.length = 0;
+  markVar(c, 0);
+  await tick();
+  assert.deepStrictEqual(log, ["second", "first"], "flush runs in deps[] order: s2 then s1");
+  log.length = 0;
+  markVar(c, 0);
+  await tick();
+  assert.deepStrictEqual(log, ["second", "first"], "both now subscribed for every future flush");
+});
+
+await test("unbind mid-flush: a live bind unbinds another queued bind before it runs", async () => {
+  const c = createContext(null);
+  const log = [];
+  let sTarget;
+  bind(c, [0], () => {
+    log.push("killer");
+    if (sTarget) unbind(c, sTarget);
+  });
+  sTarget = bind(c, [0], () => log.push("victim"));
+  log.length = 0;
+  markVar(c, 0);
+  await tick();
+  // "killer" is queued before "victim" (registered first), so it runs first
+  // and unbinds victim before victim's queued turn -> victim's fn is skipped
+  // because flush() checks s.alive before invoking fn.
+  assert.deepStrictEqual(log, ["killer"], "victim skipped: unbound before its turn");
+});
+
+await test("unbind is idempotent: calling twice does not throw or double-splice", () => {
+  const c = createContext(null);
+  const s = bind(c, [0, 1], () => {});
+  unbind(c, s);
+  assert.doesNotThrow(() => unbind(c, s));
+  assert.strictEqual(c.deps[0].length, 0);
+  assert.strictEqual(c.deps[1].length, 0);
+});
+
+await test("afterFlush: callback rides an already-pending flush", async () => {
+  const c = createContext(null);
+  const order = [];
+  bind(c, [0], () => order.push("paint"));
+  order.length = 0; // drop the immediate registration-time run
+  markVar(c, 0); // schedules a flush
+  afterFlush(c, () => order.push("post"));
+  await tick();
+  assert.deepStrictEqual(order, ["paint", "post"], "post-flush cb runs after the update pass");
+});
+
+await test("afterFlush: with nothing pending, still schedules its own flush", async () => {
+  const c = createContext(null);
+  let ran = false;
+  afterFlush(c, () => {
+    ran = true;
+  });
+  assert.strictEqual(ran, false, "not synchronous");
+  await tick();
+  assert.strictEqual(ran, true);
+});
+
+await test("afterFlush: multiple callbacks run in registration order", async () => {
+  const c = createContext(null);
+  const order = [];
+  afterFlush(c, () => order.push(1));
+  afterFlush(c, () => order.push(2));
+  afterFlush(c, () => order.push(3));
+  await tick();
+  assert.deepStrictEqual(order, [1, 2, 3]);
+});
+
+await test("afterFlush callback that registers another afterFlush: runs via its own fresh microtask flush", async () => {
+  // c.post is nulled out before draining, so a callback that calls afterFlush
+  // again schedules a brand-new flush (c.pending was false again by then).
+  // That's a fresh queueMicrotask, which still drains before our
+  // setTimeout-based `tick()` helper resolves -- microtasks fully empty
+  // before any macrotask runs -- so both callbacks are visible after one tick.
+  const c = createContext(null);
+  const order = [];
+  afterFlush(c, () => {
+    order.push("first");
+    afterFlush(c, () => order.push("second"));
+  });
+  await tick();
+  assert.deepStrictEqual(order, ["first", "second"], "nested afterFlush resolves within the same tick() wait");
+});
+
+await test("nested scopes: dropping a parent scope tears down all descendants", async () => {
+  const c = createContext(null);
+  let a = 0;
+  let b = 0;
+  let d = 0;
+  const top = beginScope(c);
+  bind(c, [0], () => a++);
+  const mid = beginScope(c);
+  bind(c, [0], () => b++);
+  const leaf = beginScope(c);
+  bind(c, [0], () => d++);
+  endScope(c); // close leaf
+  endScope(c); // close mid
+  endScope(c); // close top
+  void mid;
+  void leaf;
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(a, 2);
+  assert.strictEqual(b, 2);
+  assert.strictEqual(d, 2);
+  dropScope(c, top);
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(a, 2, "top-level scoped bind dead");
+  assert.strictEqual(b, 2, "mid-level scoped bind dead too");
+  assert.strictEqual(d, 2, "leaf-level scoped bind dead too");
+});
+
+await test("dropping an inner scope leaves sibling/outer scopes untouched", async () => {
+  const c = createContext(null);
+  let outer = 0;
+  let inner = 0;
+  const outerScope = beginScope(c);
+  bind(c, [0], () => outer++);
+  const innerScope = beginScope(c);
+  bind(c, [0], () => inner++);
+  endScope(c);
+  endScope(c);
+  dropScope(c, innerScope);
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(outer, 2, "outer scope still live after inner dropped");
+  assert.strictEqual(inner, 1, "inner scope's bind is dead, no rerun");
+  // outerScope's children array should have had innerScope spliced out.
+  assert.strictEqual(outerScope.children.includes(innerScope), false);
+});
+
+await test("scope dropped, then dropped again: safe no-op (empty arrays)", () => {
+  const c = createContext(null);
+  const scope = beginScope(c);
+  bind(c, [0], () => {});
+  endScope(c);
+  dropScope(c, scope);
+  assert.doesNotThrow(() => dropScope(c, scope));
+});
+
+await test("c.scope restored correctly after endScope even with nested begin/end", () => {
+  const c = createContext(null);
+  assert.strictEqual(c.scope, null);
+  const s1 = beginScope(c);
+  assert.strictEqual(c.scope, s1);
+  const s2 = beginScope(c);
+  assert.strictEqual(c.scope, s2);
+  endScope(c);
+  assert.strictEqual(c.scope, s1, "back to s1 after closing s2");
+  endScope(c);
+  assert.strictEqual(c.scope, null, "back to null after closing s1");
+});
+
+await test("endScope on a context with no open scope is a safe no-op", () => {
+  const c = createContext(null);
+  assert.doesNotThrow(() => endScope(c));
+  assert.strictEqual(c.scope, null);
+});
+
+await test("runScope: re-runs live binds in a scope and its children, skips dead ones", async () => {
+  const c = createContext(null);
+  const log = [];
+  const scope = beginScope(c);
+  const s1 = bind(c, [0], () => log.push("s1"));
+  const child = beginScope(c);
+  bind(c, [0], () => log.push("child"));
+  endScope(c);
+  endScope(c);
+  log.length = 0;
+  unbind(c, s1);
+  runScope(c, scope);
+  assert.deepStrictEqual(log, ["child"], "dead bind s1 skipped, live child bind ran");
+});
+
+await test("runScope: a sub that creates a new child scope on every call accumulates children, each snapshot only sees prior ones", () => {
+  // bind/beginScope/endScope run synchronously and immediately at
+  // registration, so the *first* nested child already exists in
+  // scope.children before runScope is ever invoked. runScope() itself
+  // snapshots scope.children up front (before running subs), so a child
+  // created *during this call's* subs loop is deferred to the *next*
+  // runScope call rather than visited in the same pass -- this is what makes
+  // runScope safe against a sub that conjures new scopes on the fly (e.g. an
+  // ifBlock flipping on) without infinite/duplicate recursion in one pass.
+  const c = createContext(null);
+  const log = [];
+  const scope = beginScope(c);
+  bind(c, [0], () => {
+    log.push("dynamic");
+    const inner = beginScope(c);
+    bind(c, [0], () => log.push("inner"));
+    endScope(c);
+    void inner;
+  });
+  endScope(c);
+  assert.strictEqual(scope.children.length, 1, "registration already created one child");
+  log.length = 0;
+  runScope(c, scope);
+  // subs loop reruns "dynamic", which calls beginScope/endScope again ->
+  // logs "inner" for the freshly-registered bind. But runScope() does NOT
+  // set c.scope to `scope` while walking (it calls s.fn() directly, not
+  // through begin/endScope), so that fresh beginScope() call attaches to
+  // whatever c.scope ambiently is (null here, since we're outside any
+  // begin/endScope block) rather than to `scope`. It is therefore never
+  // added to scope.children and is orphaned relative to this scope tree.
+  // Meanwhile runScope's children snapshot (taken before the subs loop) has
+  // just the one pre-existing child from registration time -> visiting it
+  // reruns its bind, logging "inner" a second time.
+  assert.deepStrictEqual(log, ["dynamic", "inner", "inner"]);
+  assert.strictEqual(scope.children.length, 1, "scope.children unchanged: the new nested scope attached to null, not this scope");
+});
+
+await test("dropScope on a scope whose child was already dropped independently", () => {
+  const c = createContext(null);
+  const parent = beginScope(c);
+  bind(c, [0], () => {});
+  const child = beginScope(c);
+  bind(c, [0], () => {});
+  endScope(c);
+  endScope(c);
+  dropScope(c, child); // drop child first
+  assert.doesNotThrow(() => dropScope(c, parent)); // then parent
+  assert.strictEqual(parent.children.length, 0);
+});
+
+console.log("core.edge.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/watch.edge.test.mjs
+++ b/packages/lunas/test/watch.edge.test.mjs
@@ -1,0 +1,186 @@
+// watch.edge.test.mjs — watch/watchEffect edge cases beyond watch.test.mjs:
+// unrelated-var isolation, multi-dep coalescing, scope-drop cleanup
+// interaction with stop(), async callback microtask ordering, double-stop
+// safety, watch vs watchEffect immediate semantics under scopes.
+// Run: node packages/lunas/test/watch.edge.test.mjs
+
+import assert from "node:assert";
+import {
+  createContext,
+  beginScope,
+  endScope,
+  dropScope,
+} from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { watch, watchEffect } from "../src/watch.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+await test("watch does not fire when an unrelated variable changes", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const b = box(c, 1, 1);
+  let runs = 0;
+  watch(c, [0], () => runs++);
+  b.v = 99;
+  await tick();
+  assert.strictEqual(runs, 0, "watch(deps=[0]) ignores writes to index 1");
+});
+
+await test("watch multi-dep: both deps changing in the same tick still fires exactly once", async () => {
+  const c = createContext(null);
+  const x = box(c, 0, 1);
+  const y = box(c, 1, 1);
+  let runs = 0;
+  watch(c, [0, 1], () => runs++);
+  x.v = 2;
+  y.v = 2;
+  await tick();
+  assert.strictEqual(runs, 1, "coalesced into one flush -> one callback invocation");
+});
+
+await test("watch with an async callback: the callback itself is fire-and-forget from the runtime's perspective, both halves land within the same tick() wait (microtask draining)", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const order = [];
+  watch(c, [0], async () => {
+    order.push("start");
+    await Promise.resolve();
+    order.push("end");
+  });
+  a.v = 2;
+  await tick();
+  assert.deepStrictEqual(order, ["start", "end"], "async continuation is itself a microtask, drains before the macrotask tick");
+});
+
+await test("watch async callback: a SECOND change fires a new async invocation independently (no queuing/collapsing of callback runs themselves)", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const order = [];
+  watch(c, [0], async (n) => {
+    order.push("start:" + a.v);
+    await Promise.resolve();
+    order.push("end:" + a.v);
+  });
+  a.v = 2;
+  await tick();
+  a.v = 3;
+  await tick();
+  assert.deepStrictEqual(order, ["start:2", "end:2", "start:3", "end:3"]);
+});
+
+await test("watchEffect: scope-drop stops it, and calling the returned stop() afterward is a safe no-op", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  const scope = beginScope(c);
+  const stop = watchEffect(c, [0], () => runs++);
+  endScope(c);
+  assert.strictEqual(runs, 1, "immediate effect run at registration");
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 2);
+  dropScope(c, scope);
+  a.v = 3;
+  await tick();
+  assert.strictEqual(runs, 2, "dropScope tore it down: no run for the third write");
+  assert.doesNotThrow(() => stop(), "stop() after the scope already dropped it must not throw");
+  a.v = 4;
+  await tick();
+  assert.strictEqual(runs, 2, "still dead after the redundant stop() call");
+});
+
+await test("watch: scope-drop stops it even when registered with { immediate: true }", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runs = 0;
+  const scope = beginScope(c);
+  watch(c, [0], () => runs++, { immediate: true });
+  endScope(c);
+  assert.strictEqual(runs, 1, "immediate run happened at registration");
+  dropScope(c, scope);
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runs, 1, "no further run: scope drop killed it before any change");
+});
+
+await test("watch: calling stop() twice does not throw and does not affect other watchers", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let runsA = 0;
+  let runsB = 0;
+  const stopA = watch(c, [0], () => runsA++);
+  watch(c, [0], () => runsB++);
+  stopA();
+  assert.doesNotThrow(() => stopA());
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runsA, 0, "stopped watcher never fires");
+  assert.strictEqual(runsB, 1, "sibling watcher on the same dep is unaffected");
+});
+
+await test("watchEffect: multiple independent effects on the same dep all run once per change, in registration order", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  const order = [];
+  watchEffect(c, [0], () => order.push("first:" + a.v));
+  watchEffect(c, [0], () => order.push("second:" + a.v));
+  order.length = 0; // drop the two immediate registration-time runs
+  a.v = 2;
+  await tick();
+  assert.deepStrictEqual(order, ["first:2", "second:2"]);
+});
+
+await test("watch: stopping one watcher mid-flush does not affect a sibling watcher on the same dep queued in the same pass", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let stopB;
+  let runsA = 0;
+  let runsB = 0;
+  watch(c, [0], () => {
+    runsA++;
+    stopB(); // stop the sibling from inside this callback
+  });
+  stopB = watch(c, [0], () => runsB++);
+  a.v = 2;
+  await tick();
+  assert.strictEqual(runsA, 1);
+  // Whether runsB observes this flush depends on adjacency order (watcher A
+  // is registered, hence queued, before watcher B), so A's callback runs
+  // first and unbinds B before B's queued turn -- matching core.mjs's
+  // documented "unbind mid-flush" semantics (see core.edge.test.mjs).
+  assert.strictEqual(runsB, 0, "B unbound before its turn in this same flush pass");
+  a.v = 3;
+  await tick();
+  assert.strictEqual(runsB, 0, "B permanently stopped, no further runs");
+});
+
+await test("watch immediate: the initial synchronous run happens before the function returns (not deferred to a microtask)", () => {
+  const c = createContext(null);
+  const a = box(c, 0, 1);
+  let ran = false;
+  watch(c, [0], () => {
+    ran = true;
+  }, { immediate: true });
+  assert.strictEqual(ran, true, "no await needed to observe the immediate run");
+});
+
+await test("watchEffect: dep read inside the effect reflects the value at the time of that run, not a stale closure", async () => {
+  const c = createContext(null);
+  const a = box(c, 0, "a");
+  const seen = [];
+  watchEffect(c, [0], () => seen.push(a.v));
+  a.v = "b";
+  a.v = "c"; // coalesced: effect should only see the final "c", not "b"
+  await tick();
+  assert.deepStrictEqual(seen, ["a", "c"], "intermediate write 'b' coalesced away");
+});
+
+console.log("watch.edge.test.mjs: all " + passed + " tests passed");


### PR DESCRIPTION
## Summary
- Adds 5 new test files under `packages/lunas/test/` covering edge cases in the reactivity core (`core.mjs`, `boxes.mjs`, `computed.mjs`, `watch.mjs`, `batch.mjs`) that the existing happy-path suites didn't exercise — ~168 new assertions total.
- `core.edge.test.mjs` (45 asserts): multi-bind fan-out/fan-in, direct `flush()` invocation, bind/unbind mutating the queue mid-flush, nested scope teardown ordering, `afterFlush` chaining/re-registration semantics.
- `boxes.deep.test.mjs` (36 asserts): `box`/`deepBox` identity no-ops, the `NaN !== NaN` quirk on both plain boxes and nested proxy writes, array method coverage (`sort`/`reverse`/`shift`/`unshift`/`pop`/length truncation), deep nesting, proxy identity stability/invalidation, and a **documented (not fixed) limitation**: `deepBox` over a native `Map`/`Set` throws on accessor reads (`Reflect.get` with the proxy as receiver breaks Map's internal slot) — fixing this needs a collection-aware Proxy handler, a cross-module design change out of scope for a test-only pass, so it's asserted as expected-throw with a clear comment rather than silently skipped.
- `computed.edge.test.mjs` (41 asserts): chained (computed-of-computed) and diamond dependency graphs, multi-dep coalescing, throw/recover semantics, per-computed memoization isolation.
- `watch.edge.test.mjs` (20 asserts): unrelated-var isolation, async callback microtask ordering, scope-drop cleanup interaction with `stop()`, double-stop safety, unbind-mid-flush ordering between sibling watchers.
- `batch.edge.test.mjs` (26 asserts): return-value passthrough, exceptions still flush via `finally`, three-level nesting, sequential (non-nested) batches, `nextTick` scheduled from inside a `batch`, independent contexts nesting correctly when interleaved.

No `src/*.mjs` changes — every assertion was verified against the actual runtime behavior first (several initial assumptions about registration-time execution order, NaN semantics, and scope snapshot timing turned out to be subtly different from a naive reading of the source, and were corrected before being committed). No genuine bugs were found that warranted a source fix.

## Test plan
- [x] `~/.nvm/versions/node/v22.18.0/bin/node packages/lunas/test/run-all.mjs` — all 22 test files pass (17 existing + 5 new)
- [x] No files outside `packages/lunas/test/` touched (verified via `git diff --stat` / `git status`)
- [x] No Rust touched, `roadmap.yml` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)