### PR TITLE
test(runtime): expand blocks / keyed-for / dom / slots suite

### DIFF
--- a/packages/lunas/test/blocks.for.nested.test.mjs
+++ b/packages/lunas/test/blocks.for.nested.test.mjs
@@ -1,0 +1,331 @@
+// blocks.for.nested.test.mjs — nested control-flow inside forBlock:
+// :for-in-:for, :if-in-:for, per-item scope teardown on removal, item patch
+// driving nested blocks, and the compiled bulk-render (html/wire) initial path
+// vs the reconcile update path. Uses the fake DOM shim (installDom) because the
+// compiled path parses per-item skeleton HTML via innerHTML.
+// Run: node packages/lunas/test/blocks.for.nested.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+const document = installDom();
+
+import { createContext, bind, markVar } from "../src/core.mjs";
+import { box, deepBox } from "../src/boxes.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { ifBlock, forBlock } from "../src/blocks.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const shape = (p) =>
+  p.childNodes
+    .map((n) => (n.kind === "text" ? (n.data === "" ? "|" : n.data) : "<" + n.tag + ">"))
+    .join(" ");
+// Flattened text content of a subtree (for asserting nested structure cheaply).
+const textOf = (n) => {
+  if (n.kind === "text") return n.data;
+  return n.childNodes.map(textOf).join("");
+};
+const rowsText = (p) =>
+  p.childNodes.filter((n) => n.kind === "element").map(textOf).join("|");
+
+const liveBinds = (c) => {
+  const seen = new Set();
+  for (const list of c.deps) if (list) for (const s of list) if (s.alive) seen.add(s);
+  return seen.size;
+};
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- :for inside :for --------------------------------------------------------
+
+await test("nested :for-in-:for renders a grid and reorders inner independently", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  // outer rows: each row has an inner :for over row.cells
+  let rows = [
+    { id: "r1", cells: ["a", "b"] },
+    { id: "r2", cells: ["c"] },
+  ];
+  forBlock(c, anchor, [0], () => rows, {
+    make: (row) => {
+      const rowEl = document.createElement("row");
+      const innerAnchor = document.createTextNode("");
+      rowEl.appendChild(innerAnchor);
+      forBlock(c, innerAnchor, [1], () => row.cells, {
+        make: (cell) => document.createTextNode(cell),
+        keyOf: (cell) => cell,
+      });
+      return rowEl;
+    },
+    keyOf: (row) => row.id,
+  });
+  assert.strictEqual(rowsText(parent), "ab|c");
+
+  // Mutate an inner list and re-run its dep var (1). Only inner :for reconciles.
+  rows[0].cells = ["b", "a", "x"];
+  markVar(c, 1);
+  await tick();
+  assert.strictEqual(rowsText(parent), "bax|c");
+});
+
+await test("removing an outer row tears down its inner :for binds (no leak)", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const hi = box(c, 2, "!");
+  let rows = [
+    { id: "r1", cells: ["a"] },
+    { id: "r2", cells: ["b"] },
+  ];
+  const cellRuns = {};
+  forBlock(c, anchor, [0], () => rows, {
+    make: (row) => {
+      const rowEl = document.createElement("row");
+      const innerAnchor = document.createTextNode("");
+      rowEl.appendChild(innerAnchor);
+      forBlock(c, innerAnchor, [1], () => row.cells, {
+        make: (cell) => {
+          const t = document.createTextNode(cell);
+          bind(c, [2], () => {
+            cellRuns[cell] = (cellRuns[cell] || 0) + 1;
+            t.data = cell + hi.v;
+          });
+          return t;
+        },
+        keyOf: (cell) => cell,
+      });
+      return rowEl;
+    },
+    keyOf: (row) => row.id,
+  });
+  assert.deepStrictEqual(cellRuns, { a: 1, b: 1 });
+  hi.v = "?";
+  await tick();
+  assert.deepStrictEqual(cellRuns, { a: 2, b: 2 }, "both inner cell binds live");
+
+  // Remove the second outer row: its inner cell "b" bind must be unregistered.
+  rows = [{ id: "r1", cells: ["a"] }];
+  markVar(c, 0);
+  await tick();
+  const bAfterRemove = cellRuns.b;
+  const aAfterRemove = cellRuns.a;
+  hi.v = "#";
+  await tick();
+  assert.strictEqual(cellRuns.b, bAfterRemove, "removed row's inner bind is dead");
+  assert.ok(cellRuns.a > aAfterRemove, "surviving row's inner bind still fires");
+});
+
+// --- :if inside a :for item --------------------------------------------------
+
+await test(":if inside a :for item toggles per item", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  let items = [
+    { id: 1, open: true },
+    { id: 2, open: false },
+  ];
+  forBlock(c, anchor, [0], () => items, {
+    make: (it) => {
+      const wrap = document.createElement("item");
+      const innerAnchor = document.createTextNode("");
+      wrap.appendChild(innerAnchor);
+      ifBlock(c, innerAnchor, [1], () => it.open, () =>
+        document.createTextNode("open" + it.id)
+      );
+      return wrap;
+    },
+    keyOf: (it) => it.id,
+  });
+  assert.strictEqual(rowsText(parent), "open1|");
+  items[1].open = true;
+  markVar(c, 1);
+  await tick();
+  assert.strictEqual(rowsText(parent), "open1|open2");
+  items[0].open = false;
+  markVar(c, 1);
+  await tick();
+  assert.strictEqual(rowsText(parent), "|open2");
+});
+
+await test("removing a :for item with an open :if drops the inner branch bind", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const tick2 = box(c, 2, 0);
+  let items = [{ id: 1 }, { id: 2 }];
+  const runs = {};
+  forBlock(c, anchor, [0], () => items, {
+    make: (it) => {
+      const wrap = document.createElement("item");
+      const innerAnchor = document.createTextNode("");
+      wrap.appendChild(innerAnchor);
+      ifBlock(c, innerAnchor, [1], () => true, () => {
+        const t = document.createTextNode("");
+        bind(c, [2], () => {
+          runs[it.id] = (runs[it.id] || 0) + 1;
+          t.data = it.id + ":" + tick2.v;
+        });
+        return t;
+      });
+      return wrap;
+    },
+    keyOf: (it) => it.id,
+  });
+  assert.deepStrictEqual(runs, { 1: 1, 2: 1 });
+  items = [{ id: 1 }]; // remove item 2
+  markVar(c, 0);
+  await tick();
+  const twoAfterRemove = runs[2];
+  const oneAfterRemove = runs[1];
+  tick2.v = 9;
+  await tick();
+  assert.strictEqual(runs[2], twoAfterRemove, "removed item's inner :if bind is dead");
+  assert.ok(runs[1] > oneAfterRemove, "kept item's inner :if bind fires");
+});
+
+// --- item patch drives a nested block (runScope) -----------------------------
+
+await test("patching a :for item re-runs its nested block with fresh data", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  // Each item carries an `arr` field; the nested :for renders it. Patch (same
+  // key, new data) must flow into the nested :for via the item scope re-run.
+  let items = [{ id: 1, arr: ["a", "b"] }];
+  forBlock(c, anchor, [0], () => items, {
+    make: (it) => {
+      const wrap = document.createElement("item");
+      const innerAnchor = document.createTextNode("");
+      wrap.appendChild(innerAnchor);
+      // The nested :for reads the CURRENT item via a closure over `it` cell.
+      forBlock(c, innerAnchor, [0], () => it.arr, {
+        make: (x) => document.createTextNode(x),
+        keyOf: (x) => x,
+      });
+      // record the item so patch can mutate the same cell the nested :for reads
+      it._cellRef = it;
+      return wrap;
+    },
+    keyOf: (it) => it.id,
+    patch: (h, d) => {
+      // The item object identity changes on patch; mirror the new arr onto the
+      // captured closure cell so the nested :for (which closed over the ORIGINAL
+      // item) sees it. In real compiled output the item box is the closure cell.
+    },
+  });
+  assert.strictEqual(rowsText(parent), "ab");
+
+  // Same key, new arr: because the nested :for closed over the original item
+  // object, we mutate that object in place (the normal deep-reactive case).
+  items[0].arr = ["b", "a", "c"];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(rowsText(parent), "bac", "nested :for re-reconciled on patch");
+});
+
+// --- compiled bulk-render (html/wire) initial path ---------------------------
+
+await test("compiled html/wire: bulk initial render then keyed update", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  let data = [
+    { id: "a", label: "A" },
+    { id: "b", label: "B" },
+    { id: "c", label: "C" },
+  ];
+  let wireCount = 0;
+  forBlock(c, anchor, [0], () => data, {
+    html: "<li><span></span></li>",
+    wire: (root, d) => {
+      wireCount++;
+      const span = root.childNodes[0];
+      span.appendChild(document.createTextNode(d.label));
+      // return a patch closure that updates the label text cell
+      return (nd) => {
+        span.childNodes[0].data = nd.label;
+      };
+    },
+    keyOf: (d) => d.id,
+  });
+  assert.strictEqual(rowsText(parent), "A|B|C");
+  assert.strictEqual(wireCount, 3, "bulk render wired 3 items once each");
+  const liNodes = parent.childNodes.filter((n) => n.kind === "element");
+
+  // Reorder: keyed reconcile reuses the same <li> nodes (no re-wire).
+  data = [
+    { id: "c", label: "C" },
+    { id: "a", label: "A" },
+    { id: "b", label: "B" },
+  ];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(rowsText(parent), "C|A|B");
+  assert.strictEqual(wireCount, 3, "reorder did not re-wire (nodes reused)");
+  const after = parent.childNodes.filter((n) => n.kind === "element");
+  assert.strictEqual(after[0], liNodes[2], "the <li> for c is the same node, moved");
+
+  // Patch in place (same keys, new labels): patch closure updates text, no wire.
+  data = [
+    { id: "c", label: "C2" },
+    { id: "a", label: "A2" },
+    { id: "b", label: "B2" },
+  ];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(rowsText(parent), "C2|A2|B2", "patch closures updated labels");
+  assert.strictEqual(wireCount, 3, "patch path never re-wires");
+});
+
+await test("compiled html/wire: insert new item builds via makeItem (per-item parse)", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  let data = [{ id: "a", label: "A" }];
+  let wireCount = 0;
+  forBlock(c, anchor, [0], () => data, {
+    html: "<li></li>",
+    wire: (root, d) => {
+      wireCount++;
+      root.appendChild(document.createTextNode(d.label));
+      return (nd) => {
+        root.childNodes[0].data = nd.label;
+      };
+    },
+    keyOf: (d) => d.id,
+  });
+  assert.strictEqual(rowsText(parent), "A");
+  assert.strictEqual(wireCount, 1);
+  data = [{ id: "a", label: "A" }, { id: "b", label: "B" }];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(rowsText(parent), "A|B");
+  assert.strictEqual(wireCount, 2, "new item parsed + wired once");
+});
+
+await test("compiled html/wire: empty initial list, then grow", async () => {
+  const c = createContext(null);
+  const parent = document.createElement("ul");
+  const anchor = anchorAppend(parent);
+  let data = [];
+  forBlock(c, anchor, [0], () => data, {
+    html: "<li></li>",
+    wire: (root, d) => {
+      root.appendChild(document.createTextNode(d.label));
+    },
+    keyOf: (d) => d.id,
+  });
+  assert.strictEqual(shape(parent), "|", "empty renders just the anchor");
+  data = [{ id: 1, label: "X" }, { id: 2, label: "Y" }];
+  markVar(c, 0);
+  await tick();
+  assert.strictEqual(rowsText(parent), "X|Y");
+});
+
+console.log("\nblocks.for.nested.test.mjs: " + passed + " passed.");

--- a/packages/lunas/test/blocks.if.edge.test.mjs
+++ b/packages/lunas/test/blocks.if.edge.test.mjs
@@ -1,0 +1,391 @@
+// blocks.if.edge.test.mjs — edge-case coverage for ifBlock / ifChain in
+// src/blocks.mjs: elseif cascades, no-match (-1), rapid toggles, nested if,
+// scope teardown across branch switches (no leaked binds), multi-root branches.
+// Run: node packages/lunas/test/blocks.if.edge.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind, beginScope, endScope, dropScope } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { ifBlock, ifChain } from "../src/blocks.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// --- minimal fake DOM (same narrow surface the runtime uses) -----------------
+class FakeNode {
+  constructor(doc, kind, data) {
+    this.ownerDocument = doc;
+    this.kind = kind;
+    this.data = data || "";
+    this.childNodes = [];
+    this.parentNode = null;
+  }
+  insertBefore(n, ref) {
+    if (ref != null && ref.parentNode !== this)
+      throw new Error("insertBefore: refNode is not a child");
+    if (n.parentNode) n.parentNode._drop(n);
+    const at = ref == null ? this.childNodes.length : this.childNodes.indexOf(ref);
+    this.childNodes.splice(at, 0, n);
+    n.parentNode = this;
+    return n;
+  }
+  appendChild(n) {
+    return this.insertBefore(n, null);
+  }
+  _drop(n) {
+    const i = this.childNodes.indexOf(n);
+    if (i >= 0) this.childNodes.splice(i, 1);
+    n.parentNode = null;
+  }
+  remove() {
+    if (this.parentNode) this.parentNode._drop(this);
+  }
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const s = this.parentNode.childNodes;
+    return s[s.indexOf(this) + 1] || null;
+  }
+}
+const doc = {
+  createTextNode: (d) => new FakeNode(doc, "text", d),
+  createElement: (t) => {
+    const n = new FakeNode(doc, "element", "");
+    n.tag = t;
+    return n;
+  },
+};
+const shape = (p) =>
+  p.childNodes
+    .map((n) => (n.kind === "text" ? (n.data === "" ? "|" : n.data) : "<" + n.tag + ">"))
+    .join(" ");
+
+// Count total live bind records registered on a context (across all vars).
+const liveBinds = (c) => {
+  const seen = new Set();
+  for (const list of c.deps) if (list) for (const s of list) if (s.alive) seen.add(s);
+  return seen.size;
+};
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- ifChain: full elseif cascade with else ----------------------------------
+
+await test("ifChain elseif cascade routes to the correct branch; else at end", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const n = box(c, 0, 0);
+  // if n<0 -> neg ; elseif n===0 -> zero ; elseif n<10 -> small ; else big
+  ifChain(
+    c,
+    anchor,
+    [0],
+    () => (n.v < 0 ? 0 : n.v === 0 ? 1 : n.v < 10 ? 2 : 3),
+    [
+      () => doc.createElement("neg"),
+      () => doc.createElement("zero"),
+      () => doc.createElement("small"),
+      () => doc.createElement("big"),
+    ]
+  );
+  assert.strictEqual(shape(parent), "<zero> |");
+  n.v = -3;
+  await tick();
+  assert.strictEqual(shape(parent), "<neg> |");
+  n.v = 5;
+  await tick();
+  assert.strictEqual(shape(parent), "<small> |");
+  n.v = 42;
+  await tick();
+  assert.strictEqual(shape(parent), "<big> |", "else branch");
+});
+
+await test("ifChain no-match (-1) with no else renders nothing", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const n = box(c, 0, 5);
+  ifChain(c, anchor, [0], () => (n.v > 0 ? 0 : n.v < 0 ? 1 : -1), [
+    () => doc.createElement("pos"),
+    () => doc.createElement("neg"),
+  ]);
+  assert.strictEqual(shape(parent), "<pos> |");
+  n.v = 0;
+  await tick();
+  assert.strictEqual(shape(parent), "|", "no branch for -1");
+  n.v = -2;
+  await tick();
+  assert.strictEqual(shape(parent), "<neg> |");
+  n.v = 0;
+  await tick();
+  assert.strictEqual(shape(parent), "|");
+});
+
+await test("ifChain -1 -> branch -> -1 leaves no leaked binds", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const on = box(c, 0, false);
+  const label = box(c, 1, "x");
+  let runs = 0;
+  ifChain(c, anchor, [0], () => (on.v ? 0 : -1), [
+    () => {
+      const el = doc.createElement("a");
+      bind(c, [1], () => {
+        runs++;
+        el.data = label.v;
+      });
+      return el;
+    },
+  ]);
+  assert.strictEqual(runs, 0, "hidden at start");
+  const baseBinds = liveBinds(c);
+  on.v = true;
+  await tick();
+  assert.strictEqual(runs, 1);
+  assert.strictEqual(liveBinds(c), baseBinds + 1, "branch bind registered");
+  on.v = false;
+  await tick();
+  assert.strictEqual(liveBinds(c), baseBinds, "branch bind unregistered on hide");
+  label.v = "y";
+  await tick();
+  assert.strictEqual(runs, 1, "no leaked bind fired");
+});
+
+// --- rapid toggles (multiple sync writes coalesce into one flush) ------------
+
+await test("ifBlock rapid synchronous toggles settle to the last state", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const show = box(c, 0, false);
+  let makes = 0;
+  ifBlock(c, anchor, [0], () => show.v, () => {
+    makes++;
+    return doc.createElement("s");
+  });
+  // Many writes in one tick: only the final value matters (run() is idempotent
+  // wrt the current condition; make happens at most once per shown transition).
+  show.v = true;
+  show.v = false;
+  show.v = true;
+  await tick();
+  assert.strictEqual(shape(parent), "<s> |", "settled to shown");
+  assert.strictEqual(makes, 1, "coalesced: built once");
+  show.v = false;
+  show.v = true;
+  show.v = false;
+  await tick();
+  assert.strictEqual(shape(parent), "|", "settled to hidden");
+  assert.strictEqual(makes, 1, "no rebuild since it ended hidden");
+});
+
+await test("ifBlock toggle same value within a tick is a no-op (no rebuild)", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const show = box(c, 0, true);
+  let makes = 0;
+  ifBlock(c, anchor, [0], () => show.v, () => {
+    makes++;
+    return doc.createElement("s");
+  });
+  assert.strictEqual(makes, 1);
+  const node = parent.childNodes[0];
+  show.v = true; // re-write same value
+  await tick();
+  assert.strictEqual(parent.childNodes[0], node, "node not rebuilt");
+  assert.strictEqual(makes, 1);
+});
+
+// --- nested if-in-if ---------------------------------------------------------
+
+await test("nested ifBlock: inner branch tears down when outer hides", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const outer = box(c, 0, false);
+  const inner = box(c, 1, false);
+  const label = box(c, 2, "x");
+  let innerRuns = 0;
+
+  ifBlock(c, anchor, [0], () => outer.v, () => {
+    const wrap = doc.createElement("outer");
+    const innerAnchor = doc.createTextNode("");
+    wrap.appendChild(innerAnchor);
+    // nested :if built inside the outer branch's scope
+    ifBlock(c, innerAnchor, [1], () => inner.v, () => {
+      const el = doc.createElement("inner");
+      bind(c, [2], () => {
+        innerRuns++;
+        el.data = label.v;
+      });
+      return el;
+    });
+    return wrap;
+  });
+
+  assert.strictEqual(shape(parent), "|", "all hidden");
+  outer.v = true;
+  await tick();
+  assert.strictEqual(innerRuns, 0, "inner still hidden");
+  inner.v = true;
+  await tick();
+  assert.strictEqual(innerRuns, 1, "inner shown, bind ran");
+  label.v = "y";
+  await tick();
+  assert.strictEqual(innerRuns, 2, "inner bind live");
+
+  // Hiding the OUTER must recursively drop the inner branch's binds.
+  outer.v = false;
+  await tick();
+  const before = innerRuns;
+  label.v = "z";
+  await tick();
+  assert.strictEqual(innerRuns, before, "inner bind dead after outer hide");
+  assert.strictEqual(shape(parent), "|");
+});
+
+// --- multi-root branch inserts/removes as a group ----------------------------
+
+await test("ifChain multi-root branches swap as whole groups", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  parent.appendChild(doc.createTextNode("H"));
+  const anchor = anchorAppend(parent);
+  parent.appendChild(doc.createTextNode("T"));
+  const n = box(c, 0, 0);
+  ifChain(c, anchor, [0], () => (n.v === 0 ? 0 : 1), [
+    () => [doc.createElement("a"), doc.createElement("b")],
+    () => [doc.createElement("x"), doc.createElement("y"), doc.createElement("z")],
+  ]);
+  assert.strictEqual(shape(parent), "H <a> <b> | T");
+  n.v = 1;
+  await tick();
+  assert.strictEqual(shape(parent), "H <x> <y> <z> | T", "whole group swapped");
+});
+
+// --- branch switch tears the OLD scope, keeps no leaks -----------------------
+
+await test("ifChain branch switch: old branch binds fully unregistered", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const which = box(c, 0, 0);
+  const l0 = box(c, 1, "a");
+  const l1 = box(c, 2, "b");
+  let r0 = 0;
+  let r1 = 0;
+  ifChain(c, anchor, [0], () => which.v, [
+    () => {
+      const el = doc.createElement("zero");
+      bind(c, [1], () => {
+        r0++;
+        el.data = l0.v;
+      });
+      return el;
+    },
+    () => {
+      const el = doc.createElement("one");
+      bind(c, [2], () => {
+        r1++;
+        el.data = l1.v;
+      });
+      return el;
+    },
+  ]);
+  const base = liveBinds(c);
+  assert.strictEqual(r0, 1);
+  which.v = 1;
+  await tick();
+  assert.strictEqual(r1, 1, "branch 1 built");
+  // branch 0's bind is gone; branch 1's is present => count unchanged.
+  assert.strictEqual(liveBinds(c), base, "one branch bind at a time");
+  l0.v = "A"; // writes to the now-dead branch's dep
+  await tick();
+  assert.strictEqual(r0, 1, "dead branch 0 bind never fires again");
+  l1.v = "B";
+  await tick();
+  assert.strictEqual(r1, 2, "live branch 1 bind fires");
+});
+
+// --- destroy() while shown, then no further work -----------------------------
+
+await test("ifBlock destroy() while shown removes content and kills binds", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const show = box(c, 0, true);
+  const label = box(c, 1, "x");
+  let runs = 0;
+  const blk = ifBlock(c, anchor, [0], () => show.v, () => {
+    const el = doc.createElement("s");
+    bind(c, [1], () => {
+      runs++;
+      el.data = label.v;
+    });
+    return el;
+  });
+  assert.strictEqual(runs, 1);
+  blk.destroy();
+  assert.strictEqual(shape(parent), "|", "content removed on destroy");
+  assert.strictEqual(liveBinds(c), 0, "all binds unregistered");
+  show.v = false;
+  show.v = true;
+  label.v = "y";
+  await tick();
+  assert.strictEqual(runs, 1, "nothing runs after destroy");
+});
+
+// --- update() drives the block synchronously (for :for item patching) --------
+
+await test("ifBlock.update() re-evaluates condition synchronously", () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  let flag = false;
+  const blk = ifBlock(c, anchor, [0], () => flag, () => doc.createElement("s"));
+  assert.strictEqual(shape(parent), "|");
+  flag = true;
+  blk.update(); // synchronous, no flush
+  assert.strictEqual(shape(parent), "<s> |");
+  flag = false;
+  blk.update();
+  assert.strictEqual(shape(parent), "|");
+});
+
+// --- scope homing across dropScope (item teardown recurses into :if) ---------
+
+await test("ifChain built inside a home scope tears down with that scope", async () => {
+  const c = createContext(null);
+  const parent = doc.createElement("div");
+  const anchor = anchorAppend(parent);
+  const which = box(c, 0, 0);
+  const label = box(c, 1, "x");
+  let runs = 0;
+  const home = beginScope(c);
+  ifChain(c, anchor, [0], () => which.v, [
+    () => {
+      const el = doc.createElement("z");
+      bind(c, [1], () => {
+        runs++;
+        el.data = label.v;
+      });
+      return el;
+    },
+  ]);
+  endScope(c);
+  assert.strictEqual(runs, 1);
+  dropScope(c, home); // simulate the enclosing :for item being removed
+  which.v = -1; // even switching now shouldn't resurrect anything
+  label.v = "y";
+  await tick();
+  assert.strictEqual(runs, 1, "branch bind dropped with home scope");
+});
+
+console.log("\nblocks.if.edge.test.mjs: " + passed + " passed.");

--- a/packages/lunas/test/dom.mountchild.test.mjs
+++ b/packages/lunas/test/dom.mountchild.test.mjs
@@ -1,0 +1,177 @@
+// dom.mountchild.test.mjs — mountChild lifecycle & wiring (src/blocks.mjs):
+// mount/unmount, multi-root (fragment) child, onDestroy fires exactly once,
+// parent link + _children registration, and unmount removing all nodes.
+// Uses the fake DOM shim so fragment()/component() innerHTML parsing works.
+// Run: node packages/lunas/test/dom.mountchild.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+const document = installDom();
+
+import { createContext, bind } from "../src/core.mjs";
+import { box, prop } from "../src/boxes.mjs";
+import { anchorAppend, component, fragment } from "../src/dom.mjs";
+import { mountChild } from "../src/blocks.mjs";
+import { onDestroy, onMount, attach, isLive } from "../src/lifecycle.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const shape = (p) =>
+  p.childNodes
+    .map((n) => (n.kind === "text" ? (n.data === "" ? "|" : n.data) : "<" + n.tag + ">"))
+    .join(" ");
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- basic mount / unmount ---------------------------------------------------
+
+await test("mountChild inserts a single-root child before the anchor; unmount removes it", () => {
+  const c = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  const Child = component("kid", {}, "<span></span>", () => {});
+  const m = mountChild(c, anchor, Child, {});
+  assert.strictEqual(shape(host), "<kid> |");
+  assert.ok(m.ctx, "handle exposes the child context");
+  m.unmount();
+  assert.strictEqual(shape(host), "|", "child removed on unmount");
+});
+
+// --- parent link + _children registration -----------------------------------
+
+await test("mountChild links child.ctx.parent to the parent and registers under _children", () => {
+  const c = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  const Child = component("kid", {}, "<i></i>", () => {});
+  const m = mountChild(c, anchor, Child, {});
+  assert.strictEqual(m.ctx.parent, c, "child.parent points at the mounting context");
+  assert.ok(c._children && c._children.includes(m.ctx), "child registered on _children");
+  m.unmount();
+  assert.ok(!c._children.includes(m.ctx), "child de-registered on unmount");
+});
+
+// --- multi-root (fragment) child mounts/unmounts as a group ------------------
+
+await test("mountChild handles a multi-root fragment child (all nodes travel together)", () => {
+  const c = createContext(null);
+  const host = document.createElement("div");
+  host.appendChild(document.createTextNode("H"));
+  const anchor = anchorAppend(host);
+  host.appendChild(document.createTextNode("T"));
+  const Child = fragment({}, "<a></a><b></b><c></c>", () => {});
+  const m = mountChild(c, anchor, Child, {});
+  assert.strictEqual(shape(host), "H <a> <b> <c> | T", "all fragment nodes inserted");
+  m.unmount();
+  assert.strictEqual(shape(host), "H | T", "unmount removed every fragment node");
+});
+
+// --- onDestroy fires exactly once --------------------------------------------
+
+await test("child onDestroy fires exactly once on unmount", () => {
+  const c = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  let destroys = 0;
+  const Child = component("kid", {}, "<x></x>", (cc) => {
+    onDestroy(cc, () => destroys++);
+  });
+  const m = mountChild(c, anchor, Child, {});
+  assert.strictEqual(destroys, 0, "not destroyed while mounted");
+  m.unmount();
+  assert.strictEqual(destroys, 1, "onDestroy ran once");
+  m.unmount(); // idempotent: runDestroy guards with _destroyed
+  assert.strictEqual(destroys, 1, "onDestroy does not fire a second time");
+});
+
+// --- onMount fires when inserted into a live tree ----------------------------
+
+await test("child onMount fires immediately when the anchor is already live", () => {
+  const parentRoot = component("root", {}, "<slot></slot>", () => {})({});
+  const liveHost = document.createElement("body");
+  attach(parentRoot, liveHost); // marks parentRoot live
+  const c = parentRoot.__lunasCtx;
+  const anchor = anchorAppend(parentRoot);
+
+  let mounted = 0;
+  const Child = component("kid", {}, "<x></x>", (cc) => {
+    onMount(cc, () => mounted++);
+  });
+  assert.ok(isLive(anchor), "anchor is in a live tree");
+  mountChild(c, anchor, Child, {});
+  assert.strictEqual(mounted, 1, "onMount fired at mount time (live insertion point)");
+});
+
+await test("child onMount stays pending until an ancestor attach() drains it", () => {
+  // Parent root is NOT attached yet. mountChild inserts the child into the
+  // detached parent; the child's onMount must not fire until attach().
+  const parentRoot = component("root", {}, "<hold></hold>", () => {})({});
+  const c = parentRoot.__lunasCtx;
+  const anchor = anchorAppend(parentRoot);
+  let mounted = 0;
+  const Child = component("kid", {}, "<x></x>", (cc) => {
+    onMount(cc, () => mounted++);
+  });
+  mountChild(c, anchor, Child, {});
+  assert.strictEqual(mounted, 0, "detached: onMount pending");
+  attach(parentRoot, document.createElement("body"));
+  assert.strictEqual(mounted, 1, "attach drained the child onMount");
+});
+
+// --- reactive prop bridge (setProp) ------------------------------------------
+
+await test("mountChild.setProp pushes into the child's reactive prop box", async () => {
+  const parent = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  let childText = null;
+  const Child = (props) => {
+    const root = document.createElement("kid");
+    const cc = createContext(root);
+    root.__lunasCtx = cc;
+    const v = prop(cc, "v", 0, props.v, "def");
+    const t = document.createTextNode("");
+    root.appendChild(t);
+    childText = t;
+    bind(cc, [0], () => {
+      t.data = String(v.v);
+    });
+    return root;
+  };
+  const n = box(parent, 0, 7);
+  const m = mountChild(parent, anchor, Child, { v: () => n.v });
+  bind(parent, [0], () => m.setProp("v", n.v));
+  assert.strictEqual(childText.data, "7", "seeded from the getter");
+  n.v = 12;
+  await tick();
+  assert.strictEqual(childText.data, "12", "parent write flowed into the child");
+});
+
+// --- unmount tears down a nested child chain (recursive destroy) -------------
+
+await test("unmount recurses: a grandchild's onDestroy also fires", () => {
+  const root = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  let grandDestroyed = 0;
+
+  const Grand = component("grand", {}, "<g></g>", (gc) => {
+    onDestroy(gc, () => grandDestroyed++);
+  });
+  const Child = component("child", {}, "<c></c>", (cc) => {
+    // The child mounts a grandchild during its own setup, linking it under cc.
+    const gAnchor = anchorAppend(cc.root);
+    mountChild(cc, gAnchor, Grand, {});
+  });
+
+  const m = mountChild(root, anchor, Child, {});
+  assert.strictEqual(grandDestroyed, 0);
+  m.unmount();
+  assert.strictEqual(grandDestroyed, 1, "grandchild destroy fired via recursion");
+});
+
+console.log("\ndom.mountchild.test.mjs: " + passed + " passed.");

--- a/packages/lunas/test/dom.norm.test.mjs
+++ b/packages/lunas/test/dom.norm.test.mjs
@@ -1,0 +1,277 @@
+// dom.norm.test.mjs — normClass / normStyle / setClass / setStyle plus
+// component / fragment / refs from src/dom.mjs. Covers string | object | array |
+// nested-array class/style, falsy filtering, camelCase->kebab, static merge,
+// and null/undefined/number values.
+// Run: node packages/lunas/test/dom.norm.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+const document = installDom();
+
+import {
+  normClass,
+  normStyle,
+  setClass,
+  setStyle,
+  component,
+  fragment,
+  refs,
+  on,
+} from "../src/dom.mjs";
+
+let passed = 0;
+let skipped = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+// test.skip — record a known-divergence test without running/failing it. The
+// reason is printed so the PR reviewer sees the deferred assertion.
+test.skip = (name, reason) => {
+  skipped++;
+  console.log("  SKIP  " + name + (reason ? "  (" + reason + ")" : ""));
+};
+
+// --- normClass ---------------------------------------------------------------
+
+test("normClass: string passes through trimmed", () => {
+  assert.strictEqual(normClass("btn primary"), "btn primary");
+  assert.strictEqual(normClass("  spaced  "), "spaced");
+});
+
+test("normClass: object keeps truthy-valued keys only", () => {
+  assert.strictEqual(
+    normClass({ a: true, b: false, c: 1, d: 0, e: "x", f: "" }),
+    "a c e"
+  );
+});
+
+test("normClass: array flattens and joins", () => {
+  assert.strictEqual(normClass(["a", "b", "c"]), "a b c");
+});
+
+test("normClass: nested arrays flatten recursively", () => {
+  assert.strictEqual(
+    normClass(["a", ["b", ["c", "d"]], "e"]),
+    "a b c d e"
+  );
+});
+
+test("normClass: mixed array of strings + objects", () => {
+  assert.strictEqual(
+    normClass(["base", { active: true, hidden: false }, ["extra"]]),
+    "base active extra"
+  );
+});
+
+test("normClass: nullish/false/empty-string entries in arrays are dropped", () => {
+  // null, undefined, false, "" are all dropped (each normalizes to "").
+  assert.strictEqual(
+    normClass(["a", null, undefined, false, "", "b"]),
+    "a b"
+  );
+});
+
+// KNOWN DIVERGENCE (deferred; see PR note): a falsy *number* (0 / NaN) inside a
+// class array is NOT dropped — normClass(0) stringifies to "0", so it leaks in
+// as a "0" class token, unlike Vue which drops falsy array entries. The array
+// branch of normClass only skips entries whose normalized result is "", and
+// normClass(0) === "0". Fix is a one-line `if (!v) continue;` in the array loop
+// of src/dom.mjs, but that edit is out of scope for this test-only PR.
+test.skip(
+  "normClass: falsy numbers (0/NaN) in arrays should be dropped (Vue-parity)",
+  "normClass(0) leaks a '0' class token; src/dom.mjs array loop needs `if (!v) continue;`"
+);
+
+test("normClass: current behavior — a falsy number in an array leaks as a token", () => {
+  // Documents the ACTUAL behavior today so the divergence is pinned and any
+  // future fix will flip this test (a signal to update it alongside the fix).
+  assert.strictEqual(normClass(["a", 0, "b"]), "a 0 b");
+  assert.strictEqual(normClass(["a", NaN, "b"]), "a NaN b");
+});
+
+test("normClass: null / undefined / false => empty string", () => {
+  assert.strictEqual(normClass(null), "");
+  assert.strictEqual(normClass(undefined), "");
+  assert.strictEqual(normClass(false), "");
+});
+
+test("normClass: number stringifies", () => {
+  assert.strictEqual(normClass(42), "42");
+});
+
+test("normClass: empty object / empty array => empty string", () => {
+  assert.strictEqual(normClass({}), "");
+  assert.strictEqual(normClass([]), "");
+});
+
+// --- setClass (static + dynamic merge) ---------------------------------------
+
+test("setClass merges static class with dynamic object", () => {
+  const el = document.createElement("div");
+  setClass(el, "static", { on: true, off: false });
+  assert.strictEqual(el.getAttribute("class"), "static on");
+});
+
+test("setClass with only static (dynamic empty) keeps static", () => {
+  const el = document.createElement("div");
+  setClass(el, "base", null);
+  assert.strictEqual(el.getAttribute("class"), "base");
+});
+
+test("setClass with neither static nor dynamic removes the attribute", () => {
+  const el = document.createElement("div");
+  el.setAttribute("class", "old");
+  setClass(el, "", false);
+  assert.strictEqual(el.getAttribute("class"), null);
+});
+
+test("setClass dynamic-only writes just the dynamic classes", () => {
+  const el = document.createElement("div");
+  setClass(el, "", ["x", "y"]);
+  assert.strictEqual(el.getAttribute("class"), "x y");
+});
+
+// --- normStyle ---------------------------------------------------------------
+
+test("normStyle: string passes through trimmed", () => {
+  assert.strictEqual(normStyle("color: red"), "color: red");
+});
+
+test("normStyle: object camelCase keys become kebab-case props", () => {
+  assert.strictEqual(
+    normStyle({ backgroundColor: "red", fontSize: "12px" }),
+    "background-color: red; font-size: 12px;"
+  );
+});
+
+test("normStyle: custom properties (--x) pass through unchanged", () => {
+  assert.strictEqual(
+    normStyle({ "--brand": "blue", color: "black" }),
+    "--brand: blue; color: black;"
+  );
+});
+
+test("normStyle: null/false values in an object are skipped", () => {
+  assert.strictEqual(
+    normStyle({ color: "red", margin: null, padding: false, top: 0 }),
+    "color: red; top: 0;"
+  );
+});
+
+test("normStyle: numeric values stringify", () => {
+  assert.strictEqual(normStyle({ zIndex: 10, opacity: 0.5 }), "z-index: 10; opacity: 0.5;");
+});
+
+test("normStyle: array merges left-to-right", () => {
+  const out = normStyle([{ color: "red" }, "font-weight: bold", { top: "1px" }]);
+  assert.match(out, /color: red;/);
+  assert.match(out, /font-weight: bold/);
+  assert.match(out, /top: 1px;/);
+});
+
+test("normStyle: null / undefined / false => empty string", () => {
+  assert.strictEqual(normStyle(null), "");
+  assert.strictEqual(normStyle(undefined), "");
+  assert.strictEqual(normStyle(false), "");
+});
+
+test("normStyle: empty object => empty string", () => {
+  assert.strictEqual(normStyle({}), "");
+});
+
+// --- setStyle (static + dynamic merge) ---------------------------------------
+
+test("setStyle merges static style (adds trailing ;) with dynamic object", () => {
+  const el = document.createElement("div");
+  setStyle(el, "margin: 0", { color: "red" });
+  assert.strictEqual(el.getAttribute("style"), "margin: 0; color: red;");
+});
+
+test("setStyle static already ending in ; merges cleanly", () => {
+  const el = document.createElement("div");
+  setStyle(el, "margin: 0;", { color: "red" });
+  assert.strictEqual(el.getAttribute("style"), "margin: 0; color: red;");
+});
+
+test("setStyle with empty dynamic keeps the static style", () => {
+  const el = document.createElement("div");
+  setStyle(el, "display: none", null);
+  assert.strictEqual(el.getAttribute("style"), "display: none;");
+});
+
+test("setStyle with nothing removes the attribute", () => {
+  const el = document.createElement("div");
+  el.setAttribute("style", "old: 1");
+  setStyle(el, "", null);
+  assert.strictEqual(el.getAttribute("style"), null);
+});
+
+// --- component / refs --------------------------------------------------------
+
+test("component builds a root, parses skeleton HTML, exposes context", () => {
+  const factory = component(
+    "div",
+    { id: "root" },
+    "<span></span><b></b>",
+    (c, props) => {
+      c._seenProps = props;
+    }
+  );
+  const root = factory({ hello: 1 });
+  assert.strictEqual(root.tag, "div");
+  assert.strictEqual(root.getAttribute("id"), "root");
+  assert.strictEqual(root.childNodes.length, 2);
+  assert.strictEqual(root.childNodes[0].tag, "span");
+  assert.ok(root.__lunasCtx, "context attached to the root");
+  assert.deepStrictEqual(root.__lunasCtx._seenProps, { hello: 1 });
+});
+
+test("refs: positional navigation to nested nodes", () => {
+  const root = document.createElement("div");
+  root.innerHTML = "<a></a><b><i></i><u></u></b>";
+  const [aNode, uNode] = refs(root, [[0], [1, 1]]);
+  assert.strictEqual(aNode.tag, "a");
+  assert.strictEqual(uNode.tag, "u");
+});
+
+test("on() wires a listener resolved by refs against a component root", () => {
+  const factory = component("div", {}, "<button></button>", () => {});
+  const root = factory({});
+  const [btn] = refs(root, [[0]]);
+  let clicks = 0;
+  on(btn, "click", () => clicks++);
+  btn.dispatch("click");
+  assert.strictEqual(clicks, 1);
+});
+
+// --- fragment (multi-root component) -----------------------------------------
+
+test("fragment returns a node group carrying context on __lunasCtx", () => {
+  const factory = fragment({}, "<a></a><b></b><c></c>", (c) => {
+    c._wired = true;
+  });
+  const frag = factory({});
+  assert.ok(Array.isArray(frag), "fragment is an array of nodes");
+  assert.strictEqual(frag.length, 3);
+  assert.strictEqual(frag[0].tag, "a");
+  assert.strictEqual(frag[2].tag, "c");
+  assert.ok(frag.__lunasCtx && frag.__lunasCtx._wired, "context on the group");
+  // nodes are detached from the throwaway host (no parent).
+  assert.strictEqual(frag[0].parentNode, null);
+});
+
+test("fragment wiring can capture refs against the parsed tree", () => {
+  let captured = null;
+  const factory = fragment({}, "<a></a><b><i></i></b>", (c) => {
+    captured = refs(c.root, [[1, 0]])[0];
+  });
+  factory({});
+  assert.strictEqual(captured.tag, "i", "ref resolved against the fragment host tree");
+});
+
+console.log(
+  "\ndom.norm.test.mjs: " + passed + " passed" +
+    (skipped ? ", " + skipped + " skipped" : "") + "."
+);

--- a/packages/lunas/test/for-diff.reorder.test.mjs
+++ b/packages/lunas/test/for-diff.reorder.test.mjs
@@ -1,0 +1,482 @@
+// for-diff.reorder.test.mjs — deep coverage of the keyed LIS reconciler
+// (src/for_diff.mjs) at the abstract-host level. Asserts BOTH final key order
+// AND node-identity preservation for items that should not be recreated/moved.
+// Run: node packages/lunas/test/for-diff.reorder.test.mjs
+//
+// The reconciler is host-abstracted, so these tests use a validating fake host
+// that mirrors real-DOM insertBefore/remove semantics (throws on double-insert,
+// removing a detached node, or a bad refNode) — the same contract the design
+// doc's reference harness enforces.
+
+import assert from "node:assert";
+import {
+  createForState,
+  seedForState,
+  reconcile,
+  longestIncreasingSubsequence,
+  extractKeys,
+} from "../src/for_diff.mjs";
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// ---------------------------------------------------------------------------
+// Validating fake host + node factory.
+// A "node" is a small object carrying its key and a monotonic uid so identity
+// is easy to assert. The host keeps an ordered array of children and enforces
+// DOM-like invariants; `null` ref means "append at the end (before anchor)".
+// ---------------------------------------------------------------------------
+function makeHost() {
+  const children = []; // current order
+  const present = new Set();
+  return {
+    children,
+    insertBefore(node, ref) {
+      // A move: remove from current position first (real DOM does this too).
+      const cur = children.indexOf(node);
+      if (cur >= 0) children.splice(cur, 1);
+      if (ref === null || ref === undefined) {
+        children.push(node);
+      } else {
+        const at = children.indexOf(ref);
+        if (at < 0) throw new Error("insertBefore: refNode is not present");
+        children.splice(at, 0, node);
+      }
+      present.add(node);
+    },
+    remove(node) {
+      const at = children.indexOf(node);
+      if (at < 0) throw new Error("remove: node is not present");
+      children.splice(at, 1);
+      present.delete(node);
+    },
+  };
+}
+
+let uid = 0;
+// A make that counts calls and tags nodes; wrap in a fresh counter per test.
+function makerWith(counter) {
+  return (data, key /*, index */) => {
+    counter.made++;
+    return { key, data, uid: uid++ };
+  };
+}
+
+const keyOrder = (host) => host.children.map((n) => n.key);
+
+// Seed a state+host from an initial keyed array, returning { state, host,
+// nodesByKey } so later assertions can check identity of specific keys.
+function seedFrom(keys) {
+  const host = makeHost();
+  const nodes = keys.map((k) => ({ key: k, data: k, uid: uid++ }));
+  for (const n of nodes) host.children.push(n);
+  const state = createForState();
+  seedForState(state, keys, nodes, keys.slice());
+  const nodesByKey = new Map();
+  keys.forEach((k, i) => nodesByKey.set(k, nodes[i]));
+  return { state, host, nodesByKey };
+}
+
+const idOpts = () => ({ keyOf: (d) => d });
+
+// ---------------------------------------------------------------------------
+// Structural cases — each asserts final order.
+// ---------------------------------------------------------------------------
+
+test("append: prefix trims, pure-insert shortcut, 0 moves on kept", () => {
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["a", "b", "c", "d", "e"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "b", "c", "d", "e"]);
+  assert.strictEqual(counter.made, 2, "only the two new items built");
+  // a,b,c identities untouched.
+  assert.strictEqual(host.children[0], nodesByKey.get("a"));
+  assert.strictEqual(host.children[2], nodesByKey.get("c"));
+});
+
+test("prepend: suffix trims, 1 insert + 0 moves", () => {
+  const { state, host, nodesByKey } = seedFrom(["b", "c", "d"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["a", "b", "c", "d"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "b", "c", "d"]);
+  assert.strictEqual(counter.made, 1);
+  // b,c,d never moved/recreated.
+  assert.strictEqual(host.children[1], nodesByKey.get("b"));
+  assert.strictEqual(host.children[3], nodesByKey.get("d"));
+});
+
+test("insert-middle: one new key in the middle, neighbors keep identity", () => {
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "d"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["a", "b", "c", "d"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "b", "c", "d"]);
+  assert.strictEqual(counter.made, 1);
+  assert.strictEqual(host.children[0], nodesByKey.get("a"));
+  assert.strictEqual(host.children[1], nodesByKey.get("b"));
+  assert.strictEqual(host.children[3], nodesByKey.get("d"));
+});
+
+test("remove-middle: pure-remove shortcut, neighbors keep identity", () => {
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c", "d"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["a", "d"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "d"]);
+  assert.strictEqual(counter.made, 0, "nothing built on pure remove");
+  assert.strictEqual(host.children[0], nodesByKey.get("a"));
+  assert.strictEqual(host.children[1], nodesByKey.get("d"));
+});
+
+test("remove-all: N -> empty", () => {
+  const { state, host } = seedFrom(["a", "b", "c"]);
+  const counter = { made: 0 };
+  reconcile(state, host, [], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), []);
+  assert.strictEqual(counter.made, 0);
+  assert.strictEqual(state.keys.length, 0);
+});
+
+test("empty -> N: pure build, 0 moves", () => {
+  const host = makeHost();
+  const state = createForState();
+  const counter = { made: 0 };
+  reconcile(state, host, ["x", "y", "z"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["x", "y", "z"]);
+  assert.strictEqual(counter.made, 3);
+});
+
+test("swap adjacent: exactly one node moves, other keeps identity", () => {
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c", "d"]);
+  const counter = { made: 0 };
+  const b = nodesByKey.get("b");
+  const cNode = nodesByKey.get("c");
+  reconcile(state, host, ["a", "c", "b", "d"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "c", "b", "d"]);
+  assert.strictEqual(counter.made, 0, "swap creates nothing");
+  // Both nodes reused (by identity); only their order changed.
+  assert.strictEqual(host.children[1], cNode);
+  assert.strictEqual(host.children[2], b);
+  assert.strictEqual(host.children[0], nodesByKey.get("a"), "a unmoved kept");
+  assert.strictEqual(host.children[3], nodesByKey.get("d"), "d unmoved kept");
+});
+
+test("reverse: all nodes reused by identity, none recreated", () => {
+  const keys = ["a", "b", "c", "d", "e"];
+  const { state, host, nodesByKey } = seedFrom(keys);
+  const counter = { made: 0 };
+  reconcile(state, host, ["e", "d", "c", "b", "a"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["e", "d", "c", "b", "a"]);
+  assert.strictEqual(counter.made, 0, "reverse recreates nothing");
+  for (const k of keys) {
+    // every original node is still present (identity preserved), just reordered
+    assert.ok(host.children.includes(nodesByKey.get(k)), "node " + k + " kept");
+  }
+  // the LIS-preserved node (the single fixed point of a full reverse) never
+  // needs recreation regardless of which one it is.
+});
+
+test("move-far: front item to the back keeps every node's identity", () => {
+  const keys = ["a", "b", "c", "d", "e"];
+  const { state, host, nodesByKey } = seedFrom(keys);
+  const counter = { made: 0 };
+  reconcile(state, host, ["b", "c", "d", "e", "a"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["b", "c", "d", "e", "a"]);
+  assert.strictEqual(counter.made, 0);
+  // b..e form the LIS (already in order) and must NOT be recreated; a moved.
+  assert.strictEqual(host.children[4], nodesByKey.get("a"));
+  for (const k of keys) assert.ok(host.children.includes(nodesByKey.get(k)));
+});
+
+test("shuffle: arbitrary permutation, all nodes reused, order exact", () => {
+  const keys = ["a", "b", "c", "d", "e", "f", "g"];
+  const { state, host, nodesByKey } = seedFrom(keys);
+  const counter = { made: 0 };
+  const target = ["d", "g", "a", "f", "b", "e", "c"];
+  reconcile(state, host, target, makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), target);
+  assert.strictEqual(counter.made, 0, "permutation recreates nothing");
+  for (const k of keys) assert.ok(host.children.includes(nodesByKey.get(k)));
+});
+
+test("stable-vs-moved: an ascending run stays put (LIS identity)", () => {
+  // [a b c d e f] -> [a b c f d e]: a,b,c stay; only f moves before d.
+  // Assert a,b,c,d,e keep identity and are NOT touched (still present).
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c", "d", "e", "f"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["a", "b", "c", "f", "d", "e"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["a", "b", "c", "f", "d", "e"]);
+  assert.strictEqual(counter.made, 0);
+  assert.strictEqual(host.children[0], nodesByKey.get("a"));
+  assert.strictEqual(host.children[1], nodesByKey.get("b"));
+  assert.strictEqual(host.children[2], nodesByKey.get("c"));
+  assert.strictEqual(host.children[3], nodesByKey.get("f"));
+  assert.strictEqual(host.children[4], nodesByKey.get("d"));
+});
+
+test("interleaved insert + remove + move in one update", () => {
+  // old: a b c d e ; new: c x a e y  (b,d removed; x,y inserted; a,c,e moved)
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c", "d", "e"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["c", "x", "a", "e", "y"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["c", "x", "a", "e", "y"]);
+  assert.strictEqual(counter.made, 2, "x and y are new");
+  // kept keys reuse their original nodes.
+  assert.strictEqual(host.children[0], nodesByKey.get("c"));
+  assert.strictEqual(host.children[2], nodesByKey.get("a"));
+  assert.strictEqual(host.children[3], nodesByKey.get("e"));
+  // removed nodes are gone.
+  assert.ok(!host.children.includes(nodesByKey.get("b")));
+  assert.ok(!host.children.includes(nodesByKey.get("d")));
+});
+
+test("single item: identity kept across a no-op update", () => {
+  const { state, host, nodesByKey } = seedFrom(["only"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["only"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["only"]);
+  assert.strictEqual(counter.made, 0);
+  assert.strictEqual(host.children[0], nodesByKey.get("only"));
+});
+
+test("single item replaced by a different key: remove + insert", () => {
+  const { state, host, nodesByKey } = seedFrom(["a"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["b"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["b"]);
+  assert.strictEqual(counter.made, 1, "b built");
+  assert.ok(!host.children.includes(nodesByKey.get("a")), "a removed");
+});
+
+test("replace-all-keys: none reused, all rebuilt", () => {
+  const { state, host, nodesByKey } = seedFrom(["a", "b", "c"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["x", "y", "z"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["x", "y", "z"]);
+  assert.strictEqual(counter.made, 3);
+  for (const k of ["a", "b", "c"])
+    assert.ok(!host.children.includes(nodesByKey.get(k)));
+});
+
+// ---------------------------------------------------------------------------
+// Key types: numbers vs strings are distinct keys (=== semantics).
+// ---------------------------------------------------------------------------
+
+test("numeric keys reconcile and reuse by identity", () => {
+  const host = makeHost();
+  const state = createForState();
+  const counter = { made: 0 };
+  reconcile(state, host, [1, 2, 3], makerWith(counter), idOpts());
+  const n2 = host.children[1];
+  reconcile(state, host, [3, 2, 1], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), [3, 2, 1]);
+  assert.strictEqual(host.children[1], n2, "numeric key 2 reused");
+  assert.strictEqual(counter.made, 3, "reorder built nothing new");
+});
+
+test("number key 1 and string key '1' are different identities", () => {
+  const host = makeHost();
+  const state = createForState();
+  const counter = { made: 0 };
+  reconcile(state, host, [1], makerWith(counter), idOpts());
+  const numNode = host.children[0];
+  reconcile(state, host, ["1"], makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), ["1"]);
+  assert.strictEqual(counter.made, 2, "'1' is a fresh key -> rebuilt");
+  assert.ok(!host.children.includes(numNode), "numeric node removed");
+});
+
+// ---------------------------------------------------------------------------
+// Duplicate keys -> index-key fallback (§7). Order still exact; no throw.
+// ---------------------------------------------------------------------------
+
+test("duplicate keys fall back to index keys; order exact; warns once", () => {
+  // Under the index fallback the reconcile degrades to a stable POSITIONAL
+  // patch (§7): old items are reused by position and patched with the new data,
+  // so the visible data ends up exactly the target sequence. We assert on the
+  // patched data (via patchItem), since node keys stay at their seed values by
+  // design when identity reuse is disabled.
+  const { state, host } = seedFrom(["a", "b", "c"]);
+  const counter = { made: 0 };
+  const warnings = [];
+  const finalData = new Array(3);
+  reconcile(state, host, ["dup", "dup", "z"], makerWith(counter), {
+    keyOf: (d) => d,
+    onWarn: (m) => warnings.push(m),
+    patchItem: (node, d, i) => {
+      finalData[i] = d;
+    },
+  });
+  // Three nodes present, in order, holding the target data.
+  assert.strictEqual(host.children.length, 3);
+  assert.deepStrictEqual(finalData, ["dup", "dup", "z"]);
+  assert.strictEqual(counter.made, 0, "positional reuse builds nothing");
+  assert.strictEqual(warnings.length, 1, "warned exactly once");
+  assert.match(warnings[0], /duplicate key/);
+  // State keys are positional after fallback.
+  assert.deepStrictEqual(state.keys, [0, 1, 2]);
+});
+
+test("duplicate-key fallback with growth: tail insert covers new length", () => {
+  // old length 2, new length 3 with a dup -> positional patch on [0,1] then a
+  // tail insert for index 2.
+  const { state, host } = seedFrom(["a", "b"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["x", "x", "y"], makerWith(counter), {
+    keyOf: (d) => d,
+    onWarn: () => {},
+  });
+  assert.strictEqual(host.children.length, 3, "grew to 3 nodes");
+  assert.strictEqual(counter.made, 1, "one tail item built");
+});
+
+test("recovers to full keyed behavior on the next unique-key update", () => {
+  const { state, host } = seedFrom(["a", "b"]);
+  const counter = { made: 0 };
+  reconcile(state, host, ["x", "x"], makerWith(counter), {
+    keyOf: (d) => d,
+    onWarn: () => {},
+  });
+  assert.strictEqual(host.children.length, 2);
+  // Now a clean unique-key update: keys become real again.
+  reconcile(state, host, ["p", "q"], makerWith(counter), idOpts());
+  assert.strictEqual(host.children.length, 2);
+  assert.deepStrictEqual(state.keys, ["p", "q"]);
+});
+
+test("extractKeys: unique keys pass through, no dup flag", () => {
+  const r = extractKeys(["a", "b", "c"], (d) => d, null);
+  assert.deepStrictEqual(r.keys, ["a", "b", "c"]);
+  assert.strictEqual(r.duped, false);
+});
+
+test("extractKeys: duplicate collapses to positional keys + duped flag", () => {
+  let warned = 0;
+  const r = extractKeys(["a", "a", "b"], (d) => d, () => warned++);
+  assert.deepStrictEqual(r.keys, [0, 1, 2]);
+  assert.strictEqual(r.duped, true);
+  assert.strictEqual(warned, 1);
+});
+
+// ---------------------------------------------------------------------------
+// LIS unit tests — the move-minimizer itself.
+// ---------------------------------------------------------------------------
+
+test("longestIncreasingSubsequence: basic ascending run positions", () => {
+  // arr values are old indices; result is POSITIONS into arr forming a longest
+  // strictly-increasing run.
+  const arr = [2, 3, 1, 5, 4];
+  const pos = longestIncreasingSubsequence(arr);
+  const vals = pos.map((p) => arr[p]);
+  // strictly increasing
+  for (let i = 1; i < vals.length; i++) assert.ok(vals[i] > vals[i - 1]);
+  assert.strictEqual(vals.length, 3, "LIS length of [2,3,1,5,4] is 3");
+});
+
+test("longestIncreasingSubsequence: skips NADA (-1) holes", () => {
+  const arr = [-1, 0, -1, 1, 2];
+  const pos = longestIncreasingSubsequence(arr);
+  const vals = pos.map((p) => arr[p]);
+  assert.ok(!vals.includes(-1), "holes never appear in the LIS");
+  assert.deepStrictEqual(vals, [0, 1, 2]);
+});
+
+test("longestIncreasingSubsequence: empty and all-holes", () => {
+  assert.deepStrictEqual(longestIncreasingSubsequence([]), []);
+  assert.deepStrictEqual(longestIncreasingSubsequence([-1, -1]), []);
+});
+
+test("longestIncreasingSubsequence: strictly decreasing has length 1", () => {
+  const arr = [5, 4, 3, 2, 1];
+  const pos = longestIncreasingSubsequence(arr);
+  assert.strictEqual(pos.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Large list (100+) correctness: reverse a big list, assert exact order and
+// that no node was recreated (all reused by identity).
+// ---------------------------------------------------------------------------
+
+test("large list (120): reverse reuses all nodes, exact order", () => {
+  const N = 120;
+  const keys = [];
+  for (let i = 0; i < N; i++) keys.push("k" + i);
+  const { state, host, nodesByKey } = seedFrom(keys);
+  const counter = { made: 0 };
+  const target = keys.slice().reverse();
+  reconcile(state, host, target, makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), target);
+  assert.strictEqual(counter.made, 0, "reverse of 120 recreated nothing");
+  for (const k of keys) assert.ok(host.children.includes(nodesByKey.get(k)));
+});
+
+test("large list (150): random shuffle, exact order + full reuse", () => {
+  const N = 150;
+  const keys = [];
+  for (let i = 0; i < N; i++) keys.push(i);
+  const { state, host, nodesByKey } = seedFrom(keys);
+  const counter = { made: 0 };
+  // deterministic LCG shuffle
+  let s = 123456789 >>> 0;
+  const rand = () => ((s = (1103515245 * s + 12345) >>> 0) / 0x100000000);
+  const target = keys.slice();
+  for (let i = target.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const t = target[i];
+    target[i] = target[j];
+    target[j] = t;
+  }
+  reconcile(state, host, target, makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), target);
+  assert.strictEqual(counter.made, 0, "shuffle recreated nothing");
+  for (const k of keys) assert.ok(host.children.includes(nodesByKey.get(k)));
+});
+
+test("large list: append 50 to 100 keeps the original 100 untouched", () => {
+  const base = [];
+  for (let i = 0; i < 100; i++) base.push("b" + i);
+  const { state, host, nodesByKey } = seedFrom(base);
+  const counter = { made: 0 };
+  const target = base.slice();
+  for (let i = 0; i < 50; i++) target.push("n" + i);
+  reconcile(state, host, target, makerWith(counter), idOpts());
+  assert.deepStrictEqual(keyOrder(host), target);
+  assert.strictEqual(counter.made, 50, "only the 50 new items built");
+  // original 100 identities preserved and unmoved.
+  for (let i = 0; i < 100; i++)
+    assert.strictEqual(host.children[i], nodesByKey.get("b" + i));
+});
+
+// ---------------------------------------------------------------------------
+// patchItem is called for kept items with new data/index.
+// ---------------------------------------------------------------------------
+
+test("patchItem receives new data & index for kept items", () => {
+  const host = makeHost();
+  const state = createForState();
+  const counter = { made: 0 };
+  const mk = (d, k) => ({ key: k, data: d, uid: uid++ });
+  reconcile(state, host, [{ id: 1, v: "a" }, { id: 2, v: "b" }], mk, {
+    keyOf: (d) => d.id,
+  });
+  const patched = [];
+  reconcile(
+    state,
+    host,
+    [{ id: 2, v: "B" }, { id: 1, v: "A" }],
+    mk,
+    {
+      keyOf: (d) => d.id,
+      patchItem: (node, d, i) => patched.push([node.key, d.v, i]),
+    }
+  );
+  assert.deepStrictEqual(keyOrder(host), [2, 1]);
+  // both kept items patched with their new value and new index.
+  const byKey = new Map(patched.map((p) => [p[0], p]));
+  assert.deepStrictEqual(byKey.get(2), [2, "B", 0]);
+  assert.deepStrictEqual(byKey.get(1), [1, "A", 1]);
+});
+
+console.log("\nfor-diff.reorder.test.mjs: " + passed + " passed.");

--- a/packages/lunas/test/slots.runtime.test.mjs
+++ b/packages/lunas/test/slots.runtime.test.mjs
@@ -1,0 +1,296 @@
+// slots.runtime.test.mjs — additional runtime coverage for slotBlock /
+// slotContent (src/blocks.mjs), complementing slots.test.mjs. Focus: scoped
+// props snapshot semantics, multiple onCleanup registrations, teardown when the
+// slot content lives inside a :for item scope, and named-slot routing where one
+// slot is filled and another falls back.
+// Run: node packages/lunas/test/slots.runtime.test.mjs
+
+import assert from "node:assert";
+import {
+  createContext,
+  bind,
+  beginScope,
+  endScope,
+  dropScope,
+} from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { slotBlock, slotContent } from "../src/blocks.mjs";
+import { onDestroy, runDestroy } from "../src/lifecycle.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// --- minimal fake DOM --------------------------------------------------------
+class FakeNode {
+  constructor(doc, kind, data) {
+    this.ownerDocument = doc;
+    this.kind = kind;
+    this.data = data || "";
+    this.childNodes = [];
+    this.parentNode = null;
+  }
+  insertBefore(n, ref) {
+    if (n.parentNode) n.parentNode._drop(n);
+    const at = ref == null ? this.childNodes.length : this.childNodes.indexOf(ref);
+    this.childNodes.splice(at, 0, n);
+    n.parentNode = this;
+    return n;
+  }
+  appendChild(n) {
+    return this.insertBefore(n, null);
+  }
+  _drop(n) {
+    const i = this.childNodes.indexOf(n);
+    if (i >= 0) this.childNodes.splice(i, 1);
+    n.parentNode = null;
+  }
+  remove() {
+    if (this.parentNode) this.parentNode._drop(this);
+  }
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const s = this.parentNode.childNodes;
+    return s[s.indexOf(this) + 1] || null;
+  }
+}
+const doc = {
+  createTextNode: (d) => new FakeNode(doc, "text", d),
+  createElement: (t) => {
+    const n = new FakeNode(doc, "element", "");
+    n.tag = t;
+    return n;
+  },
+};
+const shape = (p) =>
+  p.childNodes
+    .map((n) => (n.kind === "text" ? (n.data === "" ? "|" : n.data) : "<" + n.tag + ">"))
+    .join(" ");
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- default slot with parent content beats fallback -------------------------
+
+await test("default slot: parent content wins; fallback is not built", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  let fallbackBuilt = 0;
+  slotBlock(
+    child,
+    anchor,
+    () => doc.createTextNode("parent"),
+    () => {
+      fallbackBuilt++;
+      return doc.createTextNode("fb");
+    }
+  );
+  assert.strictEqual(shape(host), "parent |");
+  assert.strictEqual(fallbackBuilt, 0, "fallback factory never invoked");
+});
+
+// --- named routing: one filled, one falls back -------------------------------
+
+await test("named slots: filled slot renders content, unfilled shows fallback", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const aHead = anchorAppend(host);
+  const aBody = anchorAppend(host);
+  // header is provided by the parent; body is not, so its fallback shows.
+  slotBlock(child, aHead, () => doc.createTextNode("H!"), () =>
+    doc.createTextNode("noheader")
+  );
+  slotBlock(child, aBody, undefined, () => doc.createTextNode("defaultbody"));
+  assert.strictEqual(shape(host), "H! | defaultbody |");
+});
+
+// --- scoped props snapshot: slotPropsOf is read exactly once -----------------
+
+await test("scoped slot props are snapshotted once at build time", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  let propsReads = 0;
+  const factory = (sp) => doc.createTextNode("item=" + sp.item);
+  slotBlock(child, anchor, factory, null, () => {
+    propsReads++;
+    return { item: "apple" };
+  });
+  assert.strictEqual(shape(host), "item=apple |");
+  assert.strictEqual(propsReads, 1, "slotPropsOf invoked exactly once");
+});
+
+await test("scoped slot: the same props object is passed to factory and fallback path", () => {
+  // When a factory is present, fallback is ignored; verify the props object the
+  // factory saw is the object returned by slotPropsOf (identity, not a copy).
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const propsObj = { item: "x", idx: 3 };
+  let seen = null;
+  slotBlock(child, anchor, (sp) => {
+    seen = sp;
+    return doc.createTextNode(String(sp.idx));
+  }, null, () => propsObj);
+  assert.strictEqual(seen, propsObj, "factory got the exact props object");
+  assert.strictEqual(shape(host), "3 |");
+});
+
+// --- multiple onCleanup registrations all fire on child unmount --------------
+
+await test("multiple onCleanup callbacks all run on child unmount", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const fired = [];
+  const factory = (sp, onCleanup) => {
+    onCleanup(() => fired.push("a"));
+    onCleanup(() => fired.push("b"));
+    onCleanup("not a function"); // ignored defensively
+    return doc.createTextNode("c");
+  };
+  slotBlock(child, anchor, factory, null);
+  assert.deepStrictEqual(fired, [], "no cleanup before unmount");
+  runDestroy(child);
+  assert.deepStrictEqual(fired, ["a", "b"], "both function cleanups fired");
+});
+
+// --- slotContent: parent-owned scope drops on child unmount ------------------
+
+await test("slotContent binds live on the parent and drop on child unmount", async () => {
+  const parent = createContext(null);
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const n = box(parent, 0, 1);
+  let runs = 0;
+
+  const factory = (sp, onCleanup) =>
+    slotContent(
+      parent,
+      () => {
+        const t = doc.createTextNode("");
+        bind(parent, [0], () => {
+          runs++;
+          t.data = "n=" + n.v;
+        });
+        return t;
+      },
+      sp,
+      onCleanup
+    );
+
+  slotBlock(child, anchor, factory, null);
+  assert.strictEqual(shape(host), "n=1 |");
+  assert.strictEqual(runs, 1);
+  n.v = 2;
+  await tick();
+  assert.strictEqual(shape(host), "n=2 |", "parent drives the slot content");
+  assert.strictEqual(runs, 2);
+
+  runDestroy(child); // parent-owned scope dropped via onCleanup
+  n.v = 3;
+  await tick();
+  assert.strictEqual(runs, 2, "no bind ran after child unmount");
+  // Parent adjacency for var 0 is now empty (the only dependent was the slot).
+  assert.strictEqual((parent.deps[0] || []).length, 0);
+});
+
+// --- slotContent homed in a :for item scope tears down with the item ---------
+
+await test("slotContent homed in an item scope drops when that scope is dropped", async () => {
+  const parent = createContext(null);
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const n = box(parent, 0, 1);
+  let runs = 0;
+
+  // Simulate the parent mounting the child inside a :for item scope: the scope
+  // is open when slotContent runs, so its content scope homes under the item.
+  const itemScope = beginScope(parent);
+  const factory = (sp, onCleanup) =>
+    slotContent(
+      parent,
+      () => {
+        const t = doc.createTextNode("");
+        bind(parent, [0], () => {
+          runs++;
+          t.data = "v=" + n.v;
+        });
+        return t;
+      },
+      sp,
+      onCleanup
+    );
+  slotBlock(child, anchor, factory, null);
+  endScope(parent);
+
+  assert.strictEqual(runs, 1);
+  // Dropping the item scope must tear down the slot content's parent-owned bind,
+  // even though the bind lives on the parent context.
+  dropScope(parent, itemScope);
+  n.v = 5;
+  await tick();
+  assert.strictEqual(runs, 1, "slot content bind dropped with the item scope");
+});
+
+// --- fallback wired in child scope drops on child destroy --------------------
+
+await test("fallback content (child scope) drops on child destroy", async () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const flag = box(child, 0, "a");
+  let runs = 0;
+  slotBlock(child, anchor, undefined, () => {
+    const t = doc.createTextNode("");
+    bind(child, [0], () => {
+      runs++;
+      t.data = flag.v;
+    });
+    return t;
+  });
+  assert.strictEqual(shape(host), "a |");
+  assert.strictEqual(runs, 1);
+  runDestroy(child);
+  flag.v = "b";
+  await tick();
+  assert.strictEqual(runs, 1, "fallback bind dropped after destroy");
+});
+
+// --- empty parent content (factory returns null) -----------------------------
+
+await test("factory returning null renders nothing (no fallback either)", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  // A function factory is present (so fallback is skipped) but yields no nodes.
+  slotBlock(child, anchor, () => null, () => doc.createTextNode("fb"));
+  assert.strictEqual(shape(host), "|", "no content, and fallback suppressed by presence of factory");
+});
+
+// --- onDestroy ordering: slot cleanup runs alongside other child hooks -------
+
+await test("slot cleanup and a separate child onDestroy both fire once", () => {
+  const child = createContext(null);
+  const host = doc.createElement("div");
+  const anchor = anchorAppend(host);
+  const order = [];
+  onDestroy(child, () => order.push("child-hook"));
+  slotBlock(child, anchor, (sp, onCleanup) => {
+    onCleanup(() => order.push("slot-cleanup"));
+    return doc.createTextNode("x");
+  }, null);
+  runDestroy(child);
+  runDestroy(child); // idempotent
+  assert.ok(order.includes("child-hook"));
+  assert.ok(order.includes("slot-cleanup"));
+  assert.strictEqual(order.length, 2, "each hook fired exactly once");
+});
+
+console.log("\nslots.runtime.test.mjs: " + passed + " passed.");


### PR DESCRIPTION
## Summary

Mass-expansion of the JS runtime control-flow / blocks test suite — **6 new test files, 266 assertions** (all edge-focused). No existing tests, `src/*.mjs`, `index.mjs`, `package.json`, or Rust touched — new test files only, auto-globbed by `run-all.mjs`. Uses the existing `dom-shim.mjs` (or an inline fake DOM matching it) throughout.

### New files

- **`for-diff.reorder.test.mjs`** (30) — keyed LIS reconciler (`src/for_diff.mjs`) via a validating fake host. append / prepend / insert-middle / remove-middle / remove-all / swap-adjacent / reverse / move-far / shuffle / interleaved insert+remove+move / single-item / empty↔N / replace-all-keys, number-vs-string keys, duplicate-key index fallback + recovery, large-list (120 reverse, 150 shuffle, 100+50 append) correctness, and the `longestIncreasingSubsequence` primitive. **Asserts both final key order AND node-identity preservation** for unmoved/kept items.
- **`blocks.if.edge.test.mjs`** (11) — `ifBlock`/`ifChain`: elseif cascades, no-match (`-1`), rapid synchronous toggles (coalescing), nested if-in-if teardown, multi-root branch group swap, branch-switch bind unregistration (leak-free, counted via live-bind census), `update()` sync path, and scope homing under `dropScope`.
- **`blocks.for.nested.test.mjs`** (8) — `:for`-in-`:for`, `:if`-in-`:for` item, per-item scope teardown on removal (nested binds die), item patch driving nested blocks via `runScope`, and the compiled **html/wire bulk-render initial path** vs the keyed **reconcile update path** (verifies reorder reuses `<li>` nodes without re-wiring; patch closures update in place).
- **`dom.norm.test.mjs`** (31, +1 skip) — `normClass`/`normStyle`/`setClass`/`setStyle` over string | object | array | nested-array, falsy filtering, camelCase→kebab, custom `--props`, static+dynamic merge, null/undefined/number values; plus `component`/`fragment`/`refs`/`on`.
- **`dom.mountchild.test.mjs`** (8) — `mountChild`: mount/unmount, multi-root fragment child (all nodes travel together), `onDestroy` fires exactly once (idempotent), parent link + `_children` registration/de-registration, `onMount` live-insertion vs pending-until-`attach`, `setProp` reactive-prop bridge, recursive grandchild destroy.
- **`slots.runtime.test.mjs`** (10) — default-over-fallback, named routing (one filled + one fallback), scoped-props snapshot (`slotPropsOf` read once, object identity preserved), multiple `onCleanup` callbacks, `slotContent` parent-owned scope teardown on child unmount, `slotContent` homed in a `:for` item scope dropping with the item, fallback child-scope teardown, and cleanup ordering alongside a separate child `onDestroy`.

## Known divergence (deferred — not fixed here)

`dom.norm.test.mjs` **skips** one Vue-parity assertion: a **falsy _number_ (`0` / `NaN`) inside a `:class` array is not dropped** — `normClass(0)` stringifies to `"0"`, so it leaks in as a `"0"` class token. The array branch of `normClass` only skips entries whose *normalized* result is `""`, and `normClass(0) === "0"`. A companion test **pins the current behavior** so any future fix flips it as a signal. The fix is a one-line guard (`if (!v) continue;`) in the array loop of `src/dom.mjs`, but that edit is a `src` change and out of scope for this test-only PR — hence `.skip` + this note.

## Quality gate

`node packages/lunas/test/run-all.mjs` — **all 23 test files pass** (17 pre-existing + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)