### PR TITLE
docs: built-ins (teleport/transition/keep-alive/suspense) + scaling (routing/state/css/ssr/tooling)

### DIFF
--- a/docs/built-ins/keep-alive.md
+++ b/docs/built-ins/keep-alive.md
@@ -1,0 +1,141 @@
+# Keep-alive
+
+Keep-alive **caches component instances** instead of destroying them when they're
+swapped out. When you switch away from a component wrapped in keep-alive, its DOM
+is detached but its context, reactive state, and subtree stay alive. When you
+switch back, the cached instance is **re-attached with no rebuild** — preserving
+scroll position, form input, and every reactive variable.
+
+The natural targets are a dynamic component (`:is`) or a routed
+[outlet](../scaling/routing.md): a set of interchangeable panes where rebuilding
+from scratch on every switch would be wasteful and would throw away UI state.
+
+## Example
+
+```html
+<script>
+  let tab = "editor"; // "editor" | "preview" | "settings"
+</script>
+
+<nav>
+  <button @click="tab = 'editor'">Editor</button>
+  <button @click="tab = 'preview'">Preview</button>
+  <button @click="tab = 'settings'">Settings</button>
+</nav>
+
+<keep-alive>
+  <component :is="tab" />
+</keep-alive>
+```
+
+Type into a field on the **Editor** tab, switch to **Preview**, switch back —
+your text is still there, because the Editor instance was *deactivated*, not
+destroyed.
+
+## Cache policy — LRU with `max`
+
+Keep-alive is a **keyed LRU cache**. Each distinct key (here, the tab name) maps
+to one cached instance. With an optional `max` you cap how many instances are
+kept:
+
+```html
+<keep-alive max="2">
+  <component :is="tab" />
+</keep-alive>
+```
+
+- Cached instances are ordered by recency of use (most-recently-shown last).
+- When the cache overflows `max`, the **least-recently-used** instance is
+  **evicted** — and that's the only path (besides tearing the whole keep-alive
+  down) that actually destroys an instance and fires its `onDestroy`.
+- Deactivation (switching away without overflow) **never** destroys.
+
+Omit `max` for an unbounded cache (every instance ever shown is kept for the
+keep-alive's lifetime).
+
+## Lifecycle hooks
+
+Because a kept instance is deactivated rather than destroyed, it gets two extra
+lifecycle hooks in addition to the usual `onMount` / `onDestroy`:
+
+```html
+<script>
+  import { onActivated, onDeactivated } from "lunas";
+
+  onActivated(() => {
+    // fires when this instance is (re)attached from the cache
+    startPolling();
+  });
+
+  onDeactivated(() => {
+    // fires when this instance is detached but kept alive
+    stopPolling();
+  });
+</script>
+```
+
+The lifecycle mapping:
+
+| Event | Hook fired |
+|---|---|
+| First mount | `onMount` (+ `onActivated`) |
+| Switch back to a cached instance | `onActivated` |
+| Switch away (kept in cache) | `onDeactivated` |
+| LRU eviction / keep-alive destroy | `onDestroy` |
+
+A fresh instance is considered *activated* on its first show too, so
+`onActivated` fires on first mount as well as on every reactivation. Use
+`onActivated` / `onDeactivated` to pause and resume work (timers, subscriptions,
+media) that shouldn't run while the pane is hidden.
+
+## Node identity is preserved
+
+Reactivation re-inserts the **same DOM nodes** that were detached — the exact
+node objects, not clones. That's what preserves imperative DOM state (focus,
+scroll offset, `<video>` playback position, uncontrolled input values) that
+reactive state alone wouldn't capture.
+
+## How it works
+
+The compiler drives a keep-alive controller from the runtime's
+[`keepAlive`](../api/runtime.md):
+
+```js
+const ka = keepAlive({ max: 2 });
+// show the instance for `key`, mounting fresh or activating a cache hit,
+// and deactivating whichever instance was previously shown:
+ka.show(c, anchor, key, factory, props);
+```
+
+`show(c, anchor, key, factory, props)`:
+
+- deactivates the outgoing instance (detach + `onDeactivated`),
+- on a **cache hit**, moves the entry to most-recently-used and re-attaches it
+  (`onActivated`, no rebuild),
+- on a **miss**, mounts a fresh instance via `mountChild`, then trims the cache
+  to `max`.
+
+`ka.has(key)` and `ka.size` are available for tests/introspection; `ka.destroy()`
+evicts and destroys every cached instance.
+
+## Gotchas
+
+- **State is preserved across switches — that's the point, but be intentional.**
+  If a pane should reset each time it's shown, either don't keep-alive it or
+  reset its state in `onActivated`.
+- **`max` eviction is silent from the UI's perspective** but fires `onDestroy` on
+  the victim. If an evicted instance held a subscription that `onDeactivated`
+  paused, make sure `onDestroy` fully cleans it up.
+- **Keys must be stable and distinguishing.** Two panes sharing a key share one
+  cached instance. With `:is`, the component name is the natural key.
+- Keep-alive caches by key within one keep-alive block; it does not share
+  instances across different keep-alive blocks.
+
+## See also
+
+- [Suspense](./suspense.md) — pair keep-alive with async panes.
+- [Routing](../scaling/routing.md) — keep-alive a router outlet to preserve page
+  state across navigation.
+- [Transition](./transition.md) — note that kept instances *activate/deactivate*
+  rather than enter/leave.
+- [Runtime API](../api/runtime.md) — the `keepAlive` controller.

--- a/docs/built-ins/suspense.md
+++ b/docs/built-ins/suspense.md
@@ -1,0 +1,152 @@
+# Suspense
+
+A **suspense boundary** shows a fallback while asynchronous children inside it
+are still loading, then reveals the real content once every pending async
+dependency has resolved. It's the coordination point for
+[async / lazy components](#async-components) — instead of each lazy component
+managing its own spinner, one boundary waits for the whole group.
+
+## Example
+
+```html
+<script>
+  import { asyncComponent } from "lunas";
+
+  const Profile = asyncComponent(() => import("./Profile.lunas"));
+  const Feed    = asyncComponent(() => import("./Feed.lunas"));
+</script>
+
+<Suspense>
+  <template #default>
+    <Profile />
+    <Feed />
+  </template>
+
+  <template #fallback>
+    <p>Loading…</p>
+  </template>
+</Suspense>
+```
+
+Both `Profile` and `Feed` begin loading immediately. The `Loading…` fallback is
+shown until **both** modules have resolved and mounted, then the fallback is torn
+down and the real content revealed in one swap.
+
+## How the boundary coordinates
+
+The compiler emits the runtime's
+[`suspenseBlock`](../api/runtime.md):
+
+```js
+suspenseBlock(c, anchor, contentFactory, fallbackFactory);
+```
+
+- `contentFactory(c)` builds the content **immediately** — so async children
+  start loading right away — but the content is kept hidden while anything is
+  pending.
+- Each async component under the boundary registers itself with the **nearest**
+  boundary (published on the component context as `c._suspense` during the
+  content build). It bumps the boundary's pending counter while its module loads
+  and settles it once the module resolves (or fails).
+- `fallbackFactory()` builds the fallback shown while the pending counter is
+  above zero.
+- When the counter reaches zero, the fallback is removed and the content
+  revealed.
+
+### No fallback flash on synchronous content
+
+The reveal is batched via the runtime's `afterFlush`. If every async dependency
+was already cached (so the subtree resolves synchronously during the build), the
+pending counter hits zero before the first paint and the content is revealed
+**directly — the fallback never mounts**. You only see the fallback when there is
+genuinely async work to wait for.
+
+## Nested boundaries
+
+Boundaries nest, and each owns exactly its own subtree. An inner
+`<Suspense>` saves the enclosing boundary, installs itself while building its
+content, then restores the parent — so an async dependency always registers with
+its **nearest** boundary and never leaks a pending count upward.
+
+```html
+<Suspense>
+  <template #fallback><p>Loading page…</p></template>
+
+  <Header />
+
+  <!-- The Feed's own loading is scoped to this inner boundary; the outer
+       boundary reveals as soon as Header (and this inner boundary's own
+       placeholder) are ready. -->
+  <Suspense>
+    <template #fallback><p>Loading feed…</p></template>
+    <Feed />
+  </Suspense>
+</Suspense>
+```
+
+## Async components
+
+`asyncComponent(loader, opts)` turns a dynamic-import loader into a mountable
+component factory:
+
+```js
+import { asyncComponent } from "lunas";
+
+const Heavy = asyncComponent(() => import("./Heavy.lunas"), {
+  loading: Spinner,   // shown while pending — only after `delay` ms
+  error: ErrorCard,   // shown on rejection or timeout (gets `{ error }` in props)
+  delay: 200,         // ms before showing `loading` (default 200; avoids a flash)
+  timeout: 10000,     // ms after which a still-pending load is treated as an error
+});
+```
+
+- The loader can return a dynamic `import()`, an ES-module namespace
+  (`{ default }`), or a bare factory. The default export or bare factory is
+  unwrapped automatically.
+- The resolved module is **cached** after the first load, so later mounts build
+  **synchronously** with no placeholder.
+- `loading` is shown only after `delay` ms, so a fast load never flashes a
+  spinner. `error` is shown on rejection or after `timeout`.
+
+Async components work **with or without** a surrounding `<Suspense>`:
+
+- **Inside** a boundary, they register their pending state with it and the
+  boundary's fallback covers them collectively.
+- **Standalone**, each one shows its own `loading` / `error` components per its
+  own `delay` / `timeout`.
+
+Mount async children through the runtime's `mountAsyncChild` (the compiler emits
+this) — it threads the component context so the child can find the nearest
+boundary, and its `unmount()` **cancels any in-flight load** so a late resolution
+writes no DOM.
+
+## Unmount safety
+
+Every async mount owns a live token. Unmounting (including tearing down a
+boundary that's still showing its fallback) flips that token, so a loader that
+resolves *afterwards* writes nothing and settles no boundary. Destroying a
+`suspenseBlock` cancels any pending async children in its (possibly still-hidden)
+content.
+
+## Gotchas
+
+- **Content is built eagerly, shown lazily.** Async children start loading the
+  moment the boundary is created, even though you don't see them until they're
+  ready — that's what lets the boundary wait for the whole group in parallel.
+- **`delay` on a standalone async component defaults to 200 ms.** Inside a
+  suspense boundary the boundary's fallback is what you see, so the child's own
+  `loading` typically isn't needed.
+- **A rejected async component still settles its boundary.** Suspense reveals
+  content once everything *settles* (resolved or errored); it does not block
+  forever on a failed load. Handle the failure with the async component's
+  `error` option.
+- **Nested boundaries scope their waiting.** A slow child under an inner boundary
+  won't hold up an outer boundary that has nothing else pending.
+
+## See also
+
+- [Keep-alive](./keep-alive.md) — cache resolved panes so they don't reload.
+- [Routing](../scaling/routing.md) — lazy-load route components with
+  `asyncComponent`.
+- [Runtime API](../api/runtime.md) — `suspenseBlock`, `asyncComponent`,
+  `mountAsyncChild`.

--- a/docs/built-ins/teleport.md
+++ b/docs/built-ins/teleport.md
@@ -1,0 +1,115 @@
+# Teleport
+
+`<teleport>` renders a chunk of a component's template into a **different place in
+the DOM** — typically outside the component's own subtree — while keeping it part
+of the component logically. Its reactivity, event handlers, and teardown all
+still belong to the component that declared it.
+
+The classic use case is a modal, toast, or tooltip: you want the markup to live
+next to the component that owns its state, but you need it mounted on
+`document.body` (or some other container) so it escapes `overflow: hidden`,
+`transform`, or `z-index` stacking contexts of its ancestors.
+
+## Example
+
+```html
+<script>
+  let open = false;
+</script>
+
+<button @click="open = true">Open dialog</button>
+
+<teleport to="body">
+  <div :if="open" class="modal-backdrop" @click="open = false">
+    <div class="modal" @click="/* stop */">
+      <h2>Hello from a teleport</h2>
+      <button @click="open = false">Close</button>
+    </div>
+  </div>
+</teleport>
+```
+
+Even though the `.modal-backdrop` markup is written inside the component, at
+runtime it is appended into `<body>`. The `open` variable, the `@click`
+handlers, and the `:if` block all keep working exactly as if the content were
+inline.
+
+## `to` — the target
+
+`to` resolves to the mount target. It accepts either:
+
+- a **CSS selector string** (`to="body"`, `to="#overlay-root"`,
+  `to=".portals"`) — resolved with `document.querySelector(...)`; the **first**
+  match wins, or
+- an **Element** (a `:to="someEl"` binding whose value is a live DOM node).
+
+```html
+<!-- selector string -->
+<teleport to="#toast-root"> … </teleport>
+
+<!-- an element reference -->
+<teleport :to="containerEl"> … </teleport>
+```
+
+If the target cannot be resolved (no element matches the selector, or the value
+is `null`), the content is simply **not inserted** — nothing is thrown. The
+component still mounts fine; the teleported content just has nowhere to go.
+
+## How it works
+
+Under the hood the compiler emits a call to the runtime's
+[`teleportBlock`](../api/runtime.md):
+
+```js
+teleportBlock(c, anchor, targetOf, build);
+```
+
+- `build()` produces the content nodes (a single root or a multi-root group),
+  wired against **this** component's reactive context.
+- `targetOf()` resolves the target (selector string → `querySelector`, or an
+  Element).
+- The content is `appendChild`-ed into the target instead of inserted inline at
+  the anchor.
+- A permanent empty **text anchor** still marks the original inline slot, so the
+  surrounding layout is undisturbed and teardown order stays deterministic.
+
+The teleported content's reactive bindings are collected into a **scope** homed
+where the block was created. That means destroying the block (or the owning
+component) tears down every binding inside the teleported content — **no leaks**,
+exactly like an [`:if`](../guide/control-flow.md) branch.
+
+## Teardown
+
+When the owning component unmounts (or the surrounding block is removed), the
+teleport's `destroy()`:
+
+1. removes every teleported node from the target, and
+2. drops the content's reactive scope, so no late writes land after unmount.
+
+You never manage this yourself — the runtime cleans up teleported DOM even
+though it lives outside the component's own subtree.
+
+## Gotchas
+
+- **The target must already exist** when the teleport mounts. A selector like
+  `to="#overlay-root"` only works if that element is in the document at mount
+  time. For app-level portals, put the container in your `index.html`.
+- **Selector resolution is one-shot at mount.** The runtime resolves the target
+  when the content is built. If you need the target to change reactively, drive
+  it with an element binding (`:to`) rather than expecting a string selector to
+  re-query.
+- **Styling still comes from where the markup is written**, not where it lands.
+  Component-[scoped CSS](../scaling/scoped-css.md) attributes are stamped based
+  on the declaring component, so scoped rules keep applying to teleported
+  content.
+- Content that is conditionally rendered inside a teleport (like the `:if` in the
+  example) toggles normally — the teleport is the *destination*, the `:if` still
+  controls *whether* anything is there.
+
+## See also
+
+- [Transition](./transition.md) — animate a teleported modal's enter/leave.
+- [Keep-alive](./keep-alive.md) and [Suspense](./suspense.md) — the other
+  control-flow built-ins.
+- [Control flow](../guide/control-flow.md) — `:if` / `:for` basics used above.
+- [Runtime API](../api/runtime.md) — the `teleportBlock` primitive.

--- a/docs/built-ins/transition.md
+++ b/docs/built-ins/transition.md
@@ -1,0 +1,136 @@
+# Transitions
+
+Lunas animates the **enter** and **leave** of control-flow content (an `:if`
+branch, a `:for` item, a mounted child) by toggling a well-known sequence of CSS
+classes around the insert/remove. Your CSS drives the actual animation; the
+runtime just adds and removes classes and waits for `transitionend`.
+
+This is the Vue-style transition model: name a transition `n`, write CSS for the
+`n-enter-*` / `n-leave-*` classes, and Lunas choreographs them.
+
+## The class sequence
+
+For a transition named `n`, an element gets, on **enter**:
+
+| Phase | Classes |
+|---|---|
+| frame 0 (before paint) | `+ n-enter-from`  `+ n-enter-active` |
+| frame 1 (next frame) | `− n-enter-from`  `+ n-enter-to` |
+| transitionend / timeout | `− n-enter-active`  `− n-enter-to` |
+
+and symmetrically on **leave** (`n-leave-from`, `n-leave-active`,
+`n-leave-to`) — with the node **removed only after the leave transition
+finishes**.
+
+So a full fade looks like:
+
+```html
+<script>
+  let show = true;
+</script>
+
+<button @click="show = !show">Toggle</button>
+
+<div :if="show" class="box" c-transition="fade">
+  Hello
+</div>
+
+<style>
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 200ms ease;
+  }
+  .fade-enter-from,
+  .fade-leave-to {
+    opacity: 0;
+  }
+  /* fade-enter-to and fade-leave-from are the resting state (opacity: 1),
+     so they need no rule here. */
+</style>
+```
+
+- `fade-enter-from` starts the element invisible; frame 1 swaps to
+  `fade-enter-to` (the resting state), and the `fade-enter-active` transition
+  animates the change.
+- On leave the element is held in the DOM while `fade-leave-active` animates it
+  back to `fade-leave-to` (invisible), then removed.
+
+## Naming
+
+The transition **base name** defaults to `v` if you don't provide one — so
+`v-enter-from`, `v-leave-active`, etc. Give it a name (`fade` above) to run
+several distinct transitions in one app.
+
+## When enter/leave completes
+
+The runtime finishes a phase on the element's `transitionend` event. Because
+some elements never fire `transitionend` (`display: none`, a zero-duration
+transition, or an interrupted one), a **timeout fallback** is always armed so
+teardown can never hang. You can set that fallback explicitly:
+
+- The `duration` option is the fallback timeout in milliseconds (`0` → next
+  macrotask). It is a *safety net*, not the animation length — the animation
+  length still comes from your CSS `transition` property.
+
+`transitionend` events that bubble up from **child** elements are ignored — only
+the transitioning element's own `transitionend` counts. This keeps a transition
+on a container from finishing early because an inner element's transition fired.
+
+## Degradation outside the browser
+
+There is no CSS engine outside a browser (and the test DOM has none), so when
+`requestAnimationFrame` is unavailable the transition **degrades to an immediate
+insert/remove**. Importantly, the class *sequence still runs synchronously* — the
+classes are added and removed in order and completion fires right away — so the
+logic stays observable and testable. In a real browser the frames and
+`transitionend` (with the `duration` timeout fallback) drive real timing.
+
+This means:
+
+- SSR / non-DOM environments never hang waiting for an animation.
+- Transitions are a pure enhancement: if the environment can't animate, content
+  still appears and disappears correctly.
+
+## How it works
+
+The compiler wraps a block's own insert/remove closures with the runtime's
+[`withTransition`](../api/runtime.md):
+
+```js
+const t = withTransition({ name: "fade", duration: 200 });
+// enter: insert the nodes, then choreograph enter classes on each root
+t.enter(nodes, insert);
+// leave: choreograph leave classes, then remove() once every node's leave finishes
+t.leave(nodes, remove);
+```
+
+`withTransition` returns `{ enter, leave }` that compose with the block's own
+mount/unmount. `runPhase(el, base, phase, opts, done)` is the lower-level
+primitive that runs one enter/leave choreography on a single element — useful if
+you're wiring transitions by hand.
+
+## Gotchas
+
+- **Leave is asynchronous.** The node lingers in the DOM through the whole leave
+  animation, then is removed. Don't assume it's gone the instant `:if` flips
+  false.
+- **Multi-root content:** every root node gets the class sequence; a leave
+  completes only when *all* roots have finished, then all are removed together.
+- **`duration` is a fallback, not the source of truth.** Your CSS `transition`
+  duration is what animates. Set `duration` to something ≥ your CSS duration so
+  the fallback never cuts an animation short.
+- **The `-active` class is where you put the `transition` property.** The
+  `-from`/`-to` classes set start/end states; `-active` defines *how* to move
+  between them.
+- Transitions attach to control-flow blocks (`:if`, `:for`, mounted children),
+  not to arbitrary always-present elements — there's nothing to enter or leave
+  if the element is never inserted or removed.
+
+## See also
+
+- [Control flow](../guide/control-flow.md) — `:if` / `:for` blocks that
+  transitions wrap.
+- [Teleport](./teleport.md) — animate a teleported modal.
+- [Keep-alive](./keep-alive.md) — cached instances that activate/deactivate
+  instead of enter/leave.
+- [Runtime API](../api/runtime.md) — `withTransition` / `runPhase`.

--- a/docs/scaling/routing.md
+++ b/docs/scaling/routing.md
@@ -1,0 +1,223 @@
+# Routing
+
+Lunas ships a client-side router as part of its runtime. A router is
+conceptually a **store whose one reactive field is the current route** — so a
+component adopts the current route the same way it adopts any other
+[store](./state-management.md) field, and plain JS (tests, devtools, the outlet)
+can subscribe without a component context.
+
+## Defining a router
+
+```js
+import { createRouter } from "lunas";
+import Home from "./pages/Home.lunas";
+import User from "./pages/User.lunas";
+import NotFound from "./pages/NotFound.lunas";
+
+export const router = createRouter([
+  { path: "/",            component: Home },
+  { path: "/users/:id",   component: User },
+  { path: "*",            component: NotFound }, // catch-all → 404
+]);
+```
+
+A route is `{ path, component, ...extra }`. Any extra keys (a `name`, `meta`,
+etc.) ride along on the route definition and are available on the matched route.
+
+## Route matching
+
+`createRouter` pre-compiles each path into segments. A segment is one of:
+
+| Segment | Meaning | Example |
+|---|---|---|
+| **static** | must equal the incoming segment | `/users` |
+| **param** (`:name`) | captures exactly one segment | `/users/:id` |
+| **catch-all** (`*` or `*name`) | captures the rest (0+ segments) | `/files/*path` |
+
+### Precedence
+
+When several routes match, they're **ranked**: static beats param beats
+catch-all, and earlier segments dominate later ones. Ties fall back to
+declaration order (first wins). So given:
+
+```js
+{ path: "/users/new" },   // static — wins for /users/new
+{ path: "/users/:id" },   // param  — wins for /users/42
+{ path: "*" },            // catch-all — 404 for everything else
+```
+
+`/users/new` matches the static route even though `/users/:id` also *could*
+match, because static outranks param.
+
+- A catch-all captures every remaining segment as a single `/`-joined string
+  under its name (default `rest`): `*path` matching `/a/b/c` gives
+  `params.path === "a/b/c"`.
+- Trailing slashes are normalized away: `/a/b/` and `/a/b` match identically.
+
+### The reactive route object
+
+The current route is `{ path, params, query, matched }`:
+
+- `path` — normalized pathname (leading slash, no trailing slash, query
+  stripped).
+- `params` — captured `:param` / `*catch` values.
+- `query` — the parsed `?a=1&b=2` string as a plain object (last value wins for
+  repeated keys; `+` decodes to space).
+- `matched` — the matched route definition, or `null` on a total miss (declare a
+  `*` route to always have a 404 slot).
+
+## Navigating
+
+```js
+router.push("/users/42");         // navigate, push a new history entry
+router.push("/search?q=lunas");   // query strings are parsed into route.query
+router.replace("/login");         // navigate, replace the current entry
+router.back();                    // go back one entry (like the browser button)
+router.forward();                 // go forward one entry
+```
+
+`push` and `replace` return a `Promise<boolean>` that resolves to whether the
+navigation **committed** (a guard may cancel it — see below). `back` / `forward`
+are guard-free, mirroring the browser buttons.
+
+## Navigation guards
+
+`beforeEach(to, from)` runs before every `push`/`replace`. Return `false` (sync
+or via a resolved Promise) to **cancel** the navigation; anything else commits
+it:
+
+```js
+export const router = createRouter(routes, {
+  beforeEach(to, from) {
+    if (to.matched?.meta?.requiresAuth && !isLoggedIn()) {
+      router.replace("/login");
+      return false; // cancel the original navigation
+    }
+    return true;
+  },
+});
+```
+
+The guard may be async (return a `Promise<boolean>`) — useful for awaiting an
+auth check. When a guard cancels, the store is left untouched (no route change).
+
+> Guards run on `push`/`replace` only, not on `back`/`forward` — browser
+> back/forward land already committed to history and are resolved into the store
+> directly.
+
+## Rendering the matched route: `routerOutlet`
+
+An **outlet** mounts the matched route's component and swaps it whenever
+navigation changes *which route matches*:
+
+```html
+<!-- app template -->
+<nav> … </nav>
+<router-outlet />
+```
+
+which compiles to a `routerOutlet(c, anchor, router)` call. Key behavior:
+
+- The matched route's captured **params are passed as props** to the component.
+  So `/users/:id` mounts `User` with `{ id }`.
+- The outlet **re-mounts only when the matched route definition changes**, not on
+  every param tweak. Navigating `/users/1 → /users/2` keeps the same `User`
+  instance mounted; its own props reactivity handles the `id` change. Navigating
+  `/users/2 → /` swaps to `Home`.
+- Pass `options.props(route)` to override/augment the prop mapping (e.g. to
+  inject the router itself or the parsed query).
+
+## Links: `routerLink`
+
+`<a>` links wire up to client-side navigation instead of a full page load:
+
+```html
+<a :href="/users/42">View user</a>
+```
+
+compiles to `routerLink(aEl, router, "/users/42")` alongside setting the static
+`href` (kept for SSR / no-JS / middle-click). On a plain left click it calls
+`preventDefault()` + `router.push(path)`. **Modified clicks**
+(ctrl/meta/shift/alt) and non-primary buttons fall through to the browser, so
+"open in new tab" still works. Pass `{ replace: true }` to use `replace` instead
+of `push`.
+
+## Reading the current route in a component
+
+A component that reads `router.current` in its template or handlers adopts the
+route at a reactive index — the compiler emits `router.adopt(c, i)` (sugar over
+`useStore(c, i, router.store, "route")`). From then on, route changes re-render
+the parts of that component that read the route:
+
+```html
+<script>
+  import { router } from "./router.mjs";
+</script>
+
+<p>Current path: {router.current.path}</p>
+<p :if="router.current.params.id">User #{router.current.params.id}</p>
+```
+
+Outside a component (plain JS — tests, devtools), subscribe directly:
+
+```js
+const stop = router.subscribe((route) => {
+  console.log("navigated to", route.path);
+});
+// …later
+stop();
+```
+
+## `@useRouting` / `@useAutoRouting`
+
+The router runtime is the codegen target for the `@useRouting` /
+`@useAutoRouting` directives. `@useAutoRouting` expands a placeholder into an
+outlet wired to the app router (the `<router-outlet/>` shape above); `@useRouting`
+gives you the router instance to drive manually. Both compile down to
+`createRouter` + `routerOutlet` + `router.adopt`, so everything documented here
+applies regardless of which directive you use.
+
+## Testing with `memoryHistory`
+
+History access is behind an injectable adapter, so you can drive a router in a
+test (or any non-browser environment) with an in-memory stand-in:
+
+```js
+import { createRouter, memoryHistory } from "lunas";
+
+const router = createRouter(routes, {
+  history: memoryHistory("/users/1"),
+});
+
+await router.push("/users/2");
+router.current.params.id; // "2"
+router.back();            // fires the store update, like popstate
+```
+
+`memoryHistory(initial)` keeps its own back-stack. `back()`/`forward()` invoke
+the router's resolve (the popstate analogue); `push`/`replace` do **not** fire
+the listener (mirroring the browser, where `pushState` emits no `popstate` — the
+router resolves after its own programmatic navigation). The browser default is
+`historyAdapter(window)`, used automatically when you omit `options.history`.
+
+## Gotchas
+
+- **`route.matched` is a proxy view**, not `===` the original route object (it's
+  read through the store's deep-mutation proxy). Compare by a stable key like
+  `route.matched.path`, not by identity — this is exactly how the outlet decides
+  whether to re-mount.
+- **Params are always strings.** `/users/:id` gives `params.id === "42"`, not the
+  number `42`. Parse it yourself if you need a number.
+- **Declare a `*` route** if you want a real 404 page; without one, an unmatched
+  path leaves `matched === null` and the outlet renders nothing.
+- **Guards don't run on back/forward** — those follow browser history directly.
+- Call `router.destroy()` to detach the history listener on teardown / HMR.
+
+## See also
+
+- [State management](./state-management.md) — the store the router is built on.
+- [Keep-alive](../built-ins/keep-alive.md) — wrap the outlet to preserve page
+  state across navigation.
+- [Suspense](../built-ins/suspense.md) — lazy-load route components.
+- [Runtime API](../api/runtime.md) — `createRouter`, `routerOutlet`,
+  `routerLink`, `memoryHistory`.

--- a/docs/scaling/scoped-css.md
+++ b/docs/scaling/scoped-css.md
@@ -1,0 +1,156 @@
+# Scoped CSS
+
+Styles in a component's `<style>` block are **scoped to that component** — they
+apply only to the elements that component renders, not to its children or the
+rest of the page. This is the Vue-SFC model, implemented by the `lunas_css`
+crate.
+
+> **Status — scoping engine complete, codegen wiring pending.** The scoping
+> transform (`lunas_css`) is done and fully tested. Wiring it into the compiler's
+> code generation (stamping the scope attribute onto rendered elements and
+> injecting the rewritten `<style>`) is tracked as a **later integration task** in
+> the crate itself. Treat the syntax below as the designed-for contract; verify
+> against your compiler version before relying on scoped output. This page
+> documents the real transform and the intended integration.
+
+## The idea
+
+```html
+<template>
+  <button class="btn">Save</button>
+</template>
+
+<style>
+  .btn {
+    color: white;
+    background: rebeccapurple;
+  }
+</style>
+```
+
+The `.btn` rule only styles *this* component's button, not a `.btn` elsewhere in
+the app. That isolation is achieved by **attribute stamping**, not by hashed
+class names.
+
+## How scoping works — attribute stamping
+
+Each component *type* gets a unique scope attribute, computed once and stable
+across builds:
+
+```rust
+// lunas_css public API
+scope_id(component_source) -> "data-lunas-<fnv1a hex>"
+scope_css(css, scope_attr) -> (rewritten_css, diagnostics)
+```
+
+Two things then happen:
+
+1. **DOM side:** codegen stamps the scope attribute (as a value-less attribute)
+   on the component's root element and **every descendant element it renders**.
+   Elements rendered by *child* components do **not** get the parent's attribute
+   — which is what makes `:deep()` meaningful.
+2. **CSS side:** every compound selector in the `<style>` block gains
+   `[scope_attr]`, and the rewritten CSS is injected in a `<style>` tag once per
+   component type (first mount inserts it; a set of injected ids prevents
+   duplicates).
+
+So the example above becomes, at runtime, roughly:
+
+```html
+<button class="btn" data-lunas-1a2b3c>Save</button>
+```
+```css
+.btn[data-lunas-1a2b3c] { color: white; background: rebeccapurple; }
+```
+
+The attribute is stable across builds, so **SSR output and client hydration
+agree** on the same scope id.
+
+## Selector rewriting
+
+Every compound selector in every rule is scoped:
+
+| You write | Becomes (`scope = data-lunas-x`) |
+|---|---|
+| `.btn:hover` | `.btn[data-lunas-x]:hover` |
+| `ul li` | `ul[data-lunas-x] li[data-lunas-x]` |
+| `a > b` | `a[data-lunas-x] > b[data-lunas-x]` |
+| `::before` | `[data-lunas-x]::before` |
+
+## Escaping the scope: `:deep()` and `:global()`
+
+Sometimes you need to style something the scope wouldn't reach.
+
+### `:deep()` — pierce into child components
+
+Child-rendered elements don't carry the parent's scope attribute, so a normal
+scoped rule can't reach them. `:deep(...)` styles from the scoped side up to the
+boundary, then leaves the inner part unscoped:
+
+```css
+/* style a .title rendered by a child component inside my .card */
+.card :deep(.title) { font-weight: bold; }
+```
+
+becomes `.card[data-lunas-x] .title` — the `.card` is scoped to this component,
+but `.title` matches regardless of which component rendered it.
+
+### `:global()` — opt out entirely
+
+`:global(...)` unwraps to an unscoped selector:
+
+```css
+:global(.modal-open) { overflow: hidden; }
+```
+
+becomes `.modal-open` — a truly global rule.
+
+> **Limitation:** a top-level `:global(...)` anywhere in a selector makes the
+> **entire** selector global (each wrapper is unwrapped, nothing is scoped).
+> Lunas does not support the CSS-Modules-style mixed form where only part of one
+> selector is global.
+
+## At-rules
+
+- `@media`, `@supports`, `@layer`, `@container`, `@scope` — recursed into; the
+  rules inside them are scoped normally.
+- **`@keyframes name`** (including vendor-prefixed) — **renamed** to `name-<hash>`,
+  and `animation` / `animation-name` declarations referencing it are rewritten to
+  match. Forward references work (a pre-pass collects names first), so you can
+  reference an animation before its `@keyframes` block. This keeps one
+  component's animation from colliding with another's identically-named one.
+- `@font-face`, `@page`, `@import`, `@charset`, and unknown at-rules — passed
+  through **untouched**.
+
+## Robustness
+
+`lunas_css` is a hand-written tokenizer and structural walker with **no external
+CSS parser dependency**, builds on `wasm32-unknown-unknown`, and **never panics**:
+a structurally unparseable region is emitted **verbatim** with a warning
+`Diagnostic` rather than throwing. It is not a CSS validator — declarations are
+not grammar-checked, and CSS nesting (`&`) is passed through rather than scoped
+specially. Output preserves your original formatting (it's a string rewrite, not
+an AST re-serialize).
+
+## Gotchas
+
+- **Scoping is per component *type*, not per instance.** Every instance of a
+  component shares the same scope attribute and one injected `<style>` tag.
+- **Child elements aren't reached by default** — use `:deep()` to style into
+  child components on purpose.
+- **`:global` is all-or-nothing per selector** (see the limitation above). Split
+  a mixed rule into a scoped rule and a separate `:global` rule.
+- **`@keyframes` names are rewritten**, so referencing an animation by its raw
+  name from *outside* the component (or from unscoped JS) won't find it — the
+  runtime name is `name-<hash>`.
+- **Diagnostics carry ranges relative to the style block**; the compiler rebases
+  them onto the `.lunas` file, so a CSS warning points at the right line in your
+  source.
+
+## See also
+
+- [Teleport](../built-ins/teleport.md) — teleported content keeps the declaring
+  component's scope attributes, so scoped rules still apply.
+- [Tooling](./tooling.md) — how the Vite plugin compiles `.lunas` files.
+- `crates/lunas_css/README.md` — the transform's authoritative reference and
+  integration contract.

--- a/docs/scaling/ssr.md
+++ b/docs/scaling/ssr.md
@@ -1,0 +1,95 @@
+# Server-side rendering (SSR) & hydration
+
+> **Status — PLANNED / DEFERRED.** SSR + client hydration is a designed-for but
+> **not-yet-implemented** codegen mode. It is tracked as `a-ssr` in the roadmap
+> with status **`deferred`**. There is **no SSR API to call today.** This page
+> documents the intended approach so you can understand where Lunas is headed and
+> why the current architecture is built to make it a drop-in addition — not to
+> describe something you can use now.
+
+## Why Lunas is "SSR-ready" even though SSR isn't built
+
+Lunas's core construction strategy already produces the exact artifact a server
+needs, for two structural reasons:
+
+1. **The component's static HTML string is what a server would emit.** A Lunas
+   component is built by parsing a static HTML string with the browser's native
+   parser and then wiring reactive bindings against the resulting DOM. That same
+   static string is precisely what a server would send down the wire.
+
+2. **Anchors are created at runtime, not embedded in the HTML.** Control-flow
+   anchors (the text nodes that mark where `:if` / `:for` / child components go)
+   are created by the runtime during wiring — they are **not** baked into the
+   HTML string as comments or markers. The server HTML stays clean and
+   comment-free, which keeps server output small and avoids a parse penalty on
+   the client's initial document parse.
+
+Because of these two properties, **hydration can reuse the CSR wiring path**
+almost verbatim.
+
+## The designed-for hydration approach
+
+Client-side rendering today does, per component:
+
+```
+parse static HTML (innerHTML)  →  positional nav to nodes  →  create anchors  →  bind(...)
+```
+
+Hydration would do the same thing **minus the parse**:
+
+```
+(server DOM already exists)   →  positional nav to nodes  →  create anchors  →  bind(...)
+```
+
+That is: **skip `innerHTML`** (the server-rendered subtree is already in the
+document), then run the *same* positional-navigation + anchor-creation + `bind`
+steps against the server-rendered DOM. Because the wiring logic is identical, the
+hydration codegen mode reuses the CSR runtime rather than duplicating it.
+
+Two facts make this consistent:
+
+- **Positional node navigation** (`refs(root, paths)` walking `childNodes`
+  indices) works the same on a parsed-from-string tree and a server-rendered
+  tree, so the same `refs` paths locate the same nodes.
+- **The scope attribute is stable across builds** (see
+  [scoped CSS](./scoped-css.md)), so a server and a client agree on the same
+  `data-lunas-<hash>` id — server-rendered scoped styles line up with
+  client-side wiring.
+
+## What is intentionally not decided yet
+
+Because SSR is deferred, the following are **not** specified and may change when
+the mode is actually built:
+
+- The **server-side render entry point** (how you turn a component + props into
+  an HTML string on the server).
+- The **hydration entry point** on the client (the analogue of today's `attach`
+  that adopts an existing subtree instead of inserting one).
+- **Streaming**, per-request data loading, and how [async
+  components](../built-ins/suspense.md) / [suspense](../built-ins/suspense.md)
+  boundaries resolve on the server.
+- **Router** integration for server-side route resolution (though
+  [`memoryHistory`](./routing.md) already provides the injectable,
+  non-browser history seam the server path would build on).
+
+## What you can rely on today
+
+- **Nothing in the current architecture blocks SSR** — it's an additive codegen
+  mode, not a rewrite.
+- The **transition** built-in already
+  [degrades gracefully](../built-ins/transition.md) outside a browser (no
+  `requestAnimationFrame`), so it won't hang a non-DOM render.
+- The **router**'s history access is behind an injectable adapter
+  ([`memoryHistory`](./routing.md)), explicitly noted as a tests/SSR seam.
+
+If you need SSR now, it isn't available — plan for a client-rendered app and
+track the `a-ssr` roadmap item.
+
+## See also
+
+- `crates/lunas_compiler/docs/output-design.md` §9 — the authoritative
+  SSR-readiness note this page is based on.
+- [Scoped CSS](./scoped-css.md) — the stable scope id that lets server and client
+  agree.
+- [Routing](./routing.md) — `memoryHistory`, the non-browser history seam.
+- [Tooling](./tooling.md) — the current (client-only) build workflow.

--- a/docs/scaling/state-management.md
+++ b/docs/scaling/state-management.md
@@ -1,0 +1,159 @@
+# State management
+
+For state that outlives any single component and is shared across many, Lunas
+provides **stores**: module-level reactive state that any number of components
+can import and adopt. A store is the module-scope generalization of a shared prop
+— instead of one value passed *down* the tree, it's created once at module load
+and imported by however many components want it.
+
+Stores keep Lunas's compile-time reactivity model: **no auto-tracking, no
+runtime dependency discovery**. Each store field is independently subscribable, so
+writing one field only marks dirty the components that adopted *that* field.
+
+## Creating a store
+
+```js
+// store.mjs
+import { createStore } from "lunas";
+
+export const appStore = createStore({
+  count: 0,
+  user: null,
+});
+```
+
+Each key becomes an **independent field** with its own subscriber list. A write
+to `count` never notifies a component that only reads `user`.
+
+## Reading and writing
+
+From anywhere — a component handler or plain module code — read and write by key:
+
+```js
+appStore.get("count");                             // read
+appStore.set("count", appStore.get("count") + 1);  // write
+```
+
+- Object/array values are **deep-mutation reactive**: they're lazily wrapped in a
+  Proxy, so mutating a nested property notifies subscribers (same strategy as the
+  component-local `deepBox`).
+- **Same-value writes are no-ops** (`set(k, v)` where `v` is unchanged notifies
+  nobody).
+
+## Adopting a store in a component
+
+When a component reads a store field in its template or handlers, the compiler
+emits a `useStore(c, i, store, key)` call that adopts the field at the
+component's reactive index `i`. From then on, writes to that field re-render the
+parts of the component that read it:
+
+```html
+<script>
+  import { appStore } from "./store.mjs";
+</script>
+
+<p>Count: {appStore.get("count")}</p>
+<button @click="appStore.set('count', appStore.get('count') + 1)">
+  Increment
+</button>
+```
+
+Every component that adopts `count` re-renders on a write — that's
+**cross-component reactivity** with no prop drilling and no event bus. Two sibling
+components both reading `appStore.get("count")` stay in sync automatically.
+
+`useStore` is scope-aware: adopted inside a control-flow block, its adoption is
+torn down automatically when the block's content is removed (the same lifecycle a
+`bind` gets), so a torn-down piece of UI stops being notified.
+
+## Subscribing from plain JS
+
+Outside a component context (tests, devtools, glue code), subscribe directly:
+
+```js
+const stop = appStore.subscribe("count", (value) => {
+  console.log("count is now", value);
+});
+// …later
+stop();
+```
+
+`fn(value)` runs **synchronously** on every write to that key (there is no
+component flush to batch onto for a non-component listener). The
+[router](./routing.md) is built on exactly this: its current route is a store
+field named `route`, and the outlet subscribes to it.
+
+## Derived values: `derivedStore`
+
+`derivedStore(store, deps, fn)` is a read-only value computed from one or more
+store fields, lazily recomputed and memoized (like a component's `computed`) but
+living at module scope. `deps` is the list of store keys it reads:
+
+```js
+import { createStore, derivedStore } from "lunas";
+
+const cart = createStore({ items: [] });
+
+const total = derivedStore(cart, ["items"], () =>
+  cart.get("items").reduce((sum, it) => sum + it.price, 0)
+);
+```
+
+A derived value is **field-shaped**, so you can place it under a `createStore`
+key and let components adopt it like any other field:
+
+```js
+const app = createStore({ total }); // field-shaped value passes through
+// inside a component the compiler emits:
+//   useStore(c, i, app, "total");
+//   app.get("total")   // read the derived value
+```
+
+- Recomputation is **lazy for component reads** (each component reads on its own
+  schedule) but **eager for plain-JS subscribers** (a `subscribe` listener is
+  handed the fresh value synchronously, like every other store subscribe).
+- `derivedStore` returns a handle with a `stop()` to unsubscribe from its
+  upstream fields — rarely needed, since derived stores are normally
+  module-scoped for the app's lifetime.
+
+## When to use a store — vs props / provide
+
+Lunas gives you three ways to share state; pick by scope and direction:
+
+| Mechanism | Best for | Direction |
+|---|---|---|
+| **Props** (`@input`) | passing data to a direct child | parent → child, explicit |
+| **provide / inject** | data for a whole subtree without threading props | ancestor → descendants |
+| **Store** | app-wide state shared by unrelated components | any → any, no tree relationship |
+
+Rules of thumb:
+
+- **Reach for props first.** Direct parent-to-child data is clearest as a prop.
+  Don't put something in a store just to hand it to one child.
+- **Use provide/inject** when a value is needed deep in a subtree and threading
+  it through every intermediate component as props would be noise — but the
+  consumers are all *descendants* of the provider.
+- **Use a store** when the sharers have **no tree relationship** (a header and a
+  cart page), when the state must **outlive** the components that use it, or when
+  many independent components need to react to the same source of truth.
+
+## Gotchas
+
+- **Reading `get(key)` in a handler doesn't declare a dependency** — adoption
+  (the compiler-emitted `useStore`) is what wires reactivity. Read a store field
+  in your template/reactive expressions so the compiler adopts it; a bare read in
+  imperative code just fetches the current value.
+- **Field independence is per key.** If you want a write to notify a set of
+  components together, they must all adopt the same key. Splitting related state
+  across keys means each key notifies only its own adopters.
+- **Derived fields are read-only** — `set` on a store key holding a derived value
+  is not a valid write. Change the upstream fields instead.
+- **Deep mutation is reactive, but reassign the top level for clarity** when it's
+  a small value: `set("count", n)` is simpler to reason about than mutating.
+
+## See also
+
+- [Routing](./routing.md) — a router is a store with one `route` field.
+- [Component props & provide/inject](../components/props.md) — the other sharing
+  mechanisms.
+- [Runtime API](../api/runtime.md) — `createStore`, `useStore`, `derivedStore`.

--- a/docs/scaling/tooling.md
+++ b/docs/scaling/tooling.md
@@ -1,0 +1,195 @@
+# Tooling
+
+Lunas's build toolchain has three pieces:
+
+- **`create-lunas`** — the scaffolding CLI that generates a new project.
+- **`vite-plugin-lunas`** — the Vite plugin that compiles `.lunas` / `.lun`
+  single-file components.
+- **`lunas_wasm`** — the WebAssembly binding that lets JavaScript run the real
+  Rust compiler.
+
+## Scaffolding a project: `create-lunas`
+
+```sh
+npm create lunas@latest my-app
+# or, to be prompted for a name:
+npm create lunas@latest
+```
+
+Then:
+
+```sh
+cd my-app
+npm install
+npm run dev
+```
+
+You get a minimal Vite app already wired up with `vite-plugin-lunas`:
+
+- `index.html` + `src/main.mjs` — mounts the app into `#app` via `attach`.
+- `src/App.lunas` — a root component demonstrating reactive state, an event
+  handler, and `:if` / `:for` in the template.
+- `vite.config.mjs` — the Lunas Vite plugin.
+
+The scaffolder copies its bundled `template/` into your target directory
+(**refusing to overwrite a non-empty one**) and rewrites the project's package
+name. The template's `App.lunas` is compiled by the Rust test suite on every
+build, so it's guaranteed to stay valid for the current compiler.
+
+## Compiling components: `vite-plugin-lunas`
+
+### Setup
+
+```sh
+npm install -D vite-plugin-lunas
+npm install lunas
+```
+
+`vite` is a peer dependency (`>=5`).
+
+```js
+// vite.config.mjs
+import { defineConfig } from "vite";
+import lunas from "vite-plugin-lunas";
+
+export default defineConfig({
+  plugins: [lunas()],
+});
+```
+
+Import components like any other module — the default export is the compiled
+component factory:
+
+```js
+import { attach } from "lunas";
+import App from "./App.lunas";
+
+attach(App(), document.getElementById("app"));
+```
+
+The emitted module imports its runtime from the `lunas` package, so the runtime
+is shared and tree-shaken normally by Vite/Rollup.
+
+### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `extensions` | `string[]` | `[".lunas", ".lun"]` | File extensions the plugin handles. |
+| `compiler` | `{ compile }` | — | Inject a compiler `{ compile(source) => { code, diagnostics } }`. Skips wasm loading entirely (used by tests / custom builds). |
+| `wasmPkgPath` | `string` | — | Path to a `wasm-pack --target nodejs` build of `lunas_wasm` (its `pkg` dir or entry file). Overrides `LUNAS_WASM_PKG` and the in-repo default. |
+
+### How the compiler is loaded
+
+The plugin needs a compiler exposing `compile(source) -> { code, diagnostics }`.
+It resolves one in this order:
+
+1. If `options.compiler` is given, it's used directly (**no wasm is loaded**).
+2. Otherwise the plugin **lazy-loads** the `lunas_wasm` wasm-pack
+   (`--target nodejs`) build on the first `.lunas` transform, searching:
+   1. `options.wasmPkgPath`
+   2. the `LUNAS_WASM_PKG` environment variable
+   3. `crates/lunas_wasm/pkg` (the in-repo dev default)
+
+Build the wasm compiler with:
+
+```sh
+cd crates/lunas_wasm
+wasm-pack build --target nodejs
+```
+
+### Diagnostics
+
+Compiler **errors** abort the build via Rollup's `this.error`, with a
+file/line/column and a one-line code frame. **Warnings** and **hints** surface
+via `this.warn` and do not stop compilation. Positions are computed from the
+compiler's UTF-8 byte offsets.
+
+### HMR behavior — honest scope
+
+A change to a `.lunas` / `.lun` file triggers a **full page reload** of the
+modules that import it.
+
+> **Finer-grained HMR** — patching a live component in place without a reload,
+> preserving its state — is **future work**. Today, editing a component reloads
+> the page; your app's runtime state is lost on each edit. This is functional but
+> coarser than the module-hot-swap you may be used to from mature frameworks.
+
+## The compiler binding: `lunas_wasm`
+
+`lunas_wasm` is a thin `wasm-bindgen` binding over the Lunas compiler
+(`lunas_compiler`). It's **bindings only** — all logic lives in the compiler
+crate. It exists so a bundler plugin or a browser playground can run the real
+compiler with no native toolchain.
+
+```js
+import { compile, version } from "lunas_wasm";
+
+const { code, diagnostics } = compile(source);
+// code:        string | null   — the emitted ES module (null on failure)
+// diagnostics: Array<{ message, severity, start, end }>
+//   severity:  "error" | "warning" | "hint"
+//   start/end: UTF-8 byte offsets into `source`
+```
+
+`compile` **never throws** for compiler problems — they come back as
+`diagnostics`. `code` is `null` when there's an error (or nothing to emit).
+
+### Building the wasm
+
+Requires [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) and the
+`wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`).
+Build from `crates/lunas_wasm`:
+
+```sh
+# Node target (what the Vite plugin loads by default) → ./pkg
+wasm-pack build --target nodejs
+
+# Browser/bundler target (playground / web build) → ./pkg-web
+wasm-pack build --target web --out-dir pkg-web
+```
+
+Each build produces a JS wrapper + `lunas_wasm_bg.wasm`. `pkg/` and `pkg-web/`
+are build artifacts and are git-ignored.
+
+## The build workflow at a glance
+
+```
+.lunas source
+   │  (vite-plugin-lunas transform)
+   ▼
+lunas_wasm.compile(source)  →  { code, diagnostics }
+   │  errors → this.error (abort);  warnings/hints → this.warn
+   ▼
+ES module (imports runtime from `lunas`)
+   │  (Vite / Rollup bundle + tree-shake)
+   ▼
+your app bundle
+```
+
+1. `create-lunas` scaffolds the project (once).
+2. `npm run dev` / `npm run build` runs Vite; `vite-plugin-lunas` intercepts
+   `.lunas` / `.lun` imports.
+3. The plugin calls `lunas_wasm.compile` (or your injected compiler), turning each
+   component into an ES module.
+4. Vite bundles the modules with the tree-shakeable `lunas` runtime.
+
+## Gotchas
+
+- **The wasm build must exist** (or a compiler must be injected) before the first
+  `.lunas` transform. In a fresh checkout, run `wasm-pack build --target nodejs`
+  in `crates/lunas_wasm`, or point `wasmPkgPath` / `LUNAS_WASM_PKG` at a build.
+- **Diagnostics are byte offsets**, not line/column. The Vite plugin computes
+  line/column for its code frames; a raw `lunas_wasm` consumer builds its own line
+  index if it needs editor squiggles.
+- **HMR is a full reload today** — don't expect in-place state preservation on
+  edit (see above).
+- **`extensions` is configurable** — if you use only `.lunas`, you can narrow it,
+  but the default already covers both `.lunas` and `.lun`.
+
+## See also
+
+- [Scoped CSS](./scoped-css.md) — note the CSS codegen wiring is a pending
+  integration task.
+- [SSR](./ssr.md) — the build is client-only today; SSR is deferred.
+- `packages/vite-plugin-lunas/README.md`, `packages/create-lunas/README.md`,
+  `crates/lunas_wasm/README.md` — the authoritative package references.


### PR DESCRIPTION
Adds two documentation sections for the Lunas framework, written against the real runtime/crate APIs (read from `packages/lunas/src/*.mjs` + `types/*.d.ts`, `crates/lunas_compiler/docs/output-design.md` §5/§9, `crates/lunas_css`, and the tooling packages).

## `docs/built-ins/`
- **teleport.md** — `<teleport to="…">`, selector vs element targets, `teleportBlock` mechanics, leak-free scoped teardown.
- **transition.md** — enter/leave class sequence (`name-enter-from/-active/-to`), `transitionend` + `duration` timeout fallback, non-browser degradation, `withTransition`/`runPhase`.
- **keep-alive.md** — LRU instance caching (`max`), activated/deactivated hooks, preserved node identity, `keepAlive.show`.
- **suspense.md** — `<Suspense>` boundaries, nearest-boundary registration, no-flash sync reveal, nested boundaries, `asyncComponent` (delay/timeout/error), unmount safety.

## `docs/scaling/`
- **routing.md** — `createRouter`, static/param/catch-all precedence, query parsing, `push/replace/back/forward`, `beforeEach` guards, `routerOutlet`/`routerLink`, `router.adopt`, `memoryHistory`, `@useRouting`/`@useAutoRouting` note.
- **state-management.md** — `createStore`/`get`/`set`, `useStore` adoption, `subscribe`, `derivedStore`, store vs props vs provide/inject.
- **scoped-css.md** — attribute stamping, `:deep()`/`:global()`, `@keyframes` renaming, at-rule handling.
- **ssr.md** — SSR + hydration design (server HTML string, hydration reuses CSR wiring path).
- **tooling.md** — `create-lunas`, `vite-plugin-lunas` (options, diagnostics, HMR), `lunas_wasm` binding, build workflow.

## Features flagged as deferred / partial (honestly noted in-page)
- **SSR + hydration** — marked **PLANNED/DEFERRED** (roadmap `a-ssr: deferred`); documents the designed-for approach only, no API today.
- **Scoped-CSS codegen wiring** — scoping engine (`lunas_css`) is complete/tested, but compiler integration (attribute stamping + `<style>` injection) is flagged as a pending later task per the crate README.
- **HMR** — vite-plugin does a full page reload; finer-grained in-place HMR flagged as future work.

Scope: only `docs/built-ins/` and `docs/scaling/` are touched — no `roadmap.yml`, no source, zero overlap with parallel doc agents. `docs/README.md` intentionally not written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)