### PR TITLE
docs(components): props, events, slots, provide/inject, dynamic & async components

### DIFF
--- a/docs/components/async-components.md
+++ b/docs/components/async-components.md
@@ -1,0 +1,150 @@
+# Async components — lazy loading with `asyncComponent`
+
+Large or rarely-used components don't need to ship in your initial bundle.
+`asyncComponent` wraps a lazy loader (typically a dynamic `import()`) into a
+mountable child factory: the component's code is fetched only when it first
+mounts, an optional loading/error UI covers the wait, and the resolved module is
+**cached** so later mounts are synchronous.
+
+## The basics
+
+Wrap a loader with `asyncComponent`; use the result anywhere a normal component
+factory is expected:
+
+```js
+import { asyncComponent } from "lunas";
+
+const HeavyChart = asyncComponent(() => import("./HeavyChart.lunas"));
+```
+
+The loader is a function returning a `Promise` of the module (or the factory
+directly). `asyncComponent` accepts:
+
+- an **ES module namespace** — it uses the `default` export;
+- a **bare factory** — used directly;
+- a `{ default }` wrapper object — it unwraps `default`.
+
+So `() => import("./HeavyChart.lunas")` works out of the box: the module's default
+export (the component factory) is what gets mounted.
+
+## Options — loading, error, delay, timeout
+
+`asyncComponent(loader, opts)` takes an options object:
+
+```js
+const HeavyChart = asyncComponent(() => import("./HeavyChart.lunas"), {
+  loading: Spinner,     // childFactory shown while pending (only after `delay` ms)
+  error:   LoadFailed,  // childFactory shown on rejection or timeout
+  delay:   200,         // ms to wait before showing `loading` (default 200)
+  timeout: 8000,        // ms after which a still-pending load is treated as an error
+});
+```
+
+| Option | Default | Meaning |
+|---|---|---|
+| `loading` | none | a component factory shown **while pending**, but only after `delay` ms elapse — so a fast load never flashes a spinner. |
+| `error` | none | a component factory shown on **rejection** or **timeout**. It receives an `error` prop (the rejection reason / timeout error) merged into its props. |
+| `delay` | `200` | ms to wait before showing `loading`. `0` shows it immediately. |
+| `timeout` | none | ms after which a still-pending load is treated as an error (shows `error`). |
+
+These match Vue's async-component semantics: **loading only after `delay`**,
+**error on reject/timeout**.
+
+### Loading/flash behavior
+
+- If the module resolves **before** `delay` elapses, the loading component is
+  **never shown** — no flash for fast loads.
+- On a **cache hit** (see below), the component mounts **synchronously** with no
+  placeholder and no flash at all.
+- The reveal is scheduled on the flush boundary, so a micro-tick resolve that
+  races a batched update lands without flicker.
+
+## Lazy loading and caching
+
+Each `asyncComponent` wrapper holds a per-wrapper cache:
+
+- The **first** mount triggers the loader (`import()`), showing loading/error UI
+  as configured.
+- Concurrent mounts of the same wrapper **share one in-flight load** — N
+  simultaneous mounts issue one `import()`, not N.
+- Once resolved, the factory is **cached**; every **subsequent** mount builds
+  **synchronously** — no placeholder, no network, no flash.
+
+So define the wrapper **once** (module scope) and reuse it, to get caching across
+all its mounts:
+
+```js
+// Good: one wrapper, shared cache.
+const HeavyChart = asyncComponent(() => import("./HeavyChart.lunas"));
+
+// Avoid: a fresh wrapper per use defeats the cache.
+// asyncComponent(() => import("./HeavyChart.lunas"))  // don't create inline per-mount
+```
+
+## Unmount safety
+
+Every async mount owns a liveness token. If the child is **unmounted while its
+load is still in flight** (e.g. the user navigates away, or an enclosing `:if`
+toggles off), the token flips and a loader that settles afterwards writes no DOM
+and touches no boundary — no late render into removed nodes. `timeout` similarly
+short-circuits a late resolve.
+
+## How it mounts — `mountAsyncChild`
+
+An async component is mounted through `mountAsyncChild`, which follows the same
+contract as `mountChild` but threads the component context so the child can
+register with the nearest [Suspense](../built-ins/suspense.md) boundary and so its
+`unmount()` cancels in-flight loads:
+
+```js
+import { mountAsyncChild } from "lunas";
+
+const handle = mountAsyncChild(c, anchor, HeavyChart, props);
+// handle.unmount() cancels any pending load and removes the subtree.
+```
+
+You normally don't call this by hand — the compiler emits it for an async
+component tag. It is shown here so the runtime shape is documented.
+
+## Integration with Suspense
+
+Async components are designed to cooperate with a **Suspense boundary**. When an
+async child mounts inside a `suspenseBlock`, it registers as a pending dependency
+with the nearest boundary; the boundary shows its fallback until **every** async
+descendant has settled, then reveals the content in one batch (so a
+fully-synchronous subtree never flashes the fallback). This lets you coordinate
+the loading state of several async children with a single fallback, instead of a
+spinner per component.
+
+For the boundary API, nesting rules, and examples, see
+[../built-ins/suspense.md](../built-ins/suspense.md). The `loading` option on
+`asyncComponent` and a Suspense fallback are complementary: `loading` is per
+async component; Suspense coordinates a whole subtree.
+
+## Combining with dynamic components
+
+An `asyncComponent` factory is just a component factory, so it composes with
+`<component :is="expr">` — you can switch to a lazily-loaded component. See
+[dynamic-components.md](./dynamic-components.md).
+
+## Gotchas
+
+- **Create the wrapper once.** A wrapper made inline on every mount has an empty
+  cache each time, forcing a reload. Hoist it to module scope.
+- **`delay` guards against spinner flash.** With the default `200` ms, a
+  sub-200 ms load shows no loading UI. Lower it (even to `0`) only if you *want*
+  the loading component to appear immediately.
+- **`error` gets an `error` prop.** The rejection reason (or timeout error) is
+  merged into the error component's props under `error`.
+- **Unmounting cancels in-flight loads.** A late-settling load after unmount is a
+  no-op — safe, but it means a component that unmounts before its load finishes
+  never renders.
+
+## Related
+
+- [dynamic-components.md](./dynamic-components.md) — switch to an async component
+  at runtime.
+- [../built-ins/suspense.md](../built-ins/suspense.md) — coordinate multiple async
+  children with one fallback.
+- [registration.md](./registration.md) — ordinary (eager) component registration.
+- [../api/](../api/) — `asyncComponent`, `mountAsyncChild`, `suspenseBlock`.

--- a/docs/components/dynamic-components.md
+++ b/docs/components/dynamic-components.md
@@ -1,0 +1,130 @@
+# Dynamic components — `<component :is="expr">`
+
+Sometimes *which* component to render is a runtime decision — a tab that swaps
+between panels, a form that switches editors by field type. `<component
+:is="expr">` renders whatever component factory `expr` currently evaluates to,
+and **swaps** to a new one whenever `expr` changes. It is the Lunas equivalent of
+Vue's `<component :is>`.
+
+## The basics
+
+`:is` takes an expression that evaluates to a component factory — usually a
+`@use`d component held in a reactive variable:
+
+```lunas
+@use Panel  from "./Panel.lunas"
+@use Notice from "./Notice.lunas"
+
+html:
+    <div>
+        <component :is="view" :label="title"/>
+        <button @click="swap()">swap</button>
+    </div>
+
+script:
+    let view  = Panel        <!-- start with Panel -->
+    let title = "hi"
+    function swap() { view = Notice }   <!-- switch to Notice -->
+```
+
+- `view` holds a component factory (`Panel`, imported via `@use`).
+- `<component :is="view">` renders `Panel`.
+- Clicking **swap** sets `view = Notice`; the dynamic slot unmounts `Panel` and
+  mounts `Notice` in its place.
+
+## `@use` and dynamic components
+
+A `<component :is>` can select *any* component you might switch to, but the
+compiler cannot know statically which one. So when a `<component :is>` tag is
+present in a template, **all** the file's `@use` factories are emitted as
+imports — none are tree-shaken away — so every candidate is available at runtime:
+
+```lunas
+@use Panel  from "./Panel.lunas"   <!-- both emitted because a <component :is> -->
+@use Notice from "./Notice.lunas"  <!-- exists in this template -->
+```
+
+You still declare each candidate with `@use`; that is how the factory identifiers
+(`Panel`, `Notice`) come into scope for the `:is` expression to reference.
+
+## Switching and remount-on-change
+
+The slot re-mounts **when the factory identity changes** — i.e. when `:is`
+evaluates to a *different* factory than before:
+
+- `view = Notice` (was `Panel`) → unmount `Panel`, mount `Notice`.
+- Setting `view` to the *same* factory it already holds → **no** remount.
+- Setting `view` to a falsy value → render **nothing** (the old child is
+  unmounted, no new one mounts).
+
+Because switching is a genuine unmount + mount, the outgoing component's state is
+**discarded** and the incoming component starts **fresh**. If you need to switch
+between components while *preserving* their state (so returning to a component
+restores its scroll position, form input, etc.), wrap the dynamic slot in
+keep-alive instead of relying on `:is` alone; see [../built-ins/](../built-ins/).
+
+## Passing props
+
+Props on a `<component :is>` tag flow to whichever component is currently
+mounted, exactly like a normal child mount:
+
+```lunas
+<component :is="view" :label="title"/>
+```
+
+- Reactive props (`:label="title"`) are forwarded and kept live: changing
+  `title` pushes the new value into the current child.
+- The same props object is reused across remounts and re-seeds the fresh child
+  when `:is` switches — so after a swap, `Notice` receives the current `title`
+  too.
+
+Whether a given prop is *meaningful* depends on the mounted component: if `Panel`
+declares `@input label` but `Notice` doesn't, the `:label` value is simply ignored
+by `Notice`. Provide the union of props the candidates need.
+
+## How it compiles
+
+`<component :is="expr">` compiles to a `dynamicBlock` at a text anchor:
+
+```js
+// <component :is="view" :label="title"/>
+const dyn = dynamicBlock(
+  c,
+  anchor,
+  [/* deps of `view` */],
+  () => view,                 // factoryOf: the current factory
+  { label: () => title },     // props: reactive props as getters
+);
+bind(c, [/* deps of title */], () => dyn.setProp("label", title)); // keep props live
+```
+
+- `factoryOf()` returns the current factory. When it changes (its deps flush),
+  `dynamicBlock` unmounts the old child and mounts the new one via `mountChild`
+  at the same anchor.
+- Props are forwarded through `setProp`, reused across remounts.
+- The handle exposes `{ handle, update(), setProp(name, value), destroy() }`
+  (`handle` is the current `mountChild` handle, or `null` when nothing is
+  mounted).
+
+## Gotchas
+
+- **`:is` must evaluate to a component *factory*, not a string.** In Lunas you
+  bind the factory itself (`let view = Panel`), not a tag name. Import each
+  candidate with `@use` so its identifier is in scope.
+- **Every `@use` is emitted when a `<component :is>` is present.** That is
+  intentional — dead-code elimination can't see which factory `:is` will pick.
+  Remove unused `@use` lines to keep the import set tight.
+- **Switching resets state.** A swap unmounts and remounts; the outgoing
+  component's reactive state is gone. Use keep-alive to preserve it.
+- **A falsy `:is` renders nothing.** Setting `view` to `null`/`undefined`
+  unmounts the current child and leaves the slot empty until `:is` becomes a
+  factory again.
+
+## Related
+
+- [registration.md](./registration.md) — `@use` (candidates must be declared).
+- [props.md](./props.md) — how forwarded props behave.
+- [async-components.md](./async-components.md) — lazily-loaded components, which
+  compose with dynamic switching.
+- [../built-ins/](../built-ins/) — keep-alive for state-preserving switches.
+- [../api/](../api/) — the `dynamicBlock` runtime helper.

--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -1,0 +1,187 @@
+# Events — child → parent with `emit`
+
+Props flow **down** (parent → child); events flow **up** (child → parent). A
+child raises a named event with an optional payload by calling `emit`, and the
+parent listens by attaching an `@name` handler to the child's tag. Under the
+hood, `@name` on a component tag compiles to an `on<Name>` prop, and `emit`
+looks that prop up and calls it.
+
+## Raising an event from the child
+
+In the child's `script`, call `emit(c, "<name>", payload)`:
+
+```lunas
+@input label:string = "Save"
+
+html:
+    <button @click="save()">${label}</button>
+
+script:
+    function save() {
+        emit("saved", { at: Date.now() })
+    }
+```
+
+- The first argument is the child's component context (`c`); in `.lunas` script
+  it is available implicitly — you write `emit("saved", payload)`.
+- `"saved"` is the event name (a plain identifier; kebab-case is allowed, see
+  [Naming](#naming-the-name--onname-convention)).
+- The second argument is an optional single **payload**.
+
+## Listening in the parent
+
+Attach an `@name` handler to the child's tag, exactly like a native DOM event:
+
+```lunas
+@use SaveButton from "./SaveButton.lunas"
+
+html:
+    <SaveButton label="Save now" @saved="onSaved($event)"/>
+
+script:
+    function onSaved(e) {
+        console.log("child saved at", e.at)
+    }
+```
+
+- `@saved="onSaved($event)"` runs `onSaved` in the **parent's** scope when the
+  child emits `"saved"`.
+- `$event` is the payload the child passed to `emit`.
+
+### How it compiles — `@name` → `onName`
+
+`@name` on a **component tag** does not become a DOM listener. It becomes an
+`on<Name>` entry on the child's `mountChild` props object:
+
+```js
+// <SaveButton @saved="onSaved($event)"/>
+mountChild(c, anchor, SaveButton, {
+  label: "Save now",
+  onSaved: ($event) => onSaved($event),   // @saved → onSaved
+});
+```
+
+At the top of the child's `setup`, `registerEmits` stashes the props so `emit`
+can find handlers; then `emit(c, "saved", payload)` looks up `onSaved` and calls
+it:
+
+```js
+// child setup
+registerEmits(c, props /*, ["saved"] optional declared list */);
+// …later…
+emit(c, "saved", { at: Date.now() });   // → props.onSaved({ at: … })
+```
+
+`eventPropName` is the exact mapping the compiler uses: `"save"` → `"onSave"`.
+
+> **Component tag vs. DOM element.** `@click` on a `<button>` is a DOM listener;
+> `@saved` on a `<SaveButton/>` is an emit handler. The compiler distinguishes
+> them by whether the tag is a `@use`d component or a native element.
+
+## Naming — the `@name` → `onName` convention
+
+Event names are camel-cased with an `on` prefix:
+
+| Emitted name | Handler prop | Parent attribute |
+|---|---|---|
+| `save` | `onSave` | `@save` |
+| `close` | `onClose` | `@close` |
+| `save-all` | `onSaveAll` | `@save-all` |
+| `update-model-value` | `onUpdateModelValue` | `@update-model-value` |
+
+Kebab-case segments are joined and capitalized: `save-all` → `onSaveAll`. Pick a
+convention (kebab in templates is idiomatic) and the mapping is mechanical.
+
+## Payloads
+
+`emit` takes **one** payload argument. To send multiple values, pass an object:
+
+```lunas
+<!-- child -->
+function submit() {
+    emit("submit", { name: name, email: email })
+}
+```
+
+```lunas
+<!-- parent -->
+<Form @submit="save($event)"/>
+script:
+    function save(data) { post(data.name, data.email) }
+```
+
+The parent receives that object as `$event`. There is no implicit argument
+spreading — one payload, one parameter.
+
+## `emit` does not mark the parent dirty
+
+This is the key semantic to internalize:
+
+> `emit` invokes the parent's `on<Name>` handler, but it does **not** by itself
+> mark the parent's reactive state dirty. The handler decides.
+
+If the handler mutates parent reactive state, the parent's box setters mark the
+parent dirty and it flushes as usual:
+
+```lunas
+<!-- parent -->
+@use Counter from "./Counter.lunas"
+html:
+    <Counter @changed="onChanged($event)"/>
+    <p>total: ${total}</p>
+script:
+    let total = 0
+    function onChanged(n) { total = total + n }  // box setter → parent flushes
+```
+
+Here the child's `emit("changed", 1)` calls `onChanged(1)`, which writes `total`
+— *that* write is what re-renders `${total}`. An event whose handler touches no
+reactive state produces no re-render. The two contexts stay independent: a child
+event marks only the child; the parent updates only if its handler chooses to
+mutate parent state.
+
+## No parent, no listener → no-op
+
+`emit` is safe to call even when nobody is listening:
+
+- If the parent passed **no** matching `on<Name>` handler, `emit` is a no-op.
+- If the child has **no parent** at all (mounted standalone), `emit` is a no-op.
+
+In both cases `emit` returns `false`; when a handler ran it returns `true`. So a
+reusable component can `emit("changed", …)` unconditionally without checking
+whether anyone subscribed.
+
+## Optional validation
+
+`registerEmits` accepts an optional array of declared event names. Emitting a
+name **not** in that list logs a `console.warn` (it does **not** throw) and
+still runs any handler that happens to be attached:
+
+```js
+registerEmits(c, props, ["save", "close"]);
+emit(c, "delete", …);   // warns: emitted undeclared event "delete"; handler still runs if present
+```
+
+This is a lean, warn-only guard — useful in development, never fatal.
+
+## Gotchas
+
+- **`@saved` on a native element is a DOM listener, not an emit.** Emit handlers
+  only apply to `@use`d component tags. `@click` on `<button>` binds the native
+  click event.
+- **`emit` alone won't re-render the parent.** Make the handler mutate parent
+  state if you want a re-render. (This is a feature: side-effect-only events
+  don't force layout work.)
+- **One payload only.** Bundle multiple values into an object.
+- **Names are case/segment sensitive in the mapping.** `@save-all` maps to
+  `onSaveAll`; the child must `emit(c, "save-all", …)` (kebab) — the runtime
+  camel-cases it for the lookup.
+
+## Related
+
+- [props.md](./props.md) — the downward (parent → child) direction.
+- [registration.md](./registration.md) — `@use` (a tag with `@name` must be a
+  `@use`d component).
+- [provide-inject.md](./provide-inject.md) — for cross-cutting communication
+  that shouldn't thread through every level.
+- [../api/](../api/) — `emit`, `registerEmits`, `eventPropName`.

--- a/docs/components/fragments.md
+++ b/docs/components/fragments.md
@@ -1,0 +1,148 @@
+# Fragments — multi-root components
+
+A component doesn't have to have a single wrapper element. When a template has
+**more than one top-level node**, Lunas compiles it as a **fragment**: the
+component renders its several roots directly, with **no wrapper element** added
+around them. This keeps your DOM clean — no stray `<div>` inserted just to
+satisfy a "single root" rule.
+
+## The basics
+
+Write however many top-level nodes you need in the `html:` section:
+
+```lunas
+html:
+    <h1 @click="rename()">${title}</h1>
+    <p :if="show">visible ${title}</p>
+    <footer>end</footer>
+
+script:
+    let title = "T"
+    let show  = true
+    function rename() {
+        title = "T2"
+        show  = !show
+    }
+```
+
+This component has **three** top-level nodes (`<h1>`, `<p>`, `<footer>`). There is
+no enclosing element — mounted into a parent, it contributes those three siblings
+directly, not a wrapper containing them.
+
+Contrast a **single-root** component, which has exactly one top-level element:
+
+```lunas
+html:
+    <div class="counter">
+        <span>${value}</span>
+        <button @click="inc()">+</button>
+    </div>
+```
+
+The compiler picks single-root vs. fragment automatically based on how many
+top-level nodes the template has — you don't declare it.
+
+## How it compiles
+
+A single-root component compiles to a `component(tag, attrs, HTML, setup)`
+factory whose root is the wrapper element. A multi-root component compiles to a
+`fragment(attrs, HTML, setup)` factory instead:
+
+```js
+// single-root:
+export default component("div", { class: "counter" }, HTML, setup);
+
+// multi-root (fragment): NO wrapper tag
+export default fragment({}, HTML, setup);
+```
+
+At runtime, `fragment`:
+
+1. bulk-parses the static skeleton via `innerHTML` into a **throwaway host**;
+2. runs `setup` while the nodes are still attached to that host (so positional
+   `refs` navigate the parsed tree, exactly like a single-root component);
+3. **snapshots the host's child nodes** (after setup, so any top-level anchors
+   created during wiring travel with the group), detaches them from the host, and
+   returns them as an **Array of nodes** carrying the component context on
+   `__lunasCtx`.
+
+That Array *is* the mountable unit. Because it carries `__lunasCtx`, a parent's
+`mountChild` drives its props exactly as it would for a single-root child — a
+fragment child is used identically to any other child:
+
+```lunas
+@use MultiRoot from "./MultiRoot.lunas"
+html:
+    <MultiRoot :title="heading"/>
+```
+
+## Mounting and teardown
+
+The block helpers (`mountChild`, `ifBlock`, `forBlock`, …) already treat a node
+group as a unit — they iterate the whole array to insert, move, or remove it. So a
+fragment:
+
+- **mounts** by inserting *all* its nodes before the anchor;
+- **moves** as a unit (e.g. reordered inside a `:for`);
+- **unmounts** by removing *every* node of the group and firing its `onDestroy`
+  once.
+
+No wrapper means no single element to move — the runtime tracks the node set
+instead. This is transparent to you: a fragment child behaves like any child from
+the outside.
+
+> Under the hood, the context uses the **first** node as its `root` for
+> positional refs against the whole child list. You don't interact with this
+> directly; it's why `refs`, `:ref`, and event wiring work the same as in a
+> single-root component.
+
+## Use with control flow
+
+Control-flow branches and list items can themselves be multi-root — the same
+node-group machinery applies:
+
+- **`:if` with a multi-node branch** — when several top-level nodes live inside a
+  branch, the branch is tracked as a group (or delimited by a start/end anchor
+  pair) so toggling the condition inserts/removes the whole group.
+- **`:for` items with several nodes** — a multi-node item is likewise tracked as a
+  group, so reordering/removing moves/removes all of the item's nodes together.
+
+The compiler picks the cheap single-node path when a branch or item is
+single-root, and the group path when it's multi-root — you just write the markup.
+
+A fragment component *inside* an `:if` or `:for` composes naturally: its node
+group is nested inside the block's node group, and teardown recurses.
+
+## When to reach for a fragment
+
+- **Table rows / list items** that must be direct children of a `<table>` /
+  `<ul>` — a wrapper `<div>` would be invalid HTML there. A fragment component can
+  return `<tr>`-level or `<li>`-level siblings directly.
+- **Layout siblings** where an extra wrapper would break flex/grid layout.
+- **Anywhere the wrapper element would be semantically meaningless.** If you'd
+  otherwise add a `<div>` "just because", a fragment avoids it.
+
+Prefer a single root when there *is* a natural container element — it's the
+fastest common path (one element, one attach). Reach for a fragment when the
+wrapper would be noise or invalid.
+
+## Gotchas
+
+- **Fragment vs. single-root is automatic.** It's decided by the number of
+  top-level nodes in the template, not a flag. Two top-level nodes → fragment.
+- **`attrs` on a fragment are ignored.** A fragment has no single root to attach
+  attributes to; the `fragment(attrs, …)` signature accepts `attrs` for parity
+  but does not apply them. Put attributes on the individual roots instead.
+- **A fragment child is used like any child.** `@use` it, mount it, pass props and
+  slots — nothing special at the call site.
+- **The group moves/removes together.** You can't detach one root of a fragment
+  independently; the runtime treats the set as one unit.
+
+## Related
+
+- [registration.md](./registration.md) — `@use` and how a component's default
+  export (a `fragment(...)` factory here) is imported.
+- [props.md](./props.md) — props work identically on a fragment child.
+- [../built-ins/](../built-ins/) — `:if` / `:for` control flow that hosts
+  multi-root branches and items.
+- [../api/](../api/) — the `fragment` and `component` runtime factories.

--- a/docs/components/props.md
+++ b/docs/components/props.md
@@ -1,0 +1,213 @@
+# Props — `@input`
+
+A component declares the inputs it accepts with `@input`. Props are Lunas's
+one-way channel from parent to child: the parent supplies values (static or
+reactive), and the child reads them like any other reactive variable. When a
+reactive prop's source changes in the parent, the child re-renders the parts
+that read it — automatically, with no wiring on your side.
+
+## Declaring a prop
+
+`@input` lines go at the top of the child's `.lunas` file, alongside `@use`:
+
+```lunas
+@input start:number = 0
+
+html:
+    <div class="counter">
+        <span class="value">${value}</span>
+        <button @click="inc()">+</button>
+    </div>
+
+script:
+    let value = start
+    function inc() { value = value + 1 }
+```
+
+The grammar is:
+
+```
+@input <name>:<type>[?] [= <default>]
+```
+
+| Part | Meaning |
+|---|---|
+| `<name>` | the prop name — the attribute the parent passes (`:start="…"`). |
+| `<type>` | the declared type (`string`, `number`, `boolean`, a custom type, …). Used for typing/tooling; see [Typing](#typing). |
+| `?` | optional marker — the prop may be omitted with no default. |
+| `= <default>` | a default expression, used when the parent omits the prop. |
+
+Examples:
+
+```lunas
+@input tone:string = "plain"    <!-- optional via default -->
+@input text:string = "?"        <!-- optional via default -->
+@input label:string             <!-- required: no default, no ? -->
+@input title:string?            <!-- optional, no default (undefined if omitted) -->
+```
+
+A declared prop name is in scope in the `script:` block as a value you can read
+(`let value = start`), and in the template as an interpolation (`${text}`).
+
+## Passing props from the parent
+
+Reference the child by its `@use` tag and pass attributes:
+
+```lunas
+@use Counter from "./Counter.lunas"
+@use Badge   from "./Badge.lunas"
+
+html:
+    <Counter :start="seed"/>       <!-- reactive: bound to `seed` -->
+    <Badge text="static label"/>   <!-- static: a literal string -->
+    <Badge :text="user"/>          <!-- reactive: bound to `user` -->
+
+script:
+    let seed = 10
+    let user = "ada"
+```
+
+There are two flavours of prop passing:
+
+### Static props
+
+A plain attribute (`text="static label"`) — or an interpolation-free value — is a
+**static prop**: a constant passed once at construction. A valueless flag
+attribute (`disabled`) passes `true`.
+
+```lunas
+<Badge text="hello"/>   <!-- text = "hello" -->
+<Badge/>                <!-- text = "?" (the child's default) -->
+```
+
+### Reactive props
+
+A bound attribute (`:start="seed"`, `:text="user"`) — or a static value
+containing an interpolation — is a **reactive prop**. The child seeds from it at
+construction, *and* the parent keeps it live: whenever the bound expression's
+dependencies change, the new value is pushed into the child.
+
+```lunas
+<Counter :start="seed"/>
+```
+
+If the parent later does `seed = 20`, the child's `start` prop updates and any
+child template part that reads it re-renders.
+
+### How it compiles
+
+A child mounts through the `mountChild` runtime helper. Reactive props are passed
+as **getters** in the initial props object (so the child seeds correctly at
+construction), and each reactive prop gets a parent-side `bind` that pushes new
+values via `setProp`:
+
+```js
+// <Counter :start="seed"/>  with a static "static" prop for illustration
+const ch0 = mountChild(c, anchor, Counter, {
+  start: () => seed,      // reactive prop → getter
+  static: "x",            // static prop → plain value
+});
+bind(c, [/* deps of seed */], () => ch0.setProp("start", seed)); // keeps it live
+```
+
+- The **getter** seeds the child's reactive prop box at construction.
+- The **`bind`** re-runs on the source expression's compile-time deps and calls
+  `ch0.setProp("start", seed)`. The bind's initial run re-seeds the same value,
+  which the box no-ops on (an equal write does nothing).
+- **Static props** are plain values in the initial object — no driving `bind` is
+  emitted.
+
+Inside the child, each `@input` prop is adopted as a **reactive box** with the
+`prop` helper at the top of `setup`:
+
+```js
+const start = prop(c, "start", i, props.start, /* default */ 0);
+```
+
+`prop` seeds the box from `props.start` (calling it if the parent passed a
+getter, else using the value), or from the default when the prop is omitted, and
+registers the box under `c._props["start"]` so the parent's `setProp` can drive
+it.
+
+## One-way data flow
+
+Data flows **parent → child only**. `setProp` writes the child's own prop box —
+`child._props[name].v` — which marks the **child** dirty and flushes the child.
+It never touches the parent's reactive state.
+
+Symmetrically, the child mutating a prop locally (`value = value + 1` above, or
+mutating a prop directly) changes only the child's copy and does **not**
+propagate back to the parent. The two component contexts are fully independent:
+
+> A parent prop push marks only the child; a child event marks only the child.
+> Parent and child never cross-contaminate reactive state.
+
+If a child needs to send information upward, use an **event** ([events.md](./events.md))
+rather than mutating a prop. This one-way discipline is what keeps updates
+predictable.
+
+## Reactivity of props (parent change → child updates)
+
+Because a reactive prop is driven by a parent-side `bind`, the flow is:
+
+1. Parent state changes (`seed = 20`).
+2. The parent's driving bind re-runs and calls `ch0.setProp("start", 20)`.
+3. `setProp` writes the child's `start` box → the **child** is marked dirty.
+4. The child flushes; every child template part that reads `start` re-runs.
+
+```lunas
+<!-- Parent -->
+@use Badge from "./Badge.lunas"
+html:
+    <Badge :text="user"/>
+    <button @click="user = 'grace'">rename</button>
+script:
+    let user = "ada"
+```
+
+Clicking the button sets `user = "grace"`; the `Badge`'s `${text}` re-renders to
+`[grace]` on the next flush. You wire nothing extra — declaring `:text` as a
+bound attribute is enough.
+
+### Deep mutation of an object/array prop
+
+By default a prop box is a plain reassign-only `box`. If the child deeply mutates
+the prop value locally (e.g. `arr.push(…)`, `obj.k = …`), the compiler selects a
+`deepBox` for that prop (the `deep` flag on `prop`), so deep mutations mark the
+child dirty. Parent-driven whole-value replacement still works either way.
+
+## Typing
+
+The `:type` in `@input name:type` documents the prop's type for tooling and
+readability. Use the framework's type names (`string`, `number`, `boolean`) or
+your own type identifiers. The `?` marker and the presence/absence of a
+`= default` together describe optionality:
+
+| Declaration | Required? | Value when omitted |
+|---|---|---|
+| `@input x:number` | required | — |
+| `@input x:number?` | optional | `undefined` |
+| `@input x:number = 0` | optional | `0` |
+
+## Gotchas
+
+- **A static prop is never reactive.** `text="user"` passes the literal string
+  `"user"`, not the value of the `user` variable — you almost certainly meant
+  `:text="user"`. The `:` prefix is what makes an attribute bound.
+- **Mutating a prop in the child does not update the parent.** It only updates
+  the child's local copy. Emit an event instead.
+- **Equal writes are free.** The prop box no-ops when the new value equals the
+  old one (`x !== v` check), so re-pushing the same value costs nothing.
+- **Passing a getter yourself isn't the API.** You write `:prop="expr"`; the
+  compiler turns it into a getter + driving bind. Don't pass a function unless the
+  prop's *type* is a function.
+
+## Related
+
+- [registration.md](./registration.md) — `@use` (a prop-passing tag must be
+  `@use`d first).
+- [events.md](./events.md) — the child → parent direction (the counterpart to
+  props).
+- [slots.md](./slots.md) — passing *content* (not just values) to a child.
+- [../guide/reactivity](../guide/) — how reactive boxes and flushing work.
+- [../api/](../api/) — the `prop` / `mountChild` runtime helpers.

--- a/docs/components/provide-inject.md
+++ b/docs/components/provide-inject.md
@@ -1,0 +1,178 @@
+# Provide / inject — dependency injection down the tree
+
+Props and events pass data between a parent and its *direct* child. When a value
+needs to reach a **deep descendant** — a theme, a current user, a service handle
+— threading it through every intermediate component ("prop drilling") is
+tedious. `provide` / `inject` let an ancestor publish a value that any descendant
+can pull, no matter how deep, without the components in between knowing about it.
+
+## The basics
+
+An ancestor calls `provide(c, key, value)`; any descendant calls
+`inject(c, key, default?)` to read it:
+
+```lunas
+<!-- App.lunas (ancestor) -->
+@use Page from "./Page.lunas"
+html:
+    <Page/>
+script:
+    provide("theme", "dark")
+```
+
+```lunas
+<!-- DeepButton.lunas (some descendant, any depth below App) -->
+html:
+    <button class="btn ${theme}">click</button>
+script:
+    let theme = inject("theme", "light")   // "dark" — resolved from App
+```
+
+- In `.lunas` script the component context `c` is implicit — you write
+  `provide("theme", "dark")` and `inject("theme", "light")`.
+- The descendant does not need to know *which* ancestor provided the value, or
+  how many levels up it is.
+
+## How resolution works
+
+`inject` walks the **parent-context chain** — the `childCtx.parent` links that
+`mountChild` sets when it mounts a child. It returns the value from the **nearest
+ancestor** that provided the key (self included), stopping at the first match.
+
+```
+App        provide("theme", "dark")
+ └─ Layout
+     └─ Panel
+         └─ DeepButton   inject("theme")  → walks up → finds App's "dark"
+```
+
+The walk is O(depth). Only children mounted via `mountChild` are linked, so a
+**root** component's `parent` is `null` and `inject` on a root falls straight
+through to its default.
+
+## Keys — strings or Symbols
+
+A key may be a **string** or a **Symbol**:
+
+```lunas
+script:
+    provide("theme", "dark")            // string key
+```
+
+```lunas
+script:
+    const StoreKey = Symbol("store")
+    provide(StoreKey, { count: 1 })     // Symbol key
+```
+
+String and Symbol keys are distinct — a string `"store"` will **not** match a
+`Symbol("store")`. Symbols avoid accidental collisions between unrelated
+providers that happen to pick the same string name; export a shared `Symbol` from
+a module when several components must agree on the same injection key.
+
+## Defaults
+
+`inject(c, key, default)` returns `default` when no ancestor provides the key:
+
+```lunas
+let color = inject("accent", "#0af")   // "#0af" if nobody provided "accent"
+```
+
+Omit the default and an unprovided key yields `undefined`:
+
+```lunas
+let color = inject("accent")           // undefined if unprovided
+```
+
+The default is a plain value (matching the common case). If you need a lazily
+constructed default, pass a thunk and call it yourself:
+
+```lunas
+let svc = inject("service") || makeService()
+```
+
+### Provided-`undefined` vs. absent
+
+An ancestor can deliberately provide `undefined`. To distinguish "provided the
+value `undefined`" from "never provided", use `hasInjection`:
+
+```lunas
+if (hasInjection(c, "maybe")) {
+    // some ancestor provided "maybe" (its value may itself be undefined)
+} else {
+    // no ancestor provides "maybe" at all
+}
+```
+
+`hasInjection` walks the same chain and returns a boolean.
+
+## Nearest wins (shadowing)
+
+If several ancestors provide the **same key**, the **nearest** one shadows the
+others for a given descendant:
+
+```
+App     provide("k", "root")
+ └─ Mid   provide("k", "mid")   ← shadows App's "root"
+     └─ Leaf   inject("k")  → "mid"
+```
+
+A component deeper than `Mid` sees `"mid"`; a component between `App` and `Mid`
+(if any) sees `"root"`. This lets a subtree override an inherited value locally
+without affecting the rest of the tree.
+
+## How it compiles
+
+`provide` / `inject` are direct runtime calls; there is no special template
+syntax. They compile to:
+
+```js
+// provide("theme", "dark")
+provide(c, "theme", "dark");   // registers on c._provides (a Map)
+
+// inject("theme", "light")
+const theme = inject(c, "theme", "light");   // walks c.parent chain, nearest wins
+```
+
+`provide` stores the key on the component's own `_provides` Map (a later
+`provide` of the same key on the same component overwrites it). `inject` walks
+`c.parent` links — the chain `mountChild` builds — to the nearest provider.
+
+## Reactivity note
+
+`provide` registers a value; it is not itself a reactive channel. If you provide
+a plain value and later replace it, existing injectors that already read it hold
+the old value. To share **reactive** state broadly, provide a reactive container
+(a box, a store, or an object you mutate) rather than a bare snapshot — the
+descendants then read through that live container. For app-wide reactive state
+outside any single component, prefer a **store** (`createStore` / `useStore`);
+see [../scaling/](../scaling/).
+
+## When to use provide/inject vs. props
+
+- **Props** — direct, explicit parent → child value. Best for a component's
+  declared interface. Prefer props when the relationship is one level deep or the
+  value is genuinely part of the child's API.
+- **provide/inject** — cross-cutting concerns that many descendants need (theme,
+  locale, current user, a service handle) where threading props through every
+  level would be noise. Use sparingly; it creates an implicit dependency that
+  isn't visible in a component's tag.
+
+## Gotchas
+
+- **Only `mountChild`-linked descendants can inject.** A component mounted
+  outside the tree (standalone root) has `parent = null` and only sees its
+  defaults.
+- **String and Symbol keys never collide.** Pick one convention per key and stick
+  to it; export shared `Symbol`s for keys that multiple modules must agree on.
+- **Nearest provider wins.** A closer ancestor's `provide` shadows a farther one
+  for that subtree.
+- **A bare provided value is a snapshot.** Provide a reactive container if
+  descendants must see later changes.
+
+## Related
+
+- [props.md](./props.md) — the explicit, one-level-deep alternative.
+- [events.md](./events.md) — child → parent communication.
+- [../scaling/](../scaling/) — module-level stores for app-wide reactive state.
+- [../api/](../api/) — `provide`, `inject`, `hasInjection` runtime helpers.

--- a/docs/components/registration.md
+++ b/docs/components/registration.md
@@ -1,0 +1,133 @@
+# Registration — using one component inside another
+
+A Lunas component becomes a child of another component by being **declared with
+`@use`** and then **referenced by tag** in the template. There is no global
+registry and no runtime lookup: `@use` is a compile-time import statement, so a
+tag only resolves to a component if that component was `@use`d in the same file.
+
+## Declaring a child with `@use`
+
+`@use` lines sit at the very top of a `.lunas` file, before the `html:` and
+`script:` sections:
+
+```lunas
+@use Counter from "./Counter.lunas"
+@use Card    from "./Card.lunas"
+@use Badge   from "./Badge.lunas"
+
+html:
+    <main class="app">
+        <Card tone="lead">
+            <Counter :start="seed"/>
+        </Card>
+        <Badge :text="user"/>
+    </main>
+
+script:
+    let seed = 10
+    let user = "ada"
+```
+
+The grammar is:
+
+```
+@use <Name> from "<path>"
+```
+
+- **`<Name>`** is the local tag you will write in the template. It is the name
+  you choose in *this* file — it does not have to match the child's filename,
+  though matching keeps things readable.
+- **`<path>`** is a module path, taken **verbatim**. The compiler does not
+  rewrite or normalize it — extension handling is the module resolver's job (see
+  [Paths](#paths) below).
+
+### How it compiles
+
+Each `@use` becomes a plain ES import in the emitted module:
+
+```js
+import Card from "./Card.lunas";
+import Counter from "./Counter.lunas";
+import Badge from "./Badge.lunas";
+```
+
+Two refinements the generator applies:
+
+- **Only components actually used in the template are imported.** A `@use`
+  declaration that is never referenced by a tag is dropped from the output — it
+  is dead code. (The one exception is dynamic components: when a `<component
+  :is="…">` tag is present, *all* `@use` factories are emitted, because the
+  compiler cannot know statically which one `:is` will select. See
+  [dynamic-components.md](./dynamic-components.md).)
+- **Tag-name collisions with runtime identifiers are aliased.** If you name a
+  component after a runtime helper — e.g. a component literally named `bind` —
+  it is imported under a `$`-suffixed alias so it never shadows the runtime.
+
+## Naming is case-sensitive
+
+Tag names are matched **exactly** against the `@use` names. `Counter`, `counter`
+and `COUNTER` are three different tags, and only the one that matches a `@use`
+declaration resolves to a component. By convention Lunas components are named in
+`PascalCase`, which also keeps them visually distinct from native HTML elements
+(which are lowercase):
+
+```lunas
+@use UserCard from "./UserCard.lunas"
+
+html:
+    <UserCard :name="name"/>   <!-- resolves: matches @use UserCard -->
+    <usercard :name="name"/>   <!-- does NOT resolve: treated as a plain tag -->
+```
+
+A tag that matches no `@use` name is left as an ordinary HTML element in the
+static skeleton — it is **not** an error, so a typo in a component tag silently
+renders as an unknown element rather than mounting your component. Watch the
+casing.
+
+## Paths
+
+The path string is passed straight through to the emitted `import`, so it
+follows your bundler's / runtime's module resolution:
+
+```lunas
+@use Counter from "./Counter.lunas"        <!-- relative, same folder -->
+@use Header  from "../layout/Header.lunas" <!-- relative, parent folder -->
+@use Button  from "@ui/Button.lunas"       <!-- alias resolved by the bundler -->
+```
+
+- **Relative paths** (`./`, `../`) resolve from the current file, as usual.
+- **Bare / aliased paths** are handed to the resolver unchanged; configure
+  aliases (e.g. `@ui`) in your bundler.
+- The **`.lunas` extension** is written explicitly here because the compiler does
+  not add or strip it. Whether your toolchain wants the extension present is a
+  resolver concern, not a compiler one — write the path exactly as your setup
+  expects to import it.
+
+## Where components live
+
+Lunas imposes no directory layout. A component is just a `.lunas` file that
+exports a factory; put them wherever your project's conventions dictate (a
+`components/` folder, colocated beside the feature that uses them, etc.). What
+matters is that the `@use` path resolves to the file.
+
+A single-root component compiles to a `component(tag, attrs, HTML, setup)`
+factory as its default export; a multi-root component compiles to a
+`fragment(...)` factory (see [fragments.md](./fragments.md)). Either way the
+default export is the child factory that `@use` imports and that a parent mounts.
+
+## Every reference needs a `@use`
+
+There is no "auto-registration" or ambient/global component set. If a template
+uses `<Widget/>`, the same file must contain `@use Widget from "…"`. This keeps
+each module's dependencies explicit and lets the compiler tree-shake unused
+imports.
+
+## Related
+
+- [props.md](./props.md) — declaring and passing `@input` props to a child.
+- [events.md](./events.md) — child → parent communication with `emit`.
+- [slots.md](./slots.md) — projecting parent content into a child.
+- [dynamic-components.md](./dynamic-components.md) — `<component :is="expr">` and
+  why it forces all `@use` imports to be emitted.
+- [fragments.md](./fragments.md) — multi-root (wrapper-less) components.
+- [../guide/](../guide/) — the getting-started guide.

--- a/docs/components/slots.md
+++ b/docs/components/slots.md
@@ -1,0 +1,244 @@
+# Slots — projecting parent content into a child
+
+Props pass *values* to a child; **slots** pass *content* — template markup the
+parent writes but the child decides where to render. A child declares outlets
+with `<slot>`; the parent fills them by writing content between the child's
+tags. Slots come in three forms: the **default slot**, **named slots**, and
+**scoped slots**.
+
+Crucially, **parent-provided slot content is wired in the parent's scope** — it
+reads and reacts to *parent* state, even though it renders inside the child's
+DOM. The child only decides the *location*.
+
+## Default slot + fallback
+
+A child marks where children go with `<slot>`, optionally with fallback content
+inside it:
+
+```lunas
+<!-- Card.lunas (child) -->
+html:
+    <section class="card">
+        <main><slot>empty</slot></main>
+    </section>
+```
+
+The parent fills the default slot by writing content between the child's tags:
+
+```lunas
+<!-- parent -->
+@use Card from "./Card.lunas"
+html:
+    <Card>
+        Hello from the parent, ${user}.
+    </Card>
+script:
+    let user = "ada"
+```
+
+- If the parent provides content, it renders in place of `empty`.
+- If the parent provides **no** content, the child's fallback (`empty`) renders.
+
+Because the content is wired in the parent, `${user}` is the *parent's* `user`,
+and it stays reactive: changing `user` in the parent updates the text in place,
+inside the child's `<main>`.
+
+### How it compiles
+
+The child's `<slot>` becomes a `slotBlock` at a text anchor; the parent's content
+becomes a `default` factory on the child's `$slots` object:
+
+```js
+// child: <slot>empty</slot>
+slotBlock(c, anchor, props.$slots && props.$slots["default"], () => /* fallback: "empty" */);
+
+// parent: the content between <Card>…</Card>
+mountChild(c, anchor, Card, {
+  $slots: {
+    default: (slotProps, onCleanup) =>
+      slotContent(c, (slotProps) => { /* wire content in the PARENT */ }, slotProps, onCleanup),
+  },
+});
+```
+
+- `slotBlock` renders the parent-provided factory if present, else the child's
+  own fallback, else nothing. It is null-safe.
+- `slotContent` opens a scope on the **parent** context, wires the content there,
+  and registers teardown via `onCleanup` so the content's binds are dropped when
+  the child unmounts — no leaks, no late writes.
+
+## Named slots
+
+A child can expose several outlets by naming them:
+
+```lunas
+<!-- Card.lunas (child) -->
+html:
+    <section class="card">
+        <header><slot name="head">untitled</slot></header>
+        <main><slot>empty</slot></main>
+        <footer><slot name="foot"></slot></footer>
+    </section>
+```
+
+The parent targets a named slot with `<template #name>`:
+
+```lunas
+<!-- parent -->
+@use Card from "./Card.lunas"
+html:
+    <Card>
+        <template #head>Dashboard for ${user}</template>
+        The counter starts here.
+        <template #foot>the footer</template>
+    </Card>
+script:
+    let user = "ada"
+```
+
+- `<template #head>…</template>` fills the `head` slot.
+- Bare content (not inside a `<template>`) goes to the **default** slot.
+- A named slot with no matching parent content shows its own fallback (`untitled`
+  for `head`), or nothing if it has none.
+
+### `<template #x>` syntax variants
+
+These are equivalent ways to target a named slot from the parent:
+
+| Syntax | Meaning |
+|---|---|
+| `<template #head>…</template>` | shorthand — fills the `head` slot. |
+| `<template slot="head">…</template>` | long form of the same. |
+| `<template>…</template>` (no name) | inlines its children into the **default** slot. |
+
+### How named slots compile
+
+Each `<template #x>` becomes an `x` entry on the parent's `$slots` object; the
+child's `<slot name="x">` reads `props.$slots["x"]`:
+
+```js
+// child: <slot name="head">untitled</slot>
+slotBlock(c, anchor, props.$slots && props.$slots["head"], () => /* "untitled" */);
+
+// parent
+mountChild(c, anchor, Card, {
+  $slots: {
+    head:    (sp, onCleanup) => slotContent(c, (sp) => { /* wire in parent */ }, sp, onCleanup),
+    default: (sp, onCleanup) => slotContent(c, (sp) => { /* wire in parent */ }, sp, onCleanup),
+  },
+});
+```
+
+## Scoped slots
+
+Sometimes the child has data the parent's slot content wants to render — e.g. a
+list row, or a computed count. The child exposes it as a **scoped prop** on the
+`<slot>`, and the parent receives it in the `<template>` binding:
+
+```lunas
+<!-- Card.lunas (child) -->
+html:
+    <footer><slot name="foot" :count="rows"></slot></footer>
+script:
+    let rows = 3
+```
+
+```lunas
+<!-- parent -->
+@use Card from "./Card.lunas"
+html:
+    <Card>
+        <template #foot="s">rows: ${s.count}</template>
+    </Card>
+```
+
+- The child's `<slot :count="rows">` exposes `{ count: rows }` up to the parent.
+- The parent binds those props to `s` via `#foot="s"` and reads `s.count`.
+- `slot-scope="s"` is the long form of `#foot="s"`.
+
+### How scoped slots compile
+
+The child's `<slot :count="rows">` emits a trailing scoped-props getter; the
+parent's `#foot="s"` binds it into the content build:
+
+```js
+// child: <slot name="foot" :count="rows"></slot>
+slotBlock(c, anchor, props.$slots && props.$slots["foot"], fallbackOrNull,
+          () => ({ count: rows }));   // scoped-props getter
+
+// parent: <template #foot="s">rows: ${s.count}</template>
+{
+  foot: (s, onCleanup) => slotContent(c, (s) => { /* read s.count */ }, s, onCleanup),
+}
+```
+
+### Scoped-slot reactivity — the implemented semantics (read this)
+
+Lunas implements a **restricted, honest** form of scoped-slot reactivity. Know
+exactly what you get:
+
+- **What works today (the common case):** the child's scoped props are captured
+  **once, at slot build time**, via the scoped-props getter (`slotPropsOf()`).
+  They are a **snapshot object**, not a live reactive channel. The parent's slot
+  content reads them through the bound name (`s.count`) and renders **correctly on
+  first paint**. Scoped props whose shape and values are fixed at build — which is
+  the common case, e.g. a stable row object or a count that doesn't change after
+  mount — work fine.
+- **Parent state stays fully reactive.** Any *parent* state the slot content also
+  reads (`${user}`, other parent variables) is wired with parent-scope binds and
+  updates normally. Only the *child-supplied* scoped values are the snapshot.
+- **The current limitation:** if the **child later mutates** a scoped value
+  (`rows = 4` after mount) and expects the parent's slot content to re-render
+  from that change, **it will not** — the snapshot is not a live channel. Making
+  child→parent scoped props reactive needs a per-scoped-prop bridge (analogous to
+  `setProp`, but flowing child → parent), which is **deferred**. It is an additive
+  change on top of the current contract: nothing you write today breaks when it
+  lands.
+
+In short: scoped props render correctly on first paint and reflect their value at
+build time; live child→parent scoped-prop updates after mount are not yet wired.
+Don't rely on a child mutating a scoped value to push a parent re-render.
+
+## Teardown
+
+Slot content is torn down with the child. When the child unmounts — e.g. it lives
+inside an `:if` that toggles off — the parent-owned slot binds are dropped via
+the `onCleanup` teardown registered in `slotContent`. They do not fire
+afterwards: no leaks, no late writes into removed DOM.
+
+## Content can contain components
+
+Slot content is ordinary parent template markup, so it can itself include child
+components. A component inside slot content mounts inside the outer child's slot
+outlet, wired in the parent's scope as usual:
+
+```lunas
+@use Card    from "./Card.lunas"
+@use Counter from "./Counter.lunas"
+html:
+    <Card>
+        <Counter :start="seed"/>   <!-- mounts inside Card's default slot -->
+    </Card>
+script:
+    let seed = 10
+```
+
+## Gotchas
+
+- **Slot content reads *parent* state, not child state.** It is wired in the
+  parent scope. To read child data, use a **scoped slot** (`:x` on the child
+  `<slot>` → `#name="p"` in the parent).
+- **Scoped props are a build-time snapshot.** Correct on first paint; not a live
+  child→parent channel (see above). Deferred.
+- **Bare content is the default slot.** Only `<template #x>` / `<template
+  slot="x">` route to a named slot.
+- **A named slot with no content shows its fallback** (or nothing) — parent
+  content is optional per slot.
+
+## Related
+
+- [props.md](./props.md) — passing *values* (slots pass *content*).
+- [events.md](./events.md) — child → parent events.
+- [registration.md](./registration.md) — `@use` the component you fill slots on.
+- [../built-ins/](../built-ins/) — `<template>` and control-flow built-ins.
+- [../api/](../api/) — `slotBlock`, `slotContent` runtime helpers.


### PR DESCRIPTION
## COMPONENTS-IN-DEPTH documentation

Adds the component-deep-dive section of the Lunas docs under `docs/components/` (8 files, example-first, with "how it compiles" notes, gotchas, and cross-links). No files outside `docs/components/` are touched — zero overlap with parallel doc work.

### Files
- `registration.md` — `@use Name from "./Path.lunas"`, verbatim paths, case-sensitive tag names, tree-shaking of unused imports, `$`-aliasing on collisions.
- `props.md` — `@input name:type[?] [= default]`, static vs. reactive (`:p="e"`) props, getter+`setProp` compile shape, one-way flow, parent-change→child-update reactivity, `deepBox` for deep mutation, typing.
- `events.md` — `emit(c, "name", payload)`, the `@name`→`onName` mapping (`save-all`→`onSaveAll`), single payload, `emit` does not mark parent dirty, no-parent/no-listener no-op, optional warn-only validation.
- `slots.md` — default+fallback, named slots, `<template #x>` / `slot="x"` / `#x="p"` / `slot-scope` variants, and an **honest** writeup of the implemented scoped-slot **snapshot** semantics plus the deferred child→parent live-update limitation.
- `provide-inject.md` — `provide`/`inject`/`hasInjection`, string & Symbol keys, defaults, nearest-wins shadowing, parent-chain walk, reactivity caveat.
- `dynamic-components.md` — `<component :is="expr">`, factory-identity remount, why all `@use` imports are emitted, prop forwarding, keep-alive pointer for state preservation.
- `async-components.md` — `asyncComponent(loader, { loading, error, delay, timeout })`, caching/dedup, unmount cancellation, `mountAsyncChild`, Suspense integration (links `../built-ins/suspense.md`).
- `fragments.md` — multi-root (wrapper-less) components, `fragment(...)` node-group mount/teardown, use inside `:if`/`:for`, ignored `attrs`.

### Accuracy
Every API and syntax detail was verified against `crates/lunas_compiler/docs/output-design.md` (§3/§5/§6), the `.lunas` fixtures (`app/App`, `Card`, `Counter`, `Badge`, `multi_root`, `dynamic_teleport`), and the runtime source (`packages/lunas/src/{blocks,dom,boxes,emits,provide,async}.mjs` + tests). No invented API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)