### PR TITLE
docs(guide): essentials guide (template syntax, reactivity, rendering, lifecycle)

### DIFF
--- a/docs/guide/class-and-style.md
+++ b/docs/guide/class-and-style.md
@@ -1,0 +1,99 @@
+# Class and style bindings
+
+`:class` and `:style` are the ergonomic way to compute an element's classes and
+inline styles. They accept strings, objects, and arrays, and they **merge with**
+any static `class` / `style` attribute already on the element.
+
+## `:class`
+
+The bound value can be a string, an object, or an (arbitrarily nested) array:
+
+```lunas
+html:
+    <div class="box" :class="{ active: on, big: huge }"></div>
+
+script:
+    let on = false
+    let huge = true
+```
+
+### Accepted shapes
+
+- **String** — used verbatim (trimmed): `:class="theme"`.
+- **Object** — each key is included when its value is truthy:
+  `:class="{ active: on, big: huge }"` → `active big` when both are truthy.
+- **Array** — flattened recursively; entries may be strings or objects:
+  `:class="['tag', { on: active }, extra]"`.
+- **Falsy** (`null`, `false`) — contributes nothing.
+
+### Merging with the static class
+
+The static `class` attribute is always kept and prepended:
+
+```lunas
+<div class="box" :class="{ active: on }"></div>
+```
+
+When `on` is true the element's class becomes `box active`; when false it is just
+`box`. The dynamic part is normalized (`normClass`) and joined onto the static
+string, then the whole `class` attribute is written. If the merged result is
+empty, the `class` attribute is removed.
+
+## `:style`
+
+The bound value can be a string, an object of camelCase properties, or an array:
+
+```lunas
+html:
+    <div :style="{ color: hue, fontWeight: weight }"></div>
+
+script:
+    let hue = "red"
+    let weight = "bold"
+```
+
+### Accepted shapes
+
+- **String** — used verbatim (trimmed): `:style="cssText"`.
+- **Object** — keys are CSS properties written in **camelCase**, converted to
+  kebab-case: `{ fontWeight: "bold" }` → `font-weight: bold;`. Custom properties
+  (`--x`) and already-kebab names pass through unchanged. Entries whose value is
+  `null` or `false` are skipped.
+- **Array** — merged left-to-right; later entries win.
+
+### Merging with the static style
+
+The static `style` attribute is kept and prepended (a trailing `;` is added if
+missing), then merged with the normalized dynamic style. As with class, an empty
+merged result removes the `style` attribute.
+
+## How it compiles
+
+`:class` and `:style` compile to `setClass` / `setStyle` calls that receive the
+static value and the dynamic expression, wrapped in a `bind` on the expression's
+dependencies:
+
+```js
+// <div class="box" :class="{ active: on, big: huge }">
+bind(c, [/* deps of on, huge */], () => {
+  setClass(e0, "box", { active: on.v, big: huge.v });
+});
+```
+
+`setClass`/`setStyle` normalize the dynamic value, merge it with the static
+string, and write the whole attribute — so the two never fight over the same
+element.
+
+## Notes
+
+- Object keys for `:style` are **camelCase** (`fontWeight`), not kebab
+  (`font-weight`); the runtime converts them.
+- `:class` object keys are class names as-is; only their truthiness matters.
+- These bindings are reactive: they re-run when any variable they read changes,
+  exactly like other [attribute bindings](./template-syntax.md).
+
+## Related
+
+- [Template syntax](./template-syntax.md) — attribute bindings and static
+  interpolation (`class="a ${x} b"`).
+- [Reactivity fundamentals](./reactivity-fundamentals.md).

--- a/docs/guide/computed.md
+++ b/docs/guide/computed.md
@@ -1,0 +1,81 @@
+# Computed values
+
+A computed value is a piece of state **derived** from other reactive state. It
+recomputes only when one of its inputs changes, and only when it is actually
+read — it is both **lazy** and **memoized**.
+
+## Deriving a value
+
+The simplest derived value is a plain expression over reactive state:
+
+```lunas
+html:
+    <p>${remaining} left</p>
+
+script:
+    let items = []
+    const remaining = items.filter(i => !i.done).length
+```
+
+Because `remaining` reads `items`, the template part that displays it depends on
+`items`; when `items` changes, the display re-evaluates.
+
+For a derived value you want to reuse across several template parts — and pay for
+only once per change — use the runtime `computed` helper. It gives the derived
+value its own reactive identity so downstream reads share a single memoized
+result:
+
+```js
+// deps are the reactive indices the derived value reads (compiler-supplied)
+const fullName = computed(c, i, [firstNameIdx, lastNameIdx],
+  () => `${first.v} ${last.v}`);
+
+// read it like any box:
+fullName.v;
+```
+
+`computed(c, i, deps, fn)` returns a read-only, box-shaped handle whose `.v`
+getter yields the memoized result.
+
+## Laziness and memoization
+
+The semantics are precise and worth understanding:
+
+- **Lazy compute.** `fn` runs only when `.v` is *read* **and** an input has
+  changed since the last computation. A computed value that is never read never
+  recomputes — even if its inputs change constantly.
+- **Memoized.** After a compute, the result is cached. Reading `.v` repeatedly
+  without an intervening input change returns the cached value; `fn` does not
+  re-run.
+- **Invalidate, don't recompute eagerly.** When an input changes, the computed
+  does **not** recompute immediately. It marks itself stale and marks its own
+  reactive index dirty, so any dynamic part that reads it is re-queued. Those
+  parts pull the fresh value on their next run, triggering exactly one recompute.
+
+The upshot: N downstream readers plus M input changes cost **one** recompute per
+change that is followed by a read — never one per reader, never one per change
+that nobody observes.
+
+## computed vs an inline expression
+
+| Use an inline expression when… | Use `computed` when… |
+|---|---|
+| the derivation is read in one place | the same derivation feeds several parts and you want it computed once |
+| it is cheap | it is expensive and you want memoization |
+| you don't need to reference it by name elsewhere | you want a named, reusable reactive handle |
+
+## computed vs watch
+
+- **`computed`** produces a *value* you render or read. It is pull-based and lazy.
+- **[`watch`](./watchers.md)** runs a *side effect* when state changes. It is
+  push-based and eager.
+
+Reach for `computed` when you need a derived value; reach for `watch` when you
+need to *do something* (log, fetch, sync to storage) in response to a change.
+
+## Related
+
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — the box model these
+  build on.
+- [Watchers](./watchers.md) — side effects on change.
+- Module-scope derived state: `derivedStore` in [scaling](../scaling/).

--- a/docs/guide/conditional-rendering.md
+++ b/docs/guide/conditional-rendering.md
@@ -1,0 +1,112 @@
+# Conditional rendering
+
+`:if`, `:elseif`, and `:else` conditionally render an element (and its subtree).
+They are **attributes on the element itself**, not wrapper tags — the element
+they sit on is the conditional's body.
+
+## Basic `:if`
+
+```lunas
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <span :if="show">Now you see me</span>
+    </div>
+
+script:
+    let show = true
+    function toggle() { show = !show }
+```
+
+When `show` is truthy the `<span>` is built and inserted; when falsy its nodes
+are removed. A permanent text **anchor** marks the slot position, so the location
+is always known even while the branch is absent.
+
+## Cascades: `:elseif` / `:else`
+
+`:elseif` and `:else` chain onto a preceding sibling `:if` to form one cascade.
+Exactly one branch is shown at a time:
+
+```lunas
+html:
+    <div>
+        <button @click="bump()">step</button>
+        <p :if="n == 0">zero</p>
+        <p :elseif="n > 3">big ${n}</p>
+        <p :else>small ${n}</p>
+    </div>
+
+script:
+    let n = 0
+    function bump() { n = n + 1 }
+```
+
+- `:if` and `:elseif` carry a condition expression.
+- `:else` carries **no value** and matches when every preceding condition is
+  false.
+- Branches must be adjacent siblings (whitespace between them is fine). An
+  `:elseif` / `:else` with no matching `:if` is an error.
+- A cascade **without** an `:else` shows nothing when all conditions are false.
+
+## Behavior: build-on-show
+
+A branch's DOM is built only when it becomes visible:
+
+- On show, the branch is constructed from its own static skeleton (one
+  `innerHTML` parse for that branch) and inserted before the anchor.
+- On hide, its nodes are removed and any bindings inside it are torn down, so a
+  hidden branch receives no updates and leaks nothing.
+- Switching branches in a cascade tears down the old branch and builds the new
+  one.
+
+This means an expensive subtree behind an `:if="false"` costs nothing until it is
+first shown.
+
+### How it compiles
+
+A lone `:if` compiles to an `ifBlock`; a full cascade compiles to a single
+`ifChain` with a `which()` selector that maps the conditions to a branch index
+(`-1` when nothing should show):
+
+```js
+// <p :if="n > 0">…</p><p :elseif="n < 0">…</p><p :else>…</p>
+ifChain(c, a0, [0], () => (n.v > 0) ? 0 : (n.v < 0) ? 1 : 2, [ /* branch builders */ ]);
+```
+
+The whole cascade shares one anchor and one dependency set, so a change
+re-evaluates the selector once and swaps branches only if the winning index
+changed.
+
+## Nesting
+
+Conditionals nest by element nesting — an `:if` element can contain other `:if`
+elements, `:for` lists, or components, and each inner block builds and tears down
+with its parent branch:
+
+```lunas
+html:
+    <ul>
+        <li :for="group of groups" :key="group.id">
+            <b>${group.name}</b>
+            <em :if="group.open">(open)</em>
+        </li>
+    </ul>
+```
+
+Here the `:if` lives inside a `:for` item; showing/hiding it re-evaluates against
+the current item's data, and removing the item tears the inner `:if` down with
+it. See [list rendering](./list-rendering.md) for `:for` + `:if` interaction.
+
+## Notes
+
+- `:if` toggles **presence in the DOM**. To toggle visibility while keeping the
+  node (and its state) mounted, bind a class or style instead — see
+  [class and style](./class-and-style.md).
+- Because a hidden branch's bindings are removed, its component children unmount
+  and their [`onDestroy`](./lifecycle.md) fires; re-showing rebuilds fresh.
+
+## Related
+
+- [List rendering](./list-rendering.md) — `:for`, and `:for` + `:if`.
+- [Template syntax](./template-syntax.md).
+- Keeping hidden components alive across toggles: keep-alive in [built-ins](../built-ins/).

--- a/docs/guide/event-handling.md
+++ b/docs/guide/event-handling.md
@@ -1,0 +1,92 @@
+# Event handling
+
+An `@`-prefixed attribute wires a DOM event listener. The event name is whatever
+follows the `@` (`@click`, `@input`, `@keydown`, …), and the value is a
+JavaScript handler.
+
+## Method vs inline handlers
+
+```lunas
+html:
+    <button @click="inc()">+1</button>
+    <input @keydown="onKey" />
+
+script:
+    let count = 0
+    function inc() { count = count + 1 }
+    function onKey(e) { if (e.key == "Enter") inc() }
+```
+
+Two forms:
+
+- **Inline call** — `@click="inc()"`. The value is an expression evaluated when
+  the event fires. It compiles to `on(e0, "click", () => { inc(); })`.
+- **Bare reference** — `@keydown="onKey"`. The named function is used as the
+  listener directly, so it receives the DOM event as its argument.
+
+Use a bare reference when your handler needs the event object; use an inline call
+when you want to pass specific arguments.
+
+## Arguments
+
+Because the inline form is just an expression, you can pass any arguments —
+including loop variables and data:
+
+```lunas
+html:
+    <ul>
+        <li :for="item of items" :key="item.id">
+            ${item.label}
+            <button @click="remove(item.id)">×</button>
+        </li>
+    </ul>
+
+script:
+    let items = [{ id: 1, label: "a" }]
+    function remove(id) { items = items.filter(x => x.id !== id) }
+```
+
+Here `item.id` is captured per-item, so each button removes its own row.
+
+To also use the DOM event alongside arguments, reference it explicitly in the
+inline expression (e.g. `@input="onType($event)"` where your handler takes the
+event), or use a bare reference and read `e.target` inside.
+
+## How handler writes trigger updates
+
+Handlers drive reactivity simply by **mutating reactive state**. When a handler
+reassigns or deeply mutates a reactive variable, the box setter marks that
+variable dirty; the affected [bindings](./reactivity-fundamentals.md) are
+enqueued and run on the next microtask flush.
+
+```lunas
+script:
+    let count = 0
+    let log = []
+    function inc() {
+        count = count + 1     // marks count's index dirty
+        log.push(count)       // marks log's index dirty (deepBox)
+        // both updates flush together on the next microtask
+    }
+```
+
+You don't declare what a handler changes — the compiler analyzes the handler (and
+functions it calls) to know its write set, and the box setters do the enqueuing
+at runtime. Multiple writes in one handler coalesce into a single DOM update
+pass.
+
+## Component events
+
+`@name` on a **component tag** is different from a DOM event: it listens for an
+event the child *emits*, not a native DOM event. `@save="onSave($event)"` becomes
+an `onSave` handler passed to the child, which raises it with `emit`. Names are
+camel-cased (`@save-all` → `onSaveAll`). The handler runs in the parent. See
+[components](../components/) for child-to-parent events.
+
+## Related
+
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — how writes schedule
+  updates.
+- [Forms & two-way binding](./forms-and-two-way.md) — `::value` combines a bind
+  with an input listener.
+- [Template syntax](./template-syntax.md).

--- a/docs/guide/forms-and-two-way.md
+++ b/docs/guide/forms-and-two-way.md
@@ -1,0 +1,105 @@
+# Forms and two-way binding
+
+A `::`-prefixed attribute creates a **two-way binding**: it binds a value to the
+element *and* writes user input back into your reactive state. `::value="name"`
+is sugar for `:value="name"` plus an input listener that assigns
+`name = el.value`.
+
+## Text inputs — `::value`
+
+```lunas
+html:
+    <input ::value="name">
+    <p>Hello, ${name}</p>
+
+script:
+    let name = "ada"
+```
+
+Type in the field and `name` updates; assign `name` in script and the field
+updates. The value of `::value` is an **lvalue** (an assignment target), not a
+general expression — it must be something you can write back to.
+
+### How it compiles
+
+`::value="name"` emits both directions:
+
+```js
+bind(c, [0], () => { e0.value = name.v; });          // read side (property)
+on(e0, "input", () => { name.v = e0.value; });        // write side (input event)
+```
+
+The read side runs on flush when `name` changes; the write side fires on every
+`input` event.
+
+## Checkboxes and radios — `::checked`
+
+`::checked` binds a boolean and commits on the **`change`** event (checkbox/radio
+semantics), not `input`:
+
+```lunas
+html:
+    <input type="checkbox" ::checked="agree">
+    <p>agree = ${agree}</p>
+
+script:
+    let agree = false
+```
+
+Compiles to:
+
+```js
+bind(c, [0], () => { e0.checked = !!(agree.v); });    // read side (boolean property)
+on(e0, "change", () => { agree.v = e0.checked; });     // write side (change event)
+```
+
+**Radios:** bind each radio in a group to the same variable. Use `::checked`
+against a boolean per option, or drive selection through `::value` plus the
+radios' `value` attributes, depending on how you model the group.
+
+## Select and other inputs
+
+For a `<select>`, bind the selected value with `::value`; the write-back captures
+the chosen option on input/change. The same `::name` mechanism generalizes: it
+pairs a value binding with a write-back listener appropriate to the property.
+
+```lunas
+html:
+    <select ::value="choice">
+        <option value="a">A</option>
+        <option value="b">B</option>
+    </select>
+```
+
+## Combining with other directives
+
+Two-way binding is just a value bind plus a listener, so you can add more
+attributes and events freely:
+
+```lunas
+html:
+    <input ::value="draft" @keydown="onKey" placeholder="What needs doing?" />
+
+script:
+    let draft = ""
+    function onKey(e) { if (e.key == "Enter") add(draft) }
+    function add(text) { /* … */ }
+```
+
+Here `::value` keeps `draft` in sync while a separate `@keydown` handler reacts to
+Enter.
+
+## Notes
+
+- The bound target is an **lvalue**: `::value="user.name"` writes back to
+  `user.name`. Deeply-mutated targets use a `deepBox`, so nested writes stay
+  reactive.
+- `::value` commits on `input` (every keystroke); `::checked` commits on `change`.
+- If you need custom write-back logic, use a one-way [`:value`](./template-syntax.md)
+  plus your own [`@input`/`@change`](./event-handling.md) handler instead.
+
+## Related
+
+- [Event handling](./event-handling.md).
+- [Reactivity fundamentals](./reactivity-fundamentals.md).
+- [Template syntax](./template-syntax.md) — one-way `:attr` bindings.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,104 @@
+# Introduction
+
+Lunas is a single-file-component web framework: a `.lunas` file bundles an
+`html:` template, an optional `style:` block, and a `script:` block, and a
+**Rust compiler** turns it into plain JavaScript that targets a **tiny,
+dependency-free runtime**.
+
+```lunas
+html:
+    <main>
+        <h1>${title}</h1>
+        <button @click="inc()">Count: ${count}</button>
+    </main>
+
+script:
+    let title = "Hello Lunas"
+    let count = 0
+    function inc() { count = count + 1 }
+```
+
+If you have used Svelte or Vue single-file components, this will feel familiar.
+The differences are in how it compiles and how it stays fast.
+
+## What Lunas is
+
+Lunas has two parts:
+
+- **A compiler** (Rust). It parses your component, works out exactly which
+  template parts depend on which reactive variables, and emits a small,
+  purpose-built JS module — no framework interpreter shipped to the browser.
+- **A runtime** (`lunas` on npm). A dependency-free ES2015 module. Its whole
+  reactive core is a handful of functions; only the ones your component uses are
+  imported, and it tree-shakes cleanly.
+
+There is **no virtual DOM**, no runtime dependency-tracking graph, and no
+per-node effect objects.
+
+## Why it is fast
+
+Two compounding sources of speed, both settled by cross-hardware benchmarks (see
+the [API reference](../api/) for the design contract):
+
+1. **Static DOM is built in bulk by the browser's native HTML parser.** The
+   compiler emits the static skeleton of your component as one contiguous
+   `innerHTML` string. Dynamic seams are excluded from that string and
+   represented as lightweight runtime anchors, so a mostly-static component is
+   essentially a single native parse. The static HTML is kept whitespace-free and
+   **comment-free** on purpose — a comment node drops Chromium's parser off its
+   fast path.
+2. **Dependencies are resolved at compile time.** Because the compiler already
+   knows which variables each dynamic part reads, runtime reactivity setup is
+   nearly free: just registering precomputed dependency indices. A write enqueues
+   exactly the affected update functions; a microtask flush runs only those. No
+   graph is discovered at runtime.
+
+The headline win is *fast initial render* (construction offloaded to the native
+parser) plus *near-zero reactivity setup*. Updates are targeted node mutations —
+`innerHTML` is never used to update, so DOM state, listeners, focus, and
+selection are preserved.
+
+## How it compares
+
+Lunas sits in the **compiler + small runtime** family alongside Svelte, and
+shares Vue 3's template ergonomics (`:attr`, `@event`, `:if`/`:for`, slots,
+`provide`/`inject`). The distinguishing choices:
+
+| | Lunas | Svelte 5 | Vue 3 |
+|---|---|---|---|
+| Reactivity | compile-time dependency dispatch (numbered vars) | signals/runes | signals + proxy tracking |
+| DOM construction | bulk `innerHTML` of a static skeleton | incremental DOM ops | virtual DOM |
+| Runtime tracking | none (deps known at compile time) | signal graph | proxy graph |
+| Reactive authoring | mutate a top-level `let` | `$state` / runes | `ref` / `reactive` |
+| Compatibility floor | ES2015 + `Proxy` | modern | modern |
+
+What makes a variable reactive in Lunas is simply **mutating a top-level `let`**
+in your script. You write ordinary JavaScript; the compiler wires the
+reactivity. See [Reactivity fundamentals](./reactivity-fundamentals.md).
+
+## Feature overview
+
+Everything below is documented in this guide:
+
+- [Template syntax](./template-syntax.md) — `${}` interpolation, `:attr`
+  bindings, `@event` handlers.
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — what makes state
+  reactive, the flush/microtask model.
+- [Computed values](./computed.md) — lazy, memoized derived state.
+- [Class and style bindings](./class-and-style.md) — `:class` / `:style`.
+- [Conditional rendering](./conditional-rendering.md) — `:if` / `:elseif` /
+  `:else`.
+- [List rendering](./list-rendering.md) — `:for` with keyed reconciliation.
+- [Event handling](./event-handling.md) — `@event` handlers and arguments.
+- [Forms & two-way binding](./forms-and-two-way.md) — `::value` / `::checked`.
+- [Watchers](./watchers.md) — `watch` / `watchEffect`.
+- [Template refs](./template-refs.md) — `:ref` for elements and components.
+- [Lifecycle](./lifecycle.md) — `onMount` / `onDestroy` / `onUpdate`.
+- [Raw HTML](./raw-html.md) — `:html` and its XSS caveat.
+
+Beyond the essentials, Lunas also ships [components & props](../components/),
+[built-ins](../built-ins/) (slots, teleport, keep-alive, transitions, dynamic
+components), and [scaling](../scaling/) features (stores, router, provide/inject,
+async components). See the [API reference](../api/) for the runtime surface.
+
+Ready to build something? Head to the [Quick start](./quick-start.md).

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -1,0 +1,100 @@
+# Lifecycle
+
+Lifecycle hooks let you run code at defined moments in a component's life:
+after it mounts, when it is destroyed, and after each update. They are runtime
+helpers imported from `lunas`.
+
+## The hooks
+
+```js
+import { onMount, onDestroy, onUpdate } from "lunas";
+```
+
+- **`onMount(c, fn)`** — runs `fn` after the component's root is attached to a
+  live tree. Fires once.
+- **`onDestroy(c, fn)`** — runs `fn` when the component is torn down (unmounted).
+  Fires exactly once.
+- **`onUpdate(c, fn)`** — runs `fn` after each [flush](./reactivity-fundamentals.md)
+  of this component that actually ran updates.
+
+Two more exist for [keep-alive](../built-ins/) cached components:
+`onActivated(c, fn)` and `onDeactivated(c, fn)` fire when a cached instance is
+re-activated or deactivated (rather than destroyed).
+
+## When onMount fires — the attach contract
+
+This is the key detail. A component factory returns a **detached** root; the
+*caller* attaches it (that's what [`attach`](./quick-start.md) does at the app
+root, and what mounting a child does internally). So `onMount` cannot fire at
+construction — it is queued and drained the moment the root becomes part of a
+live tree:
+
+```js
+import { attach } from "lunas";
+import App from "./App.lunas";
+
+attach(App(), document.getElementById("app"));
+// ↑ appends the root AND fires the whole subtree's onMount callbacks
+```
+
+A single top-level `attach` fires `onMount` for the root **and every child**
+mounted during setup, because children register with their parent. If you
+register `onMount` after the component is already live, `fn` still runs (on the
+next microtask), so you always observe a mounted, painted tree.
+
+Because of this, `onMount` is the right place for anything that needs the element
+to be **in the document**: focus, layout measurement, scroll position, or
+starting a subscription that touches the DOM.
+
+```js
+import { onMount, onDestroy } from "lunas";
+
+let field;                         // a :ref
+onMount(c, () => { field.focus(); });
+```
+
+## Cleanup patterns
+
+Pair every subscription, timer, or listener started in `onMount` with teardown in
+`onDestroy`. `onDestroy` fires on **every** unmount path — a child unmounting, a
+`:if` branch hiding, a `:for` item leaving, or keep-alive eviction — and fires
+exactly once:
+
+```js
+import { onMount, onDestroy } from "lunas";
+
+let id;
+onMount(c, () => { id = setInterval(tick, 1000); });
+onDestroy(c, () => { clearInterval(id); });
+```
+
+For effects that respond to reactive changes rather than mount timing, prefer a
+[watcher](./watchers.md) — watchers created in a control-flow block are torn down
+automatically with that block.
+
+## onUpdate
+
+`onUpdate` runs after any flush that ran updates for this component. Use it
+sparingly — for syncing to something the DOM update implies (e.g. reflecting
+final layout after content changed). It does **not** run on the initial mount
+(that's what `onMount` is for), only after subsequent update passes.
+
+```js
+import { onUpdate } from "lunas";
+onUpdate(c, () => { /* runs after each update flush */ });
+```
+
+## Ordering summary
+
+1. Component setup runs (script executes, bindings wired) — off-DOM.
+2. Caller attaches the root → `onMount` fires (children first, then parent).
+3. State changes → flush → DOM updated → `onUpdate` fires.
+4. Component unmounted → `onDestroy` fires once.
+
+## Related
+
+- [Template refs](./template-refs.md) — read refs inside `onMount`.
+- [Watchers](./watchers.md) — change-driven effects with automatic teardown.
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — the flush that drives
+  `onUpdate`.
+- Keep-alive activation hooks: [built-ins](../built-ins/).

--- a/docs/guide/list-rendering.md
+++ b/docs/guide/list-rendering.md
@@ -1,0 +1,126 @@
+# List rendering
+
+`:for` renders an element once per item of an iterable. Like `:if`, it is an
+attribute on the element that becomes the repeated body.
+
+## Basic `:for`
+
+```lunas
+html:
+    <ul>
+        <li :for="n of history">Was ${n}</li>
+    </ul>
+
+script:
+    let history = [1, 2, 3]
+```
+
+The value of `:for` is a JavaScript **for-loop header** — the part inside
+`for(...)`. The common form is `item of items`, but the header is real
+destructuring/iteration syntax:
+
+```lunas
+<li :for="item of items">${item.label}</li>
+<li :for="tag of group.tags">${tag}</li>
+```
+
+The loop binding (`item`, `tag`, …) **shadows** your reactive variables inside
+the item, so `item.label` is read directly — it is item-local data, not a
+top-level box.
+
+## Keys
+
+Add `:key` to give each item a stable identity. This is what lets Lunas move
+existing DOM nodes on update instead of rebuilding them:
+
+```lunas
+html:
+    <ul>
+        <li :for="item of items" :key="item.id">
+            ${item.label}
+        </li>
+    </ul>
+
+script:
+    let items = [{ id: 1, label: "a" }, { id: 2, label: "b" }]
+    function add() { items.push({ id: items.length + 1, label: "n" }) }
+```
+
+Use a key that is **stable and unique per item** (an `id`, or the item itself for
+primitives). Duplicate keys are reported via a warning hook. Without `:key`,
+items fall back to identity by value.
+
+## How rendering works
+
+Lunas splits the initial render from updates for speed:
+
+- **Initial render — one bulk parse.** Every item's static skeleton is
+  concatenated into a **single `innerHTML`** string and parsed once, then each
+  item's dynamic parts are wired. A 1,000-row list is essentially one native
+  parse, not 1,000 element constructions.
+- **Updates — keyed diff, node identity preserved.** On update the reconciler
+  compares keys and applies the minimal set of insert / remove / **move**
+  operations. Existing items keep their DOM nodes (and their listeners, focus,
+  and input state); only their changed data cells re-run. Moves are minimized
+  using a longest-increasing-subsequence (LIS) diff, so reordering touches as few
+  nodes as possible.
+- **Updates never call `innerHTML`.** Re-parsing would destroy node state; the
+  bulk parse is the initial-render fast path only.
+
+You don't call any of this — writing to the array (`items.push(…)`,
+`items = [...]`) triggers the diff on the next flush.
+
+### How it compiles
+
+```js
+// <li :for="item of items" :key="item.id">${item.label}</li>
+forBlock(c, a0, [0], () => Array.from((items.v) || []), {
+  html: HTML_1,                 // the item skeleton, hoisted
+  wire: (r0, d0) => { let item = d0; /* bind item.label, listeners */ },
+  keyOf: (d0) => d0.id,
+});
+```
+
+The iterable is evaluated in the outer scope (reactive on `items`); each item is
+wired from its data cell `d0`, with the loop variable bound to it.
+
+## Nested lists
+
+Lists nest by element nesting; each inner list is per-item and tears down with
+its item:
+
+```lunas
+html:
+    <ul>
+        <li :for="group of groups" :key="group.id">
+            <b>${group.name}</b>
+            <ol>
+                <li :for="tag of group.tags" :key="tag">${tag}</li>
+            </ol>
+        </li>
+    </ul>
+```
+
+When an outer item's data changes, its whole subtree — including nested `:for`
+and `:if` blocks — re-evaluates against the fresh data.
+
+## `:for` + `:if` on one element
+
+An element may carry both `:for` and `:if`. The `:for` is the **outer** block and
+`:if` the **inner** condition: the list iterates, and each item is conditionally
+rendered.
+
+```lunas
+<li :for="item of items" :if="item.visible" :key="item.id">${item.label}</li>
+```
+
+If you want to filter *which* items render at all (rather than render-then-hide),
+filter the source array in script or a [computed](./computed.md) value instead —
+that keeps keys and the diff tidy.
+
+## Related
+
+- [Conditional rendering](./conditional-rendering.md) — `:if` details.
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — array mutation vs
+  reassignment both trigger updates.
+- Rendering a list of child components: [components](../components/).

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,0 +1,118 @@
+# Quick start
+
+The fastest way to a running Lunas app is the `create-lunas` scaffolder, which
+sets up a [Vite](https://vitejs.dev) project wired to `vite-plugin-lunas`.
+
+## Scaffold a project
+
+```sh
+npm create lunas@latest my-app
+# or, to be prompted for a project name:
+npm create lunas@latest
+```
+
+Then:
+
+```sh
+cd my-app
+npm install
+npm run dev
+```
+
+You get a minimal Vite app:
+
+- `index.html` + `src/main.mjs` — mounts the app into `#app`.
+- `src/App.lunas` — a root component with reactive state, an event handler, and
+  `:if` / `:for` in the template.
+- `vite.config.mjs` — the Lunas Vite plugin.
+
+## Add Lunas to an existing Vite project
+
+If you already have a Vite project, install the plugin and the runtime:
+
+```sh
+npm install -D vite-plugin-lunas
+npm install lunas
+```
+
+`vite` is a peer dependency (`>=5`). Register the plugin:
+
+```js
+// vite.config.mjs
+import { defineConfig } from "vite";
+import lunas from "vite-plugin-lunas";
+
+export default defineConfig({
+  plugins: [lunas()],
+});
+```
+
+The plugin compiles `.lunas` and `.lun` files into ES modules. Compiler
+**errors** abort the build with a file/line/column code frame; **warnings** and
+**hints** are surfaced but don't stop the build.
+
+## Your first component
+
+A `.lunas` file has up to three blocks, each introduced by a label at column 0:
+
+```lunas
+html:
+    <main class="app">
+        <h1>Lunas Counter</h1>
+        <p>Count: ${count}</p>
+        <button @click="increment()">+1</button>
+        <button @click="reset()">Reset</button>
+        <ul>
+            <li :for="n of history">Was ${n}</li>
+        </ul>
+    </main>
+
+style:
+    .app { font-family: sans-serif; max-width: 40rem; margin: 2rem auto; }
+    button { margin-right: 0.5rem; }
+
+script:
+    let count = 0
+    let history = []
+    function increment() {
+        history = [...history, count]
+        count = count + 1
+    }
+    function reset() {
+        count = 0
+        history = []
+    }
+```
+
+- `html:` — the template. `${count}` interpolates a value; `@click="increment()"`
+  wires an event; `:for` renders a list. See [Template syntax](./template-syntax.md).
+- `style:` — plain CSS (optional).
+- `script:` — plain JavaScript (or TypeScript). Mutating a top-level `let` makes
+  it reactive; that's all the reactivity setup there is. See
+  [Reactivity fundamentals](./reactivity-fundamentals.md).
+
+## Mounting
+
+A compiled component's **default export is a factory function**. Call it (with
+props, if any) to build a *detached* root, then `attach` it to a live host
+element:
+
+```js
+// src/main.mjs
+import { attach } from "lunas";
+import App from "./App.lunas";
+
+// App() builds a detached root; attach() inserts it and fires onMount.
+attach(App(), document.getElementById("app"));
+```
+
+`attach(root, host)` appends the root to the host and fires the whole subtree's
+[`onMount`](./lifecycle.md) callbacks. The component is built off-DOM and touches
+the live tree exactly once — this is a core part of what makes the initial render
+fast.
+
+## What next
+
+- Learn the [template syntax](./template-syntax.md) in full.
+- Understand [reactivity](./reactivity-fundamentals.md) and the flush model.
+- Explore [components & props](../components/) to split your UI into pieces.

--- a/docs/guide/raw-html.md
+++ b/docs/guide/raw-html.md
@@ -1,0 +1,70 @@
+# Raw HTML
+
+`:html` sets an element's inner HTML from an expression. Use it to render
+pre-formatted or server-provided markup that you can't express with the template.
+
+```lunas
+html:
+    <article :html="markup"></article>
+    <button @click="fill()">fill</button>
+
+script:
+    let markup = "<b>bold</b>"
+    function fill() { markup = "<i>italic</i>" }
+```
+
+The value is inserted as HTML (both initially and reactively when it changes).
+
+## How it compiles
+
+`:html="markup"` compiles to an `innerHTML` assignment wrapped in a reactive
+bind:
+
+```js
+bind(c, [/* deps of markup */], () => { e0.innerHTML = markup.v; });
+```
+
+## XSS caveat — read this
+
+**The value is inserted verbatim.** Any markup — including `<script>`, event-
+handler attributes, and `<img onerror=…>` — is parsed and can execute. **Never
+bind untrusted input** (user content, URL parameters, API responses you don't
+control) through `:html`. Sanitize it first, or render it as text with
+[`${...}`](./template-syntax.md), which escapes automatically.
+
+```lunas
+<!-- SAFE: text is escaped -->
+<p>${userInput}</p>
+
+<!-- DANGEROUS: only for markup you fully trust -->
+<article :html="trustedMarkup"></article>
+```
+
+If you must render user-supplied HTML, run it through a sanitizer (e.g. a
+DOMPurify-style library) in script before binding it.
+
+## Children are overwritten
+
+`:html` **replaces** the element's children. Putting both static children and
+`:html` on the same element is a conflict — the compiler emits a warning, and the
+`:html` value wins (the static children are overwritten at runtime):
+
+```lunas
+<!-- Warns: the "keep me" content is overwritten by markup -->
+<div :html="markup">keep me</div>
+```
+
+Give the raw-HTML value its own dedicated element with no static children.
+
+## Notes
+
+- Reserved bound names `:innerHtml` and `:textContent` are **rejected** by the
+  compiler — `:html` is the supported way to set inner HTML.
+- Setting HTML re-parses the fragment on each change, replacing prior nodes; any
+  DOM state inside the previous markup (focus, listeners you attached manually) is
+  discarded. Prefer declarative template constructs where you can.
+
+## Related
+
+- [Template syntax](./template-syntax.md) — `${...}` for escaped text.
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — how the bind updates.

--- a/docs/guide/reactivity-fundamentals.md
+++ b/docs/guide/reactivity-fundamentals.md
@@ -1,0 +1,125 @@
+# Reactivity fundamentals
+
+Lunas reactivity is designed to feel invisible: you write ordinary JavaScript in
+`script:`, and mutating a top-level variable updates the DOM. There is no
+`ref()`, no `$state`, no wrapper to remember. This page explains what actually
+makes a variable reactive and how updates are scheduled.
+
+## What makes a variable reactive
+
+A top-level `let` that is **mutated** somewhere in your script is reactive:
+
+```lunas
+html:
+    <p>${count}</p>
+    <button @click="inc()">+1</button>
+
+script:
+    let count = 0            // reactive: reassigned in inc()
+    function inc() { count = count + 1 }
+```
+
+The rules the compiler applies:
+
+- A `let` that is **reassigned** (`count = …`, `count++`) is reactive.
+- A `let`/`const` that is **deeply mutated** (`arr.push(…)`, `obj.k = …`) is
+  reactive.
+- A variable that is never mutated is treated as a constant — template reads of
+  it are assigned once at build time with no update binding. (A `const` you only
+  read is the common case.)
+
+You don't annotate any of this; the compiler analyzes your script and decides.
+
+## How it works under the hood
+
+Each reactive variable is assigned a compile-time **index** (0, 1, 2, …) and
+wrapped in a *box*. In the compiled output your `let count = 0` becomes:
+
+```js
+const count = box(c, 0, 0);   // reactive index 0, initial value 0
+```
+
+and every read/write of `count` in your code is rewritten to go through the box
+(`count.v`). You never write `.v` yourself — that's the compiler's job.
+
+Crucially, the compiler also knows **which template parts read which indices**.
+Each dynamic part is registered with the exact set of indices it depends on:
+
+```js
+bind(c, [0], () => { t0.data = `${count.v}`; });  // depends on index 0
+```
+
+A write to a box marks its index dirty and enqueues exactly the update functions
+registered for that index. **There is no runtime dependency discovery** — the
+whole graph is known at compile time, so reactivity setup is near-free and an
+update touches neither unrelated static DOM nor unrelated dynamic parts.
+
+### box vs deepBox
+
+The compiler picks the box kind per variable:
+
+| Your code | Box | Cost |
+|---|---|---|
+| Reassigned only (`x = …`, `x++`) | `box` — plain getter/setter | lightest, no Proxy |
+| Deeply mutated (`arr.push`, `obj.k = …`) | `deepBox` — Proxy that notifies on nested mutation | Proxy only where needed |
+
+So you can mutate an object or array in place and the DOM stays in sync:
+
+```lunas
+html:
+    <p>${o.k}</p>
+    <button @click="add()">set</button>
+
+script:
+    let o = {}                 // deeply mutated -> deepBox
+    function add() { o.k = 1 }  // nested set notifies index for `o`
+```
+
+`deepBox` wraps nested objects lazily through a `Proxy`, caching wrappers so
+object identity stays stable. Mutating array methods (`push`, `splice`, …) work
+because they run with the proxy as `this`.
+
+> **Reassign vs mutate.** Both work. `items = [...items, x]` (reassign) and
+> `items.push(x)` (deep mutate) both trigger updates — the compiler picks `box`
+> for the first pattern and `deepBox` for the second.
+
+## The flush model
+
+Writes do **not** update the DOM synchronously. Instead:
+
+1. A write marks the variable's index dirty and enqueues its dependent update
+   functions (deduplicated — an update queued twice runs once).
+2. A **microtask flush** is scheduled (via `queueMicrotask`).
+3. On flush, only the queued update functions run, once each.
+
+This means **many synchronous writes coalesce into one update pass**:
+
+```js
+function inc() {
+    count = count + 1     // enqueues the count binding
+    total = total + 1     // enqueues the total binding
+    // both flush together on the next microtask — one DOM update pass
+}
+```
+
+The first paint needs no flush: each binding runs once at wiring time, so the
+initial render is correct immediately.
+
+### Observing updates deterministically
+
+Two helpers from the runtime let you cross the flush boundary when you need to:
+
+- `await nextTick(c)` — resolves *after* the next flush, when the DOM reflects
+  your latest writes.
+- `batch(c, fn)` — run `fn`, then flush **synchronously**, so a group of writes
+  is applied before `batch` returns. Nested batches flush once, at the outermost
+  call.
+
+These are advanced tools; most components never need them. (`c` is the component
+context; see the [API reference](../api/) for how to obtain it.)
+
+## Related
+
+- [Computed values](./computed.md) — lazy, memoized derived state.
+- [Watchers](./watchers.md) — run side effects when state changes.
+- [Template syntax](./template-syntax.md) — where reactive reads appear.

--- a/docs/guide/template-refs.md
+++ b/docs/guide/template-refs.md
@@ -1,0 +1,87 @@
+# Template refs
+
+`:ref` exposes a DOM element — or a mounted component instance — to your script,
+so you can reach it imperatively (focus an input, measure a node, call a child's
+method).
+
+## Referencing an element
+
+Declare a `let` for the ref and bind it with `:ref`:
+
+```lunas
+html:
+    <div>
+        <input :ref="field">
+        <button @click="fill()">fill</button>
+    </div>
+
+script:
+    let field
+    function fill() {
+        field.value = "typed"
+        field.focus()
+    }
+```
+
+At wire time, `field` is assigned the element. Because the ref is assigned to a
+top-level variable, it becomes reactive — the compiler numbers it like any other
+reactive variable, so template parts that read it react if it changes.
+
+### How it compiles
+
+`:ref="field"` assigns the element into the ref's box during wiring:
+
+```js
+field.v = e0;   // `field` is a reactive box; the ref makes it reactive
+```
+
+Declare the variable with a bare `let field` (no initializer); the `:ref`
+assignment is what makes it reactive, so the resolver numbers it.
+
+## Referencing a component
+
+`:ref` on a component tag exposes the child's **mount handle** rather than a DOM
+node:
+
+```lunas
+html:
+    <Child :ref="childHandle" />
+
+script:
+    let childHandle
+    // childHandle exposes the mounted child instance (its handle)
+```
+
+Through the handle you can drive the child imperatively (for example pushing a
+prop or unmounting it), per the [component](../components/) mount contract.
+
+## When the ref is available
+
+The ref is assigned during **wiring**, before the component attaches to the live
+DOM. If you need the element to be *in the document* (for layout measurement,
+focus, or scroll), read the ref inside [`onMount`](./lifecycle.md):
+
+```js
+import { onMount } from "lunas";
+
+let field;
+onMount(c, () => { field.focus(); });   // element is live here
+```
+
+Reading a ref at the top level of `script:` (during setup) is too early — the
+node exists but is not yet attached.
+
+## Notes
+
+- Give each ref its own variable; a ref inside a [`:for`](./list-rendering.md)
+  item is per-item and follows the item's lifetime.
+- A ref to an element in an [`:if`](./conditional-rendering.md) branch is only
+  meaningful while the branch is shown; when the branch is hidden the node is
+  removed.
+
+## Related
+
+- [Lifecycle](./lifecycle.md) — when the element is live.
+- [Event handling](./event-handling.md) — often you can avoid a ref by handling
+  events declaratively.
+- [Components](../components/) — component instance handles.

--- a/docs/guide/template-syntax.md
+++ b/docs/guide/template-syntax.md
@@ -1,0 +1,146 @@
+# Template syntax
+
+A Lunas template is HTML with a small binding overlay. Bindings live in one of
+two places: **`${...}` interpolations** inside text and attribute values, or
+**prefixed attribute keys** (`:`, `::`, `@`, plus the control-flow attributes
+`:if` / `:elseif` / `:else` / `:for`).
+
+## Text interpolation
+
+`${ expr }` embeds a JavaScript expression in text:
+
+```lunas
+html:
+    <p>Count: ${count}</p>
+    <button>${interval == null ? "Start" : "Stop"}</button>
+
+script:
+    let count = 0
+    let interval = null
+```
+
+- The expression is arbitrary JavaScript: member access, ternaries, calls,
+  string literals, and object literals all work. The scanner is brace- and
+  string-balanced, so `${ {a:1}.a }` and `${ f("}") }` terminate correctly.
+- Multiple interpolations per text run are allowed; each becomes its own binding,
+  and static text between them is preserved verbatim.
+- An interpolation whose expression reads **no reactive variable** is assigned
+  once at build time — no update binding is created for it.
+
+### How it compiles
+
+A reactive text run compiles to a single dynamic text node updated by a `bind`.
+`<p>count: ${count}!</p>` becomes a static `<p></p>` plus:
+
+```js
+bind(c, [0], () => { t0.data = `count: ${count.v}!`; });
+```
+
+The literal parts (`count: ` and `!`) live in the dynamic text node, not the
+static HTML, so the whole run is one node updated as one template literal.
+
+## Attribute bindings
+
+A `:`-prefixed attribute means "the value is a JavaScript expression, bind it
+reactively":
+
+```lunas
+html:
+    <h1 :title="label">${greeting}</h1>
+    <div :class="isActive ? 'on' : 'off'"></div>
+
+script:
+    let label = "the heading"
+    let greeting = "hello"
+    let isActive = true
+```
+
+The reserved names `:innerHtml` and `:textContent` are rejected — use
+[`:html`](./raw-html.md) for raw markup.
+
+### Property vs attribute, and boolean attributes
+
+The compiler picks the fastest write per attribute:
+
+- **Known DOM properties** are set as properties. `:value="name"` compiles to
+  `e0.value = name.v` rather than `setAttribute`.
+- **Boolean attributes** are set as truthy properties:
+  `:disabled="locked"` compiles to `e0.disabled = !!(locked.v)`.
+- **Everything else** uses `setAttribute`: `:title="label"` compiles to
+  `e0.setAttribute("title", label.v)`.
+
+Each of these is wrapped in a `bind` on the expression's reactive dependencies,
+so it re-runs only when a dependency changes.
+
+## Interpolation inside static attributes
+
+A plain (unprefixed) attribute value may itself contain `${...}`:
+
+```lunas
+html:
+    <div class="tag ${flavor} end"></div>
+    <section class="card ${tone}"></section>
+```
+
+This compiles to a reactive attribute write built from a template literal:
+
+```js
+bind(c, [0], () => { e0.setAttribute("class", `tag ${flavor.v} end`); });
+```
+
+Interpolation is recognized in attribute **values** only (not in attribute
+names). For richer class/style logic, prefer [`:class` / `:style`](./class-and-style.md).
+
+## Event handlers
+
+An `@`-prefixed attribute wires a DOM event listener. See
+[Event handling](./event-handling.md) for the full story.
+
+```lunas
+html:
+    <button @click="inc()">bump</button>
+    <input @keydown="onKey" />
+
+script:
+    let n = 0
+    function inc() { n++ }
+    function onKey(e) { if (e.key == "Enter") { /* … */ } }
+```
+
+`@click="inc()"` compiles to `on(e0, "click", () => { inc(); })`; a bare
+reference like `@keydown="onKey"` is used as the handler directly.
+
+## Two-way binding
+
+A `::`-prefixed attribute is sugar for a value binding **plus** a write-back
+listener. `::value="name"` is `:value="name"` combined with an `input` listener
+that writes `name = el.value`. See [Forms & two-way binding](./forms-and-two-way.md).
+
+## Expressions allowed
+
+Anywhere a binding takes an expression (`${...}`, `:attr`, `@event`, `:if`,
+etc.), you may use any JavaScript expression: identifiers, member access, calls,
+ternaries, logical/comparison operators, template and object/array literals.
+Reactive dependencies are detected by the compiler — a reactive `let` you *read*
+inside an expression becomes a dependency of that binding, so the binding re-runs
+when it changes.
+
+## Directive summary
+
+| Form | Example | Value is | Notes |
+|---|---|---|---|
+| Interpolation | `${count}` | JS expression | in text & attribute values |
+| Attribute bind | `:class="x?'a':'b'"` | JS expression | `:innerHtml`/`:textContent` rejected |
+| Two-way | `::value="title"` | JS lvalue | `:value` + `@input` write-back |
+| Event | `@click="toggle()"` | JS handler/expression | |
+| Raw HTML | `:html="markup"` | JS expression | overwrites children; [XSS caveat](./raw-html.md) |
+| Ref | `:ref="field"` | binding name | [template refs](./template-refs.md) |
+| If chain | `:if` / `:elseif` / `:else` | JS condition (`:else` none) | [conditional rendering](./conditional-rendering.md) |
+| For | `:for="x of xs"` | for-loop header | [list rendering](./list-rendering.md) |
+
+## Related
+
+- [Reactivity fundamentals](./reactivity-fundamentals.md)
+- [Class and style bindings](./class-and-style.md)
+- [Conditional rendering](./conditional-rendering.md) ·
+  [List rendering](./list-rendering.md)

--- a/docs/guide/watchers.md
+++ b/docs/guide/watchers.md
@@ -1,0 +1,92 @@
+# Watchers
+
+A watcher runs a **side effect** in response to reactive state changing — logging,
+persisting to storage, kicking off a fetch, imperative DOM work. Where a
+[computed](./computed.md) value is pull-based and produces a value, a watcher is
+push-based and produces an effect.
+
+Watchers are runtime helpers, `watch` and `watchEffect`, imported from `lunas`.
+
+## `watch`
+
+`watch(c, deps, cb, opts?)` runs `cb` **after** any of its dependencies changes.
+By default the first (synchronous) run is suppressed, so the callback fires only
+on subsequent changes:
+
+```js
+import { watch } from "lunas";
+
+// runs when `count` changes (deps are the reactive indices it reads)
+watch(c, [countIdx], () => {
+  console.log("count is now", count.v);
+});
+```
+
+### `immediate`
+
+Pass `{ immediate: true }` to also invoke the callback once at registration time:
+
+```js
+watch(c, [countIdx], () => {
+  localStorage.setItem("count", String(count.v));
+}, { immediate: true });   // also persists the initial value
+```
+
+### Stopping and cleanup
+
+`watch` returns a `stop()` handle that unregisters the watcher:
+
+```js
+const stop = watch(c, [countIdx], () => { /* … */ });
+// later:
+stop();
+```
+
+Watchers are also **scope-aware**: a watcher created inside a control-flow block
+(a `:if` branch, a `:for` item) is torn down automatically when that content is
+removed. You get cleanup for free in the common case, and `stop()` for explicit
+control.
+
+## `watchEffect`
+
+`watchEffect(c, deps, fn)` runs `fn` **immediately** and again after any
+dependency changes — with no distinction between the initial and later runs. It
+is the effect-style shorthand for a watcher that always runs on registration:
+
+```js
+import { watchEffect } from "lunas";
+
+watchEffect(c, [widthIdx, heightIdx], () => {
+  canvas.width = width.v;
+  canvas.height = height.v;
+});
+```
+
+Like `watch`, it returns a `stop()` and is collected by the current scope.
+
+> `watchEffect(c, deps, fn)` is equivalent to
+> `watch(c, deps, fn, { immediate: true })` with the effect naming.
+
+## When to use a watcher vs computed
+
+| Use `computed` when… | Use `watch` / `watchEffect` when… |
+|---|---|
+| you need a **derived value** to render or read | you need to **do something** (I/O, logging, imperative DOM) |
+| the result is pure and cacheable | the effect is impure or asynchronous |
+| readers should pull lazily | you want to react eagerly to a change |
+
+Rule of thumb: if the output is a value you display, reach for
+[`computed`](./computed.md); if the output is an action, reach for a watcher.
+
+## Timing
+
+Watcher callbacks run as part of the reactive [flush](./reactivity-fundamentals.md)
+after their dependencies change, so they observe the batched, post-write state.
+Multiple writes in one tick coalesce, so a watcher runs once per flush, not once
+per write.
+
+## Related
+
+- [Computed values](./computed.md).
+- [Reactivity fundamentals](./reactivity-fundamentals.md) — the flush model.
+- [Lifecycle](./lifecycle.md) — `onMount` / `onDestroy` for mount-tied effects.


### PR DESCRIPTION
## Summary

Adds the **ESSENTIALS GUIDE** section of the Lunas documentation under
`docs/guide/` — Vue-guide-inspired, Svelte-tutorial-clear, example-first.
Only `docs/guide/` is touched (no code, tests, or other docs dirs), so there
are zero conflicts with parallel doc/feature work.

## Pages (14)

- `introduction.md` — what Lunas is (compiler + tiny runtime, bulk `innerHTML`
  construction, compile-time dependency dispatch, no VDOM), why it's fast, how
  it compares to Svelte/Vue, feature overview with links.
- `quick-start.md` — `create-lunas` scaffold / adding `vite-plugin-lunas`, a
  first `.lunas` component, mounting with `attach`.
- `template-syntax.md` — `${}`, `:attr` (property/boolean/attribute),
  static-attr interpolation, `@event`, allowed expressions.
- `reactivity-fundamentals.md` — what makes a var reactive (mutated top-level
  `let`), `box` vs `deepBox`, the microtask flush model.
- `computed.md` — laziness + memoization semantics.
- `class-and-style.md` — `:class`/`:style` shapes and static merge.
- `conditional-rendering.md` — `:if`/`:elseif`/`:else`, build-on-show, nesting.
- `list-rendering.md` — `:for`, `:key`, bulk initial render + keyed LIS diff,
  nesting, `:for`+`:if`.
- `event-handling.md` — inline vs method handlers, arguments, how writes drive
  updates.
- `forms-and-two-way.md` — `::value` (input) / `::checked` (change), write-back.
- `watchers.md` — `watch`/`watchEffect`, `immediate`, cleanup, vs computed.
- `template-refs.md` — `:ref` for elements and component handles.
- `lifecycle.md` — `onMount`/`onDestroy`/`onUpdate` (+ keep-alive hooks), the
  attach-driven mount contract, cleanup patterns.
- `raw-html.md` — `:html`, XSS caveat, children-overwrite warning.

## Accuracy

Every example and "how it compiles" note was checked against:
`crates/lunas_compiler/docs/output-design.md` (§3/§5/§6), the `.lunas` test
fixtures, the emit snapshots in `crates/lunas_compiler/tests/codegen_emit.rs`,
and the `lunas` runtime source + JSDoc/`.d.ts`.

Does **not** touch `roadmap.yml`, `docs/README.md`, or anything outside
`docs/guide/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)