### PR TITLE
docs(api): full API reference + docs index + architecture overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,95 @@
+# Lunas Documentation
+
+**Lunas** is a single-file-component web front-end framework with a Vue-parity
+feature set. A `.lunas` file bundles an `html:` template, a `style:` block, and a
+`script:` block (TypeScript or JavaScript); the Lunas compiler (written in Rust)
+turns it into plain JavaScript plus a tiny, dependency-free runtime.
+
+Lunas is fast at initial render because the static DOM is built by the browser's
+native parser in bulk (`innerHTML`), dynamic parts are represented as lightweight
+runtime anchors, and reactive dependencies are resolved **at compile time** — no
+virtual DOM, no runtime dependency graph. The [architecture overview](./architecture.md)
+explains how the pieces fit together end to end.
+
+> **Status.** The runtime and the compiler front end are in active development on
+> the `rewrite/beta-11` branch. **Server-side rendering (SSR) and hydration are
+> planned but deferred** — the compiled output is designed for them (the static
+> HTML string is exactly what a server would emit, and anchors are created at
+> runtime so hydration can reuse the client wiring path), but the SSR codegen mode
+> is not implemented yet.
+
+---
+
+## Guide
+
+Conceptual, tutorial-style pages — start here.
+
+- [Introduction](./guide/introduction.md)
+- [Quick start](./guide/quick-start.md)
+- [Template syntax](./guide/template-syntax.md)
+- [Reactivity fundamentals](./guide/reactivity-fundamentals.md)
+- [Computed values](./guide/computed.md)
+- [Class and style bindings](./guide/class-and-style.md)
+- [Conditional rendering](./guide/conditional-rendering.md)
+- [List rendering](./guide/list-rendering.md)
+- [Event handling](./guide/event-handling.md)
+- [Forms and two-way binding](./guide/forms-and-two-way.md)
+- [Watchers](./guide/watchers.md)
+- [Template refs](./guide/template-refs.md)
+- [Lifecycle](./guide/lifecycle.md)
+- [Raw HTML](./guide/raw-html.md)
+
+## Components
+
+- [Registration](./components/registration.md)
+- [Props](./components/props.md)
+- [Events](./components/events.md)
+- [Slots](./components/slots.md)
+- [Provide / inject](./components/provide-inject.md)
+- [Dynamic components](./components/dynamic-components.md)
+- [Async components](./components/async-components.md)
+- [Fragments](./components/fragments.md)
+
+## Built-ins
+
+- [Teleport](./built-ins/teleport.md)
+- [Transition](./built-ins/transition.md)
+- [Keep-alive](./built-ins/keep-alive.md)
+- [Suspense](./built-ins/suspense.md)
+
+## Scaling up
+
+- [Routing](./scaling/routing.md)
+- [State management](./scaling/state-management.md)
+- [Scoped CSS](./scaling/scoped-css.md)
+- [SSR](./scaling/ssr.md) *(planned / deferred)*
+- [Tooling](./scaling/tooling.md)
+
+## API reference
+
+Per-symbol reference for the runtime's public surface (signatures, parameters,
+returns, examples, notes). These are the primitives the compiler emits calls into.
+
+- [Reactivity](./api/reactivity.md) — `box`, `deepBox`, `shared`, `computed`,
+  `watch`, `watchEffect`, `batch`, `nextTick`, `afterFlush`, and the low-level
+  core (`bind`, `markVar`, `flush`, scopes).
+- [Component](./api/component.md) — `component`, `refs`, `on`, `normClass`,
+  `normStyle`, `mountChild`.
+- [Blocks & control flow](./api/blocks-and-control-flow.md) — anchors, `ifBlock`,
+  `ifChain`, `forBlock`, `dynamicBlock`, `teleportBlock`, `slotBlock`,
+  `slotContent`.
+- [Router](./api/router.md) — `createRouter`, `routerOutlet`, `routerLink`,
+  `memoryHistory`, guards, and the route shape.
+- [Store](./api/store.md) — `createStore`, `useStore`, `subscribe`,
+  `derivedStore`.
+- [Async & suspense](./api/async.md) — `asyncComponent`, `mountAsyncChild`,
+  `suspenseBlock`.
+- [Lifecycle, events, DI, transitions & keep-alive](./api/lifecycle.md) —
+  `onMount`/`onDestroy`/`onUpdate`/`onActivated`/`onDeactivated`, `attach`,
+  `emit`/`eventPropName`, `provide`/`inject`/`hasInjection`, `withTransition`,
+  `keepAlive`.
+
+## Architecture
+
+- [Architecture overview](./architecture.md) — the compile pipeline, the runtime
+  model, and the benchmark-locked decisions behind them.

--- a/docs/api/async.md
+++ b/docs/api/async.md
@@ -1,0 +1,195 @@
+# Async Components & Suspense API
+
+Two cooperating primitives for lazy components and async boundaries,
+dependency-free (ES2015 + `Promise`) and tree-shakeable. See the
+[async components guide](../components/async-components.md) and the
+[suspense built-in](../built-ins/suspense.md) for the conceptual model.
+
+Import from the package root or the `lunas/async` subpath.
+
+---
+
+## `asyncComponent`
+
+### Signature
+
+```ts
+function asyncComponent<P = Record<string, unknown>>(
+  loader: AsyncLoader<P>,
+  opts?: AsyncComponentOptions<P>
+): ChildFactory<P>
+
+type AsyncModule<P> = ChildFactory<P> | { default: ChildFactory<P> }
+type AsyncLoader<P> = () => Promise<AsyncModule<P>> | AsyncModule<P>
+
+interface AsyncComponentOptions<P> {
+  loading?: ChildFactory<P>;                         // shown while pending, after `delay`
+  error?: ChildFactory<P & { error?: unknown }>;     // shown on reject/timeout
+  delay?: number;                                    // ms before showing loading (default 200)
+  timeout?: number;                                  // ms after which a pending load errors
+}
+```
+
+### Description
+
+Wraps a lazy module loader — `() => import("./Heavy.mjs")` or similar — into a
+mountable child factory obeying the [`mountChild`](./component.md#mountchild)
+contract. The module is resolved on first mount (a `default` export or a bare
+factory are both accepted) and **cached**, so later mounts build synchronously
+with no placeholder.
+
+Vue-style options: `loading` is shown only after `delay` ms (avoiding a flash for
+fast loads); `error` is shown on rejection or after `timeout`, receiving
+`{ error }` in props.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `loader` | `AsyncLoader<P>` | Returns a module/factory or a promise of one. |
+| `opts` | `AsyncComponentOptions<P>` | `loading` / `error` / `delay` / `timeout`. |
+
+### Returns
+
+`ChildFactory<P>` — mount it with [`mountAsyncChild`](#mountasyncchild) (which
+threads the context for suspense).
+
+### Example
+
+```js
+import { asyncComponent } from "lunas";
+
+const Heavy = asyncComponent(() => import("./Heavy.mjs"), {
+  loading: Spinner,
+  error: ErrorBox,
+  delay: 200,
+  timeout: 10000,
+});
+```
+
+### Notes
+
+- Mount with `mountAsyncChild`, not plain `mountChild`, so the load registers with
+  the nearest [`suspenseBlock`](#suspenseblock).
+
+---
+
+## `mountAsyncChild`
+
+### Signature
+
+```ts
+function mountAsyncChild<P = Record<string, unknown>>(
+  c: Context,
+  anchor: Node,
+  asyncFactory: ChildFactory<P>,
+  props?: P
+): MountedChild
+```
+
+### Description
+
+Mounts an async component factory (from [`asyncComponent`](#asynccomponent)) at a
+text anchor. Same contract as [`mountChild`](./component.md#mountchild), but it
+threads the component context so the async component can register with the nearest
+[`suspenseBlock`](#suspenseblock). Its `unmount()` cancels any in-flight load, so
+a late resolution writes no DOM.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor. |
+| `asyncFactory` | `ChildFactory<P>` | An `asyncComponent(...)` result. |
+| `props` | `P` | Seed props. |
+
+### Returns
+
+`MountedChild` — `{ root, unmount() }` (plus `ctx`/`setProp` at runtime, like
+`mountChild`).
+
+### Example
+
+```js
+import { anchorBefore, mountAsyncChild } from "lunas";
+const a = anchorBefore(placeholder);
+mountAsyncChild(c, a, Heavy);
+```
+
+### Notes
+
+- Each async mount owns a live token; `unmount()` flips it so a loader that
+  settles afterward writes no DOM and settles no boundary.
+
+---
+
+## `suspenseBlock`
+
+### Signature
+
+```ts
+function suspenseBlock(
+  c: Context,
+  anchor: Node,
+  contentFactory: (c: Context) => Node | Node[],
+  fallbackFactory?: () => Node | Node[]
+): SuspenseHandle
+
+interface SuspenseHandle {
+  isSettled(): boolean;
+  destroy(): void;
+}
+```
+
+### Description
+
+An async boundary at a text anchor. It builds the content **immediately** (so
+async children begin loading), but shows `fallback` until every async dep
+registered under it resolves, then reveals the content. The reveal is batched via
+[`afterFlush`](./reactivity.md#afterflush), so a fully synchronous subtree never
+flashes the fallback. Nested boundaries handle their own subtree — each async
+child registers with its nearest boundary and never leaks pending counts upward.
+
+The boundary publishes itself on the context as `c._suspense` for the duration of
+its content build; `mountAsyncChild` reads the *current* `c._suspense` and, if
+present, registers with it (bumping the pending counter while loading, settling on
+resolve/reject).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor. |
+| `contentFactory` | `(c) => Node \| Node[]` | Builds the real content (async kids start loading here). |
+| `fallbackFactory` | `() => Node \| Node[]` | Builds the fallback shown while pending. |
+
+### Returns
+
+`SuspenseHandle` — `{ isSettled(), destroy() }`. `isSettled()` reports whether the
+boundary has revealed its content; `destroy()` tears the boundary down, cancelling
+pending async children.
+
+### Example
+
+```js
+import { anchorBefore, suspenseBlock, mountAsyncChild } from "lunas";
+
+const a = anchorBefore(placeholder);
+suspenseBlock(
+  c, a,
+  (bc) => {
+    const host = document.createElement("div");
+    const anchor = anchorAppend(host);
+    mountAsyncChild(bc, anchor, Heavy);
+    return host;
+  },
+  () => document.createTextNode("Loading…")
+);
+```
+
+### Notes
+
+- The mount entry for the whole app subtree is [`attach`](./lifecycle.md#attach);
+  suspense boundaries reveal after their subtree's mount and settle passes.

--- a/docs/api/blocks-and-control-flow.md
+++ b/docs/api/blocks-and-control-flow.md
@@ -1,0 +1,469 @@
+# Blocks & Control Flow API
+
+Control-flow blocks are anchored at **permanent empty text nodes** (never
+comments — comments drop Blink off its fast-path parser). Each block collects the
+binds created inside its content into a *scope* and drops that scope when the
+content is removed, so removed content never receives updates and never leaks.
+
+See the guides on [conditional rendering](../guide/conditional-rendering.md) and
+[list rendering](../guide/list-rendering.md), and the built-ins on
+[teleport](../built-ins/teleport.md), for the conceptual model.
+
+Import from the package root or the `lunas/dom` and `lunas/blocks` subpaths.
+
+---
+
+## Anchor helpers
+
+Anchors are created at wiring time (after the static parse) so the static HTML
+stays comment-free. Each returns the created anchor text node.
+
+### `anchorBefore`
+
+```ts
+function anchorBefore(node: Node): Text
+```
+
+Creates a permanent empty text-node anchor immediately **before** an existing
+node.
+
+### `anchorBeforeSplit`
+
+```ts
+function anchorBeforeSplit(textNode: Text, utf16Offset: number): Text
+```
+
+Splits a static text node at the given UTF-16 offset and places the anchor
+between head and tail (the anchor sits **before** the tail). Used when a dynamic
+seam falls inside a text run.
+
+### `anchorAppend`
+
+```ts
+function anchorAppend(parent: Node): Text
+```
+
+Creates an anchor as the **last child** of `parent` (e.g. a `:for` slot at the
+end of a container).
+
+```js
+import { anchorBefore, anchorAppend } from "lunas";
+const ifAnchor  = anchorBefore(ul);      // an :if slot before <ul>
+const forAnchor = anchorAppend(ul);      // a :for slot inside <ul>
+```
+
+---
+
+## `ifBlock`
+
+### Signature
+
+```ts
+function ifBlock(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  cond: () => boolean,
+  make: () => BlockNodes
+): BlockHandle
+
+type BlockNodes = Node | Node[]
+interface BlockHandle { destroy(): void }
+```
+
+The runtime handle also exposes `update()` (re-evaluate now; used by `:for` item
+patching).
+
+### Description
+
+A single conditional block. When `cond()` becomes truthy, `make()` builds the
+branch (via its own `innerHTML`) and inserts it before the permanent `anchor`;
+when it becomes falsy, the branch's nodes are removed and its scope torn down.
+`make()` may return a single node (single-root branch) or an array of nodes
+(multi-root branch — the compiler knows which and emits accordingly).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor marking the slot. |
+| `deps` | `number[]` | Reactive indices the condition reads. |
+| `cond` | `() => boolean` | The condition. |
+| `make` | `() => BlockNodes` | Builds the branch content. |
+
+### Returns
+
+`BlockHandle` — `{ update(), destroy() }`.
+
+### Example
+
+```js
+ifBlock(c, anchor, [0], () => count.v > 0, () => {
+  const el = fromHTML(`<p>positive</p>`, anchor).childNodes[0];
+  return el;
+});
+```
+
+### Notes
+
+- For an `:if` / `:elseif` / `:else` cascade, the compiler emits a single
+  [`ifChain`](#ifchain) rather than nested `ifBlock`s.
+
+---
+
+## `ifChain`
+
+### Signature
+
+```ts
+function ifChain(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  which: () => number,
+  makes: Array<() => BlockNodes>
+): BlockHandle
+```
+
+### Description
+
+One `:if` / `:elseif` / `:else` cascade at a single permanent anchor. `which()`
+returns the index into `makes` of the branch to show, or `-1` for "no branch" (a
+cascade without `:else` whose conditions are all false). Exactly one branch is
+alive at a time; switching tears the old branch's scope down and builds the new
+one via its own `make`.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor. |
+| `deps` | `number[]` | Reactive indices the cascade's conditions read. |
+| `which` | `() => number` | Index of the branch to show, or `-1`. |
+| `makes` | `Array<() => BlockNodes>` | One builder per branch, in cascade order. |
+
+### Returns
+
+`BlockHandle` — `{ update(), destroy() }`.
+
+### Example
+
+```js
+ifChain(c, anchor, [0], () => (n.v < 0 ? 0 : n.v > 0 ? 1 : 2), [
+  () => neg(), () => pos(), () => zero(),
+]);
+```
+
+### Notes
+
+- `which()` is compiled from the cascade's conditions; the runtime never
+  re-evaluates individual conditions itself.
+
+---
+
+## `forBlock`
+
+### Signature
+
+```ts
+function forBlock<T = unknown>(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  items: () => T[],
+  opts: ForBlockOpts<T>
+): BlockHandle
+
+interface ForBlockOpts<T> {
+  make?(itemData: T, key: unknown, index: number): BlockNodes;
+  html?: string;
+  wire?(root: Node, itemData: T, index: number): ((d: T, i: number) => void) | void;
+  keyOf?: (itemData: T, i: number) => Key;
+  patch?(handle: unknown, itemData: T, i: number): void;
+  onWarn?(message: string): void;
+  seed?: ForSeed<T>;
+}
+```
+
+### Description
+
+A keyed list block. `items` is a closure returning the current array, read
+**lazily at flush time**. The compiler picks one of two item-construction modes:
+
+- **`make(itemData, key, index)`** — build one item, returning a node or node
+  array.
+- **Compiled mode (`html` + `wire`)** — `html` is the item's single-root static
+  skeleton. The **initial render** concatenates it N times into **one bulk
+  `innerHTML` parse**, then wires each item via `wire(root, d, i)`. On updates, a
+  new item parses its own copy. `wire` may return a patch closure `(d, i) => …`
+  that updates the item's data cell; after it runs, the item's whole scope is
+  re-run so every item-local bind (including nested block binds) sees new data.
+
+Updates go through the keyed [LIS reconciler](./reactivity.md) (`reconcile` from
+`for_diff`): prefix/suffix trimming, a key→index map, and a
+longest-increasing-subsequence pass minimize node moves. `innerHTML` is **never**
+used on update. `opts.keyOf` supplies the `:key` extractor (falls back to item
+identity/index); `opts.seed` skips the initial reconcile when items are already
+mounted from an external bulk render.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor marking the list slot. |
+| `deps` | `number[]` | Reactive indices the list expression reads. |
+| `items` | `() => T[]` | Lazily read current array. |
+| `opts` | `ForBlockOpts<T>` | Item construction, key, patch, warn, and seed hooks. |
+
+### Returns
+
+`BlockHandle` — `{ update(), destroy() }`.
+
+### Example
+
+```js
+forBlock(c, anchor, [1], () => todos.v, {
+  keyOf: (t) => t.id,
+  html: `<li></li>`,
+  wire(root, t) {
+    root.textContent = t.text;
+    return (d) => { root.textContent = d.text; }; // patch on data change
+  },
+});
+```
+
+### Notes
+
+- The low-level reconciler (`createForState`, `seedForState`, `reconcile`,
+  `longestIncreasingSubsequence`) is exported from `lunas/for_diff` for advanced
+  use; `forBlock` wraps it with the DOM host.
+
+---
+
+## `dynamicBlock`
+
+### Signature
+
+```ts
+function dynamicBlock(
+  c: Context,
+  anchor: Node,
+  deps: number[],
+  factoryOf: () => ChildFactory | null | undefined,
+  props: Record<string, unknown>
+): DynamicHandle
+
+interface DynamicHandle {
+  readonly handle: MountedChild | null;
+  update(): void;
+  setProp(name: string, value: unknown): void;
+  destroy(): void;
+}
+```
+
+### Description
+
+The dynamic-component helper — the codegen target for `<component :is="e">`.
+`factoryOf()` returns the current child factory (a `component(...)` result), or a
+falsy value for "render nothing". Whenever the factory **identity** changes (its
+deps flush), the old child is unmounted and the new one is mounted at the same
+anchor via [`mountChild`](./component.md#mountchild), so prop passing and child
+reactivity keep working. `props` is the same shape `mountChild` takes; it is
+reused across remounts and re-seeds each fresh child. `setProp` forwards to the
+live child.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor. |
+| `deps` | `number[]` | Reactive indices `:is` reads. |
+| `factoryOf` | `() => ChildFactory \| falsy` | Resolves the current child factory. |
+| `props` | `object` | Seed props (getters for reactive, values for static). |
+
+### Returns
+
+`DynamicHandle` — `{ handle, update(), setProp(name, value), destroy() }`.
+
+### Example
+
+```js
+dynamicBlock(c, anchor, [0], () => views[tab.v], { data: () => payload.v });
+```
+
+### Notes
+
+- See the [dynamic components guide](../components/dynamic-components.md).
+
+---
+
+## `teleportBlock`
+
+### Signature
+
+```ts
+function teleportBlock(
+  c: Context,
+  anchor: Node,
+  targetOf: () => string | Element | null,
+  build: () => BlockNodes
+): TeleportHandle
+
+interface TeleportHandle {
+  nodes: Node[];
+  destroy(): void;
+}
+```
+
+### Description
+
+Teleport/portal — the codegen target for `<teleport to="…">`. `build()` returns
+the content node(s) (like an `:if` branch). `targetOf()` resolves the mount
+target: a selector string (`querySelector`) or an `Element`. The content is
+inserted into the target instead of inline at `anchor`; on `destroy` the nodes are
+removed. A permanent text anchor still marks the inline slot, so surrounding
+layout is undisturbed and teardown order stays deterministic. Content binds are
+collected in a scope, so `destroy` tears down every inner bind — no leaks.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent inline text anchor. |
+| `targetOf` | `() => string \| Element \| null` | Resolves the mount target. |
+| `build` | `() => BlockNodes` | Builds the teleported content. |
+
+### Returns
+
+`TeleportHandle` — `{ nodes, destroy() }`.
+
+### Example
+
+```js
+teleportBlock(c, anchor, () => "#modals", () => {
+  return fromHTML(`<div class="modal">Hi</div>`, anchor).childNodes[0];
+});
+```
+
+### Notes
+
+- If the target cannot be resolved, the content is not inserted (never-panic).
+- See the [teleport built-in](../built-ins/teleport.md).
+
+---
+
+## `slotBlock`
+
+### Signature
+
+```ts
+function slotBlock(
+  childCtx: Context,
+  anchor: Node,
+  factory: SlotFactory | null | undefined,
+  fallback?: (slotProps?: unknown) => BlockNodes,
+  slotPropsOf?: () => unknown
+): { nodes: Node[] }
+
+type SlotFactory = (slotProps: unknown, onCleanup: (fn: () => void) => void) => BlockNodes
+```
+
+### Description
+
+Renders slot content at a `<slot>` anchor **inside a child component**. This is
+the child half of the slot mechanism.
+
+- `factory` — the parent-provided slot content factory (from the reserved
+  `props.$slots` object), or absent when the parent passed no content for this
+  slot. It is wired against the **parent** context (parent reactivity drives it);
+  `onCleanup(fn)` ties its teardown to the child's `onDestroy`.
+- `fallback` — the child's own fallback (`() => nodes`), wired in the **child**
+  scope, shown only when `factory` is absent.
+- `slotPropsOf` — optional getter returning scoped-slot props
+  (`<slot :item="e"/>`) passed up to the parent content. Captured once at build.
+
+Whichever content is used is inserted before `anchor`; null/undefined entries are
+skipped defensively (never-panic).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `childCtx` | `Context` | The child component's context (where the `<slot>` lives). |
+| `anchor` | `Node` | The permanent text anchor marking the slot position. |
+| `factory` | `SlotFactory \| falsy` | Parent-provided content, or absent. |
+| `fallback` | `(slotProps?) => BlockNodes` | The child's own fallback. |
+| `slotPropsOf` | `() => unknown` | Scoped-slot props getter. |
+
+### Returns
+
+`{ nodes: Node[] }`.
+
+### Notes
+
+- Scoped-slot props are a **snapshot** captured at build time — the child later
+  mutating a scoped value and re-rendering parent content is deferred (see the
+  [slots guide](../components/slots.md)). Fixed-shape scoped props work today.
+
+---
+
+## `slotContent`
+
+### Signature
+
+```ts
+function slotContent(
+  parentCtx: Context,
+  build: (slotProps: unknown) => BlockNodes,
+  slotProps: unknown,
+  onCleanup: (fn: () => void) => void
+): BlockNodes
+```
+
+### Description
+
+Builds the **parent** half of a slot factory. Per slot it fills, the parent emits
+a factory of shape `(slotProps, onCleanup) => nodes`; this helper wraps the actual
+wiring: it opens a fresh scope on the **parent** context (homed at the scope open
+when the parent mounted the child, so nested `:for`-item slot content tears down
+with the item), runs `build(slotProps)` to create and wire the content against the
+parent, registers the scope's `dropScope` through `onCleanup`, and returns the
+nodes.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `parentCtx` | `Context` | The parent component's context. |
+| `build` | `(slotProps) => BlockNodes` | Wires the content against the parent. |
+| `slotProps` | `unknown` | Scoped-slot props forwarded from the child. |
+| `onCleanup` | `(fn) => void` | Registers teardown tied to the child's unmount. |
+
+### Returns
+
+`BlockNodes` — the produced nodes.
+
+### Example (emitted parent side)
+
+```js
+mountChild(c, anchor, Child, {
+  $slots: {
+    default: (sp, onCleanup) =>
+      slotContent(c, () => {
+        const r = fromHTML(`<span></span>`, anchor).childNodes[0];
+        bind(c, [0], () => { r.textContent = title.v; });
+        return r;
+      }, sp, onCleanup),
+  },
+});
+```
+
+### Notes
+
+- See the [slots guide](../components/slots.md) for `<template #name>` and scoped
+  slots.

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -1,0 +1,325 @@
+# Component API
+
+The DOM construction and wiring helpers a compiled component uses: the factory
+itself, positional refs, event wiring, class/style normalization, and child
+mounting. See the [components guide](../components/registration.md) for the
+conceptual model and the [architecture overview](../architecture.md) for why
+Lunas builds via `innerHTML` and navigates positionally.
+
+Import from the package root or the `lunas/dom` and `lunas/blocks` subpaths.
+
+---
+
+## `component`
+
+### Signature
+
+```ts
+function component<P = Record<string, unknown>>(
+  tag: string,
+  attrs: RootAttrs,
+  HTML: string,
+  setup: SetupFn<P>
+): ComponentFactory<P>
+
+type RootAttrs = Record<string, string>
+type SetupFn<P> = (c: Context<Element>, props: P) => void
+type ComponentFactory<P> = (props?: P) => Element
+```
+
+### Description
+
+The compiled-component factory. Given a root `tag`, static `attrs`, a static
+`HTML` skeleton, and a `setup` function, it returns a **factory** that builds one
+instance per call:
+
+1. `document.createElement(tag)` and apply `attrs` via `setAttribute`.
+2. `root.innerHTML = HTML` — one native, detached parse of the comment-free,
+   whitespace-free static skeleton (dynamic seams are excluded and become runtime
+   anchors).
+3. Expose the reactive context on `root.__lunasCtx` (so a parent's
+   [`mountChild`](#mountchild) can push reactive props into the child).
+4. Run `setup(c, props)` — all wiring happens **off-DOM**.
+5. Return `root`. The caller attaches it to the live DOM **once** (see
+   [`attach`](./lifecycle.md#attach)).
+
+`HTML` is hoisted at module scope so it is defined once and shared by every
+instance (the string, not the DOM — each instance re-parses it, which is cheaper
+than cloning).
+
+For a multi-root template (more than one top-level node), the compiler emits
+`fragment(attrs, HTML, setup)` instead — same contract, but no wrapper element:
+the factory returns an `Array` of nodes carrying `__lunasCtx`, mountable and
+movable as a unit. `fragment` is compiler-facing; you do not normally call it by
+hand.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tag` | `string` | The root element tag. |
+| `attrs` | `RootAttrs` | Static attributes for the root. |
+| `HTML` | `string` | The static skeleton (comment-free, whitespace-free). |
+| `setup` | `SetupFn<P>` | Wires binds, refs, listeners, and child blocks. |
+
+### Returns
+
+`ComponentFactory<P>` — `(props?) => Element`.
+
+### Example
+
+```js
+import { component, box, refs, on, bind } from "lunas";
+
+const HTML = `<button>+1</button><span></span>`;
+
+export default component("div", { class: "counter" }, HTML, (c, props) => {
+  const count = box(c, 0, props.start ?? 0);
+  const [btn, out] = refs(c.root, [[0], [1]]);
+  on(btn, "click", () => { count.v++; });
+  bind(c, [0], () => { out.textContent = String(count.v); });
+});
+```
+
+### Notes
+
+- The returned root is **detached**; call [`attach(root, host)`](./lifecycle.md#attach)
+  to mount a top-level component and fire its `onMount` hooks.
+- In practice you write `.lunas` files and the compiler emits this call.
+
+---
+
+## `refs`
+
+### Signature
+
+```ts
+function refs(root: Node, paths: number[][]): Node[]
+```
+
+### Description
+
+Positional navigation to the dynamic elements of a parsed tree. Each entry in
+`paths` is a list of child indices from `root`; `refs` walks
+`childNodes[i]` for each step and returns the resolved nodes in order. This
+replaces `id` + `getElementById`: it is ~2× faster, works on a **detached** tree,
+and needs no id bytes or cleanup.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `root` | `Node` | The root to navigate from (usually `c.root`). |
+| `paths` | `number[][]` | One child-index path per target node. |
+
+### Returns
+
+`Node[]` — the resolved nodes, positionally aligned with `paths`.
+
+### Example
+
+```js
+// root's child 0, and root's child 1's child 2:
+const [btn, label] = refs(c.root, [[0], [1, 2]]);
+```
+
+### Notes
+
+- Relies on the static HTML being whitespace-free so `childNodes` positions are
+  stable — this is guaranteed by the compiler's output.
+
+---
+
+## `on`
+
+### Signature
+
+```ts
+function on(el: EventTarget, ev: string, fn: EventListenerOrEventListenerObject): void
+```
+
+### Description
+
+`addEventListener` shorthand. Because box setters notify dependents, an event
+handler that mutates state needs no explicit write bookkeeping — mutating a box
+inside the handler marks the right indices dirty on its own.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `el` | `EventTarget` | The element to listen on. |
+| `ev` | `string` | The event name (`"click"`, `"input"`, …). |
+| `fn` | `EventListener` | The handler. |
+
+### Returns
+
+`void`.
+
+### Example
+
+```js
+on(btn, "click", () => { count.v++; });
+```
+
+### Notes
+
+- See the [event handling guide](../guide/event-handling.md) and
+  [forms & two-way binding](../guide/forms-and-two-way.md) for `::model`
+  write-back.
+
+---
+
+## `normClass`
+
+### Signature
+
+```ts
+function normClass(value: unknown): string
+```
+
+### Description
+
+Flattens a `:class` binding into a space-separated class string, with Vue-parity
+semantics: a string passes through (trimmed); an array is flattened recursively;
+an object contributes each key whose value is truthy; other values stringify.
+Falsy entries are dropped.
+
+The compiler pairs this with `setClass(el, staticClass, value)`, which merges the
+normalized dynamic value with the element's static `class` attribute and writes
+the whole attribute (removing it when empty).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `value` | `string \| Record<string, boolean> \| Array \| unknown` | The class binding. |
+
+### Returns
+
+`string` — the normalized class string.
+
+### Example
+
+```js
+normClass(["btn", { active: isOn, disabled: false }]);
+// isOn === true  -> "btn active"
+```
+
+### Notes
+
+- See the [class and style guide](../guide/class-and-style.md).
+
+---
+
+## `normStyle`
+
+### Signature
+
+```ts
+function normStyle(value: unknown): string
+```
+
+### Description
+
+Flattens a `:style` binding into a `prop: value;` string. A string passes through
+(trimmed); an object maps camelCase keys to kebab-case CSS properties (custom
+`--props` and already-kebab names pass through); arrays merge left-to-right (later
+entries win). Null/false object values are skipped.
+
+The compiler pairs this with `setStyle(el, staticStyle, value)`, which merges the
+static `style` string with the normalized dynamic value.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `value` | `string \| Record<string, unknown> \| Array` | The style binding. |
+
+### Returns
+
+`string` — the normalized inline-style string.
+
+### Example
+
+```js
+normStyle({ backgroundColor: "red", fontSize: "14px" });
+// -> "background-color: red; font-size: 14px;"
+```
+
+### Notes
+
+- See the [class and style guide](../guide/class-and-style.md).
+
+---
+
+## `mountChild`
+
+### Signature
+
+```ts
+function mountChild<P = Record<string, unknown>>(
+  c: Context,
+  anchor: Node,
+  childFactory: ChildFactory<P>,
+  props?: P
+): MountedChild
+
+type ChildFactory<P> = (props?: P) => Node
+interface MountedChild {
+  root: Node;
+  unmount(): void;
+}
+```
+
+The runtime handle also carries `ctx` and `setProp(name, value)` (see below).
+
+### Description
+
+Instantiates a child component and inserts its root **before** the `anchor` (a
+permanent text node marking the child's slot). `props` seeds the child once:
+static props are plain values; reactive props are getter functions
+(`{ p: () => expr }`) invoked once at construction to seed the child's reactive
+prop box. The parent keeps a reactive prop live by calling the handle's
+`setProp(name, value)` inside its own `bind` — that writes the child's
+`_props[name]` box, so the child's own template binds react.
+
+The two contexts stay **independent**: pushing a prop marks only the child dirty;
+a child event marks only the child. `mountChild` also links `childCtx.parent = c`
+(so [`provide`/`inject`](./lifecycle.md#provide) walk the chain) and registers the
+child under `c._children` (so a parent attach/teardown recurses into it). If the
+insertion point is already live, the child's queued `onMount` callbacks fire
+immediately; otherwise a later ancestor `attach()` drains them. `unmount()` fires
+the child's `onDestroy` exactly once and removes every node of the group (handling
+multi-root fragment children).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The parent context. |
+| `anchor` | `Node` | The permanent text anchor the child mounts before. |
+| `childFactory` | `ChildFactory<P>` | A `component(...)` (or `fragment(...)`) result. |
+| `props` | `P` | Seed props: values for static, getters for reactive. |
+
+### Returns
+
+`MountedChild` — `{ root, ctx, setProp(name, value), unmount() }`.
+
+### Example
+
+```js
+import { anchorBefore, mountChild, bind } from "lunas";
+import Child from "./Child.mjs";
+
+const anchor = anchorBefore(hostNode.childNodes[k]);
+const ch = mountChild(c, anchor, Child, { label: () => title.v, tone: "muted" });
+bind(c, [/* deps of title */ 0], () => ch.setProp("label", title.v));
+```
+
+### Notes
+
+- Slot content rides in via a reserved `props.$slots` object — see
+  [slots](./blocks-and-control-flow.md#slotblock).
+- For lazy children see [`mountAsyncChild`](./async.md#mountasyncchild); for
+  dynamic `:is` see the [dynamic-component helper](./blocks-and-control-flow.md#dynamicblock).

--- a/docs/api/lifecycle.md
+++ b/docs/api/lifecycle.md
@@ -1,0 +1,348 @@
+# Lifecycle, Events, DI, Transitions & Keep-Alive API
+
+Component lifecycle hooks and the `attach` contract, child→parent events
+(`emit`), dependency injection (`provide`/`inject`), CSS transitions, and instance
+caching (`keepAlive`). See the [lifecycle guide](../guide/lifecycle.md),
+[component events](../components/events.md), [provide/inject](../components/provide-inject.md),
+and the [transition](../built-ins/transition.md) / [keep-alive](../built-ins/keep-alive.md)
+built-ins for the conceptual model.
+
+Import from the package root or the `lunas/lifecycle`, `lunas/emits`,
+`lunas/provide`, `lunas/transition`, `lunas/keepalive` subpaths.
+
+---
+
+## Lifecycle hooks
+
+A `component(...)` factory returns a **detached** root; the caller attaches it, so
+`onMount` cannot fire at construction — it is queued on the context and drained
+when the root becomes live. `mountChild` links `childCtx.parent = c` and registers
+the child under `c._children`, so a single top-level [`attach`](#attach) fires the
+whole subtree's mount hooks, and a parent teardown recurses into children.
+
+### `onMount`
+
+```ts
+function onMount(c: Context, fn: () => void): void
+```
+
+Runs `fn` after this component's root attaches to a live tree. If the component is
+already mounted, `fn` runs on the next microtask. Fires once.
+
+### `onDestroy`
+
+```ts
+function onDestroy(c: Context, fn: () => void): void
+```
+
+Runs `fn` when this component is torn down — fires once, on every unmount path
+(`mountChild.unmount`, block item teardown, keep-alive eviction), all of which
+funnel through `runDestroy(c)`.
+
+### `onUpdate`
+
+```ts
+function onUpdate(c: Context, fn: () => void): void
+```
+
+Runs `fn` after each flush of `c` that actually ran updates (the core flush loop
+invokes `c.onUpdate` when the queue was non-empty).
+
+### `onActivated` / `onDeactivated`
+
+```ts
+function onActivated(c: Context, fn: () => void): void
+function onDeactivated(c: Context, fn: () => void): void
+```
+
+Keep-alive hooks. `onActivated` runs each time the component is (re)activated from
+the cache (including the first activation); `onDeactivated` runs each time it is
+deactivated (cached, not destroyed). See [`keepAlive`](#keepalive).
+
+### Example
+
+```js
+import { onMount, onDestroy } from "lunas";
+
+onMount(c, () => { console.log("mounted"); });
+onDestroy(c, () => { clearInterval(timer); });
+```
+
+---
+
+## `attach`
+
+### Signature
+
+```ts
+function attach<N extends Node>(root: N, host: Node): N
+```
+
+### Description
+
+Appends a detached component `root` to a live `host` and fires the whole subtree's
+queued `onMount` callbacks. This is the **top-level mount entry**: build a root
+with a `component(...)` factory, then `attach(root, document.body)`. Returns
+`root`.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `root` | `Node` | The detached component root. |
+| `host` | `Node` | A live host to append into. |
+
+### Returns
+
+`N` — the `root` (for chaining).
+
+### Example
+
+```js
+import { attach } from "lunas";
+import App from "./App.mjs";
+
+attach(App(), document.getElementById("app"));
+```
+
+### Notes
+
+- `isLive(node)` reports whether a node is attached to a live tree (uses
+  `Node.isConnected` with a walk-to-root fallback for shims).
+
+---
+
+## `emit`
+
+### Signature
+
+```ts
+function emit(c: Context, name: string, payload?: unknown): boolean
+```
+
+### Description
+
+Raises a child→parent event: invokes the parent's `on<Name>` handler prop if
+present, passing `payload`. Returns `true` if a handler ran. `emit` never marks
+the parent dirty by itself — the handler decides whether to mutate parent state (a
+box setter inside the handler marks the parent as usual).
+
+For `emit` to find handlers, the child must first call `registerEmits(c, props,
+declared?)` at the top of its `setup` (the compiler emits this), which stashes the
+child's props and optionally records declared event names for warn-only
+validation.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The child component's context. |
+| `name` | `string` | The event name (e.g. `"save"`). |
+| `payload` | `unknown` | Optional payload passed to the handler. |
+
+### Returns
+
+`boolean` — whether a handler ran.
+
+### Example
+
+```js
+import { registerEmits, emit } from "lunas";
+
+registerEmits(c, props, ["save"]);           // top of child setup
+on(btn, "click", () => emit(c, "save", { id })); // raises parent's onSave
+```
+
+### Notes
+
+- `eventPropName(name)` maps an event name to its prop: `eventPropName("save")` →
+  `"onSave"`, `eventPropName("save-all")` → `"onSaveAll"`. This is the codegen's
+  `@name` → `onName` mapping for component-tag event listeners.
+- A `@save="h($event)"` listener on a component tag compiles to an
+  `onSave: ($event) => h($event)` entry on the `mountChild` props.
+
+---
+
+## `provide`
+
+### Signature
+
+```ts
+function provide<T>(c: Context, key: InjectionKey, value: T): T
+type InjectionKey = string | symbol
+```
+
+### Description
+
+Registers `key → value` on this component's context (a Map on `c._provides`),
+making it available to descendants. Returns `value`. DI walks the
+`childCtx.parent` chain that [`mountChild`](./component.md#mountchild) links;
+nearest ancestor wins (shadowing).
+
+### Example
+
+```js
+import { provide } from "lunas";
+provide(c, "theme", "dark");
+```
+
+---
+
+## `inject`
+
+### Signature
+
+```ts
+function inject<T = unknown>(c: Context, key: InjectionKey, def?: T): T | undefined
+```
+
+### Description
+
+Resolves `key` from the nearest ancestor that provided it (self included), else
+returns `def` (default `undefined`).
+
+### Example
+
+```js
+import { inject } from "lunas";
+const theme = inject(c, "theme", "light");
+```
+
+---
+
+## `hasInjection`
+
+### Signature
+
+```ts
+function hasInjection(c: Context, key: InjectionKey): boolean
+```
+
+### Description
+
+Whether any ancestor (or self) provides `key`. Lets a caller distinguish "provided
+`undefined`" from "not provided".
+
+```js
+if (hasInjection(c, "theme")) { /* … */ }
+```
+
+---
+
+## `withTransition`
+
+### Signature
+
+```ts
+function withTransition(opts?: TransitionOptions): TransitionController
+
+interface TransitionOptions {
+  name?: string;       // class base name (default "v"); classes are `name-enter-from` etc.
+  duration?: number;   // fallback timeout (ms) if no transitionend fires (0 → next macrotask)
+}
+interface TransitionController {
+  enter(nodes: Node | Node[], insert: () => void): void;
+  leave(nodes: Node | Node[], remove: () => void): void;
+}
+```
+
+### Description
+
+Builds an enter/leave CSS-class transition controller that composes with a block's
+insert/remove closures. `enter(nodes, insert)` inserts the nodes then choreographs
+the enter classes; `leave(nodes, remove)` choreographs the leave classes, then
+calls `remove()` once every node's leave phase finishes. The class choreography is:
+
+```
+enter:  +name-enter-from +name-enter-active
+        → (raf) −name-enter-from +name-enter-to
+        → (transitionend/timeout) −name-enter-active −name-enter-to
+leave:  symmetric; the node is removed only after the leave phase finishes.
+```
+
+Degrades to immediate insert/remove (with the class sequence still applied
+synchronously) outside a browser (no `requestAnimationFrame`).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `opts` | `TransitionOptions` | `{ name, duration }`. |
+
+### Returns
+
+`TransitionController` — `{ enter, leave }`.
+
+### Example
+
+```js
+import { withTransition } from "lunas";
+const t = withTransition({ name: "fade", duration: 300 });
+t.enter(node, () => anchor.parentNode.insertBefore(node, anchor));
+```
+
+### Notes
+
+- The lower-level `runPhase(el, base, phase, opts, done)` runs one enter/leave
+  class phase on a single element and returns a `cancel()`; `withTransition` builds
+  on it.
+- See the [transition built-in](../built-ins/transition.md).
+
+---
+
+## `keepAlive`
+
+### Signature
+
+```ts
+function keepAlive(opts?: KeepAliveOptions): KeepAliveController
+
+interface KeepAliveOptions { max?: number }
+interface KeepAliveController {
+  show<P>(c: Context, anchor: Node, key: unknown, factory: ChildFactory<P>, props?: P): KeptChild;
+  has(key: unknown): boolean;
+  readonly size: number;
+  destroy(): void;
+}
+interface KeptChild extends MountedChild { ctx?: Context; key?: unknown }
+```
+
+### Description
+
+Caches [`mountChild`](./component.md#mountchild)-produced instances by key instead
+of destroying them on switch. `show(c, anchor, key, factory, props?)` makes the
+instance for `key` the one mounted before `anchor`: it activates a cached instance
+or mounts a fresh one, and deactivates the previously-shown instance.
+Deactivation **detaches** nodes (keeping the context and reactive state alive);
+activation **re-attaches** with no rebuild.
+
+`max` sets an LRU capacity (unbounded when omitted); overflow evicts the
+least-recently-shown instance. Real eviction (LRU overflow or `destroy()`) fires
+`onDestroy`; activate/deactivate fire [`onActivated`/`onDeactivated`](#onactivated--ondeactivated).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `opts` | `KeepAliveOptions` | `{ max }` — LRU capacity. |
+
+### Returns
+
+`KeepAliveController` — `{ show, has(key), size, destroy() }`.
+
+### Example
+
+```js
+import { keepAlive, anchorBefore } from "lunas";
+
+const ka = keepAlive({ max: 3 });
+const anchor = anchorBefore(placeholder);
+// switching tabs keeps each tab's component state alive:
+ka.show(c, anchor, tab.v, views[tab.v]);
+```
+
+### Notes
+
+- Only eviction/`destroy()` fires `onDestroy`; a plain switch-away
+  deactivates (state preserved).
+- See the [keep-alive built-in](../built-ins/keep-alive.md).

--- a/docs/api/reactivity.md
+++ b/docs/api/reactivity.md
@@ -1,0 +1,491 @@
+# Reactivity API
+
+The reactive core of the Lunas runtime. These are the primitives the compiler
+emits calls into — see the [reactivity fundamentals](../guide/reactivity-fundamentals.md),
+[computed](../guide/computed.md), and [watchers](../guide/watchers.md) guides for
+the conceptual model, and the [architecture overview](../architecture.md) for how
+compile-time dependency dispatch works.
+
+Every reactive helper is keyed on a **context** `c` (created internally by
+`component(...)`, see [component API](./component.md)) and a numeric **reactive
+index** `i`. The compiler assigns each reactive variable an index and computes,
+for each dynamic part, the exact set of indices it reads (its `deps`). There is
+no runtime dependency tracking.
+
+Import from the package root or the `lunas/boxes`, `lunas/core`, `lunas/computed`,
+`lunas/watch`, `lunas/batch` subpaths.
+
+---
+
+## `box`
+
+### Signature
+
+```ts
+function box<T>(c: Context, i: number, v: T): Box<T>
+```
+
+`Box<T>` is `{ v: T }`.
+
+### Description
+
+Creates a **reassign-only** reactive cell at reactive index `i`. This is the
+lightest reactive path: a plain getter/setter, no `Proxy`. Reading `.v` returns
+the current value; assigning `.v` writes it and marks index `i` dirty, scheduling
+a microtask flush. Same-value writes (`x !== v` fails) are no-ops.
+
+The compiler chooses `box` for variables that are only ever reassigned
+(`x = …`), never deeply mutated.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `i` | `number` | The reactive index of this variable. |
+| `v` | `T` | The initial value. |
+
+### Returns
+
+`Box<T>` — a cell exposing a single `v` accessor.
+
+### Example
+
+```js
+import { component, box, refs, bind, on } from "lunas";
+
+component("div", {}, `<button>+1</button><span></span>`, (c) => {
+  const count = box(c, 0, 0);
+  const [btn, out] = refs(c.root, [[0], [1]]);
+  on(btn, "click", () => { count.v++; });
+  bind(c, [0], () => { out.textContent = String(count.v); });
+});
+```
+
+### Notes
+
+- Writing an equal value never re-runs dependents.
+- For deep mutation of an array/object value, use [`deepBox`](#deepbox).
+
+---
+
+## `deepBox`
+
+### Signature
+
+```ts
+function deepBox<T>(c: Context, i: number, v: T): Box<T>
+```
+
+### Description
+
+Creates a **deeply-mutated** reactive cell at reactive index `i`. Reads through
+`.v` return a `Proxy` that marks index `i` dirty on any nested `set` or `delete`
+— including array mutators (`push`, `splice`, …) which run with the proxy as
+`this`. Nested objects are wrapped lazily on property access; wrappers are cached
+per underlying object (via a `WeakMap`) so proxy identity is stable across reads.
+Replacing the whole value (`box.v = next`) also marks dirty and re-wraps.
+
+The compiler chooses `deepBox` for variables it observes being deeply mutated
+(`arr.push(...)`, `obj.k = …`).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `i` | `number` | The reactive index of this variable. |
+| `v` | `T` | The initial value (typically an array or object). |
+
+### Returns
+
+`Box<T>` — a cell whose `.v` getter yields the deep proxy.
+
+### Example
+
+```js
+const todos = deepBox(c, 1, []);
+todos.v.push({ text: "buy milk" }); // marks index 1 dirty
+todos.v[0].text = "buy oat milk";   // nested set — also marks dirty
+```
+
+### Notes
+
+- Only the reactive floor `Proxy` (ES2015) is used; no `BigInt`.
+- The Proxy handler is shared with module-level stores (see [store API](./store.md)).
+
+---
+
+## `shared`
+
+### Signature
+
+```ts
+function shared<T>(v: T): Shared<T>
+
+interface Shared<T> {
+  v: T;
+  attach(c: Context, i: number): void;
+  detach(c: Context): void;
+}
+```
+
+### Description
+
+Creates a value **shared across components** — the classic "a prop is passed
+down and mutated" case. Each dependent component `attach`es with its own context
+and reactive index; a write to `.v` marks the variable dirty in **every** attached
+component. Same-value writes are no-ops. `detach(c)` removes every attachment
+belonging to context `c` (used on teardown).
+
+For state that lives outside any component and is imported by many, prefer a
+module-level store — see [`createStore`](./store.md#createstore), which
+generalizes this concept.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `v` | `T` | The initial shared value. |
+
+### Returns
+
+`Shared<T>` — `{ v, attach(c, i), detach(c) }`.
+
+### Example
+
+```js
+const theme = shared("light");
+theme.attach(childCtx, 3);      // child index 3 tracks the theme
+theme.v = "dark";               // marks childCtx index 3 dirty
+```
+
+### Notes
+
+- `attach` does not deduplicate; detach with `detach(c)` per context.
+
+---
+
+## `computed`
+
+### Signature
+
+```ts
+function computed<T>(c: Context, i: number, deps: number[], fn: () => T): Computed<T>
+```
+
+`Computed<T>` is `{ readonly v: T }`.
+
+### Description
+
+A **lazy, memoized** derived value at reactive index `i` reading the upstream
+reactive indices in `deps`. `fn` runs only when the value is actually read
+**and** an upstream dep has changed since the last computation. Reading `.v`
+from inside a `bind` that declares `i` in its deps keeps the consumer reactive to
+the computed's own index.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `i` | `number` | The reactive index this computed publishes on. |
+| `deps` | `number[]` | Upstream reactive indices it reads. |
+| `fn` | `() => T` | The compute function. |
+
+### Returns
+
+`Computed<T>` — a read-only box-shaped handle whose `.v` getter yields the
+memoized result.
+
+### Example
+
+```js
+const first = box(c, 0, "Ada");
+const last  = box(c, 1, "Lovelace");
+const full  = computed(c, 2, [0, 1], () => `${first.v} ${last.v}`);
+
+bind(c, [2], () => { nameEl.textContent = full.v; });
+```
+
+### Notes
+
+- Never eager: if nothing reads `.v`, `fn` never runs after invalidation.
+- See the [computed guide](../guide/computed.md).
+
+---
+
+## `watch`
+
+### Signature
+
+```ts
+function watch(c: Context, deps: number[], cb: () => void, opts?: WatchOpts): StopHandle
+
+interface WatchOpts { immediate?: boolean }
+type StopHandle = () => void
+```
+
+### Description
+
+Runs `cb` after any of `deps` changes. By default the first (synchronous) run is
+**suppressed**, so the callback fires only on subsequent changes. Pass
+`{ immediate: true }` to also invoke it once at registration time. The watcher is
+collected by the currently-open scope (so it is torn down by `dropScope` when its
+enclosing control-flow block is removed) in addition to the returned `stop()`.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `deps` | `number[]` | Reactive indices to watch. |
+| `cb` | `() => void` | Callback run after a change. |
+| `opts` | `WatchOpts` | `{ immediate }` — also run once now (default `false`). |
+
+### Returns
+
+`StopHandle` — a function that unregisters the watcher.
+
+### Example
+
+```js
+const stop = watch(c, [0], () => {
+  console.log("count changed to", count.v);
+});
+// later: stop();
+```
+
+### Notes
+
+- See the [watchers guide](../guide/watchers.md).
+
+---
+
+## `watchEffect`
+
+### Signature
+
+```ts
+function watchEffect(c: Context, deps: number[], fn: () => void): StopHandle
+```
+
+### Description
+
+Runs `fn` **immediately** and again after any of `deps` changes — no distinction
+between the initial and later runs. Like `watch`, the returned `stop()` and the
+open scope both tear it down.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `deps` | `number[]` | Reactive indices to watch. |
+| `fn` | `() => void` | Effect run now and on every change. |
+
+### Returns
+
+`StopHandle`.
+
+### Example
+
+```js
+watchEffect(c, [0], () => {
+  document.title = `count: ${count.v}`;
+});
+```
+
+### Notes
+
+- Because Lunas resolves deps at compile time, you pass the index list explicitly
+  rather than having them auto-tracked.
+
+---
+
+## `batch`
+
+### Signature
+
+```ts
+function batch<T>(c: Context, fn: () => T): T
+```
+
+### Description
+
+Runs `fn` (which may write many boxes) and **flushes synchronously afterward**,
+collapsing the whole group of writes into a single update pass that has completed
+by the time `batch()` returns. Nested batches on the same context flush only at
+the outermost call. Returns whatever `fn` returns.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `fn` | `() => T` | A function performing one or more writes. |
+
+### Returns
+
+`T` — the return value of `fn`.
+
+### Example
+
+```js
+batch(c, () => {
+  a.v = 1;
+  b.v = 2;
+  c2.v = 3;
+}); // one update pass, already applied to the DOM here
+```
+
+### Notes
+
+- Without `batch`, multiple writes in the same tick already coalesce into one
+  microtask flush; `batch` makes the flush **synchronous** and immediate.
+
+---
+
+## `nextTick`
+
+### Signature
+
+```ts
+function nextTick(c: Context): Promise<void>
+```
+
+### Description
+
+Returns a `Promise` resolved after the next flush completes (i.e. after the DOM
+update pass). If nothing is pending, a flush is still scheduled, so
+`await nextTick(c)` always lands after the current tick's update pass.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+
+### Returns
+
+`Promise<void>`.
+
+### Example
+
+```js
+count.v++;
+await nextTick(c);
+// the DOM now reflects the new count
+```
+
+### Notes
+
+- Built on [`afterFlush`](#afterflush).
+
+---
+
+## `afterFlush`
+
+### Signature
+
+```ts
+function afterFlush(c: Context, cb: () => void): void
+```
+
+### Description
+
+Runs `cb` once, after the next flush completes. If a flush is already pending the
+callback rides that one; otherwise a flush is scheduled so the callback still
+fires this tick. This is the primitive behind [`nextTick`](#nexttick) and the
+reveal-after-settle behavior of [`suspenseBlock`](./async.md#suspenseblock).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `cb` | `() => void` | Callback run after the next flush. |
+
+### Returns
+
+`void`.
+
+### Notes
+
+- Prefer `nextTick` for a promise-shaped API; `afterFlush` is the callback form.
+
+---
+
+## Low-level core
+
+These are the raw primitives the compiler and the higher-level helpers are built
+on. You rarely call them by hand — [`box`](#box)/[`deepBox`](#deepbox) already
+call `markVar`, and `component(...)` already calls `createContext`. Documented
+here for completeness.
+
+### `bind`
+
+```ts
+function bind(c: Context, deps: number[], fn: () => void): BindRecord
+```
+
+Registers an update function that reads the reactive indices in `deps`. Runs `fn`
+**once immediately** (so the first paint is correct without a flush). Returns the
+bind record (needed for [`unbind`](#unbind)). This is the workhorse behind every
+reactive text node, attribute, and control-flow block.
+
+### `markVar`
+
+```ts
+function markVar(c: Context, i: number): void
+```
+
+Signals that reactive variable `i` changed: enqueues its dependents (deduplicated)
+and schedules a microtask [`flush`](#flush). **Low-level / internal** — the box
+setters call this for you. Call it directly only when writing a custom reactive
+cell.
+
+### `flush`
+
+```ts
+function flush(c: Context): void
+```
+
+Runs every queued update once, then drains any callbacks registered via
+[`afterFlush`](#afterflush). Only affected parts run (cost is O(affected)).
+**Low-level / internal** — flushes are normally scheduled automatically on the
+microtask queue by `markVar`; call `flush` directly only to force a synchronous
+update pass (which is what [`batch`](#batch) does for you).
+
+### `createContext`
+
+```ts
+function createContext<R = unknown>(root: R): Context<R>
+```
+
+Creates a fresh reactive context rooted at `root` (typically the component's root
+DOM node). `component(...)` calls this; you rarely call it directly.
+
+### `unbind`
+
+```ts
+function unbind(c: Context, s: BindRecord): void
+```
+
+Permanently unregisters a bind record. Safe to call while a flush containing `s`
+is pending (the dead record is skipped at flush time).
+
+### `beginScope` / `endScope` / `dropScope`
+
+```ts
+function beginScope(c: Context): Scope
+function endScope(c: Context): void
+function dropScope(c: Context, scope: Scope): void
+```
+
+Scope machinery for control-flow blocks. `beginScope` opens a collection scope
+(nested under the currently-open one); every `bind` created until the matching
+`endScope` is collected into it. `dropScope` unregisters every bind in the scope
+recursively (including nested child scopes) and detaches it from its parent — the
+mechanism by which removed `:if`/`:for` content never receives updates and never
+leaks. See [blocks and control flow](./blocks-and-control-flow.md).

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -1,0 +1,258 @@
+# Router API
+
+The client-side router runtime: a route table with matching, history
+integration, a store-backed reactive current route, an outlet, links, and
+navigation guards. Conceptually the router is a store whose single field
+`"route"` is the current route — components adopt it exactly like any other store
+field (see [store API](./store.md)).
+
+See the [routing guide](../scaling/routing.md) for the conceptual walkthrough.
+
+Import from the package root or the `lunas/router` subpath.
+
+---
+
+## `createRouter`
+
+### Signature
+
+```ts
+function createRouter<C = unknown>(routes: Route<C>[], options?: RouterOptions<C>): Router<C>
+
+interface Route<C> {
+  path: string;              // static segments, ":param"s, trailing "*"/"*name"
+  component?: C;             // factory to mount when matched (outlet target)
+  [extra: string]: unknown;  // name, meta, …
+}
+
+interface RouterOptions<C> {
+  history?: HistoryAdapter;  // defaults to historyAdapter() over window
+  beforeEach?: (to: RouteState<C>, from: RouteState<C>) => boolean | Promise<boolean>;
+}
+```
+
+### Description
+
+Builds a router over `routes`. The current route lives in a store field named
+`"route"`, so components adopt it via `router.adopt(c, i)` (or
+[`useStore`](./store.md#usestore)) and plain consumers via `router.subscribe(fn)`.
+Route matching ranks **static > param > catch-all**.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `routes` | `Route<C>[]` | The route table. |
+| `options` | `RouterOptions<C>` | History adapter and `beforeEach` guard. |
+
+### Returns
+
+A `Router<C>` instance:
+
+```ts
+interface Router<C> {
+  readonly store: Store<{ route: RouteState<C> }>;
+  readonly current: RouteState<C>;
+  push(path: string): Promise<boolean>;    // resolves to whether it committed
+  replace(path: string): Promise<boolean>;
+  back(): void;                            // guard-free, like the browser button
+  forward(): void;
+  subscribe(fn: (route: RouteState<C>) => void): Unsubscribe;
+  adopt(c: Context, i: number): Unsubscribe; // sugar over useStore(c, i, store, "route")
+  destroy(): void;                         // detach the history listener
+}
+```
+
+### Example
+
+```js
+import { createRouter } from "lunas";
+import Home from "./Home.mjs";
+import User from "./User.mjs";
+
+const router = createRouter([
+  { path: "/", component: Home },
+  { path: "/users/:id", component: User },
+  { path: "*", component: NotFound },
+]);
+```
+
+### Notes
+
+- `push`/`replace` return a `Promise<boolean>` — a `beforeEach` guard returning
+  `false` (sync or via a resolved promise) cancels the navigation.
+- `back`/`forward` are guard-free (they mirror the browser buttons).
+
+---
+
+## The route shape (`RouteState`)
+
+```ts
+interface RouteState<C> {
+  path: string;               // normalized pathname (leading slash, no trailing, no query)
+  params: Record<string, string>; // captured ":name" segments and "*name" catch-all
+  query: Record<string, string>;  // parsed query string (last-value-wins per key)
+  matched: Route<C> | null;   // the matched route def, or null on a total miss
+}
+```
+
+`router.current` is the live `RouteState`; components read it reactively after
+`router.adopt(c, i)`.
+
+---
+
+## Navigation guards
+
+`options.beforeEach(to, from)` runs before every `push`/`replace`. Returning
+`false` — synchronously or via a resolved `Promise<boolean>` — cancels the
+navigation; anything else commits it. `back()`/`forward()` bypass the guard.
+
+```js
+const router = createRouter(routes, {
+  beforeEach: (to) => {
+    if (to.matched?.meta?.auth && !isLoggedIn()) return false; // block
+    return true;
+  },
+});
+```
+
+---
+
+## `routerOutlet`
+
+### Signature
+
+```ts
+function routerOutlet<C = unknown>(
+  c: Context,
+  anchor: Node,
+  router: Router<C>,
+  options?: OutletOptions<C>
+): OutletHandle
+
+interface OutletOptions<C> {
+  props?: (route: RouteState<C>) => Record<string, unknown>;
+}
+interface OutletHandle { destroy(): void }
+```
+
+### Description
+
+Mounts the matched route's `component` at the text `anchor` (with
+[`mountChild`](./component.md#mountchild) semantics), swapping it out whenever
+navigation changes **which route** matches. By default the matched route's
+captured `params` are passed as props; override with `options.props`. Re-mounts
+only when the matched route definition changes, **not** on every param tweak.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `anchor` | `Node` | The permanent text anchor for the outlet. |
+| `router` | `Router<C>` | The router instance. |
+| `options` | `OutletOptions<C>` | Optional route→props mapping. |
+
+### Returns
+
+`OutletHandle` — `{ destroy() }`.
+
+### Example
+
+```js
+import { anchorBefore, routerOutlet } from "lunas";
+const a = anchorBefore(placeholder);
+routerOutlet(c, a, router);
+```
+
+---
+
+## `routerLink`
+
+### Signature
+
+```ts
+function routerLink(
+  el: Element,
+  router: Router,
+  path: string,
+  options?: LinkOptions
+): Unsubscribe
+
+interface LinkOptions { replace?: boolean }
+```
+
+### Description
+
+Wires `el`'s click to a client-side navigation: `preventDefault` + `router.push`
+(or `router.replace` when `options.replace`). Modified/aux clicks (Ctrl/Cmd/middle
+button) fall through to the browser. Returns an `unbind()`.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `el` | `Element` | The link element. |
+| `router` | `Router` | The router instance. |
+| `path` | `string` | The destination path. |
+| `options` | `LinkOptions` | `{ replace }`. |
+
+### Returns
+
+`Unsubscribe` — removes the click wiring.
+
+### Example
+
+```js
+routerLink(anchorEl, router, "/users/1");
+```
+
+---
+
+## `memoryHistory`
+
+### Signature
+
+```ts
+function memoryHistory(initial?: string): HistoryAdapter
+```
+
+### Description
+
+An in-memory History-API stand-in for tests and non-browser environments. Keeps
+its own back-stack; `listen`'s callback fires on `back()`/`forward()` (the
+popstate analogue) but **not** on `push()`/`replace()`. Pass it via
+`options.history` to run a router without a `window`.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `initial` | `string` | The initial location (default `"/"`). |
+
+### Returns
+
+A `HistoryAdapter`:
+
+```ts
+interface HistoryAdapter {
+  readonly location: string;          // "pathname + search"
+  push(path: string): void;
+  replace(path: string): void;
+  go(delta: number): void;
+  listen(fn: (path: string) => void): Unsubscribe;
+}
+```
+
+### Example
+
+```js
+import { createRouter, memoryHistory } from "lunas";
+const router = createRouter(routes, { history: memoryHistory("/") });
+```
+
+### Notes
+
+- The default adapter over the browser History API is `historyAdapter(win?)`
+  (`win` defaults to global `window`; throws if no window is available). The
+  router uses it automatically when no `history` option is given.

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -1,0 +1,221 @@
+# Store API
+
+Module-level reactive state living **outside** any component. A store is the
+module-scope generalization of [`shared`](./reactivity.md#shared): created once at
+module load and imported by however many components want it, with the same
+adjacency-dispatch contract (no auto-tracking, no runtime dependency discovery).
+Each field is independently subscribable — a write to one field only notifies
+components that adopted *that* field.
+
+See the [state management guide](../scaling/state-management.md) for the
+conceptual model.
+
+Import from the package root or the `lunas/store` subpath.
+
+---
+
+## `createStore`
+
+### Signature
+
+```ts
+function createStore<T extends Record<string, any>>(initial: T): Store<T>
+
+interface Store<T> {
+  get<K extends keyof T>(key: K): T[K];
+  set<K extends keyof T>(key: K, v: T[K]): void;
+  subscribe<K extends keyof T>(key: K, fn: (value: T[K]) => void): Unsubscribe;
+}
+
+type Unsubscribe = () => void
+```
+
+### Description
+
+Creates a module-level store from a plain object of named initial values. Each key
+becomes an independent **field** (its own subscriber list). Object/array field
+values get deep-mutation support (lazily `Proxy`-wrapped, the same handler as
+[`deepBox`](./reactivity.md#deepbox)). A value that is already field-shaped — e.g.
+the result of [`derivedStore`](#derivedstore) — is kept as-is instead of being
+wrapped, so derived values can be declared inline in the initial object.
+
+- `get(key)` — current value (through the deep-mutation proxy for objects/arrays).
+- `set(key, v)` — write, notifying every component that adopted `key` (batched per
+  the normal microtask flush) and every `subscribe` listener (synchronously).
+  Same-value writes are no-ops. Throws if `key` holds a derived (read-only) value.
+- `subscribe(key, fn)` — outside-component subscription for plain-JS consumers
+  (router, devtools, tests); `fn(value)` runs synchronously on every write to
+  `key`. Returns an unsubscribe.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `initial` | `T` | Plain object of named initial values. |
+
+### Returns
+
+`Store<T>`.
+
+### Example
+
+```js
+import { createStore } from "lunas";
+
+export const appStore = createStore({ count: 0, user: null });
+
+appStore.set("count", appStore.get("count") + 1);
+const off = appStore.subscribe("count", (n) => console.log("count:", n));
+```
+
+### Notes
+
+- Components adopt a field with [`useStore`](#usestore).
+- There is also an internal `_field(key)` accessor used by `useStore`/
+  `derivedStore`; prefer `get`/`set`/`subscribe` in application code.
+
+---
+
+## `useStore`
+
+### Signature
+
+```ts
+function useStore<T extends Record<string, any>, K extends keyof T>(
+  c: Context,
+  i: number,
+  store: Store<T>,
+  key: K
+): Unsubscribe
+```
+
+### Description
+
+Adopts store field `key` at component context `c`'s reactive index `i`. From then
+on, writes to `key` mark index `i` dirty in `c` (batched per the normal microtask
+flush) — exactly like a compiler-emitted `shared(...).attach(c, i)` but sourced
+from a module-level store. This is the shape the compiler emits: one call per
+`(component, field)` adoption.
+
+Returns a `detach()` that undoes the adoption (idempotent). When called while
+`c.scope` is open (i.e. from inside a control-flow block's `make()`), the adoption
+is **also** torn down automatically by `dropScope(c, scope)` — the same lifecycle
+a plain `bind` gets.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `c` | `Context` | The component context. |
+| `i` | `number` | The reactive index that tracks the field. |
+| `store` | `Store<T>` | The store. |
+| `key` | `keyof T` | The field to adopt. |
+
+### Returns
+
+`Unsubscribe` — the (idempotent) detach.
+
+### Example
+
+```js
+import { useStore, bind } from "lunas";
+import { appStore } from "./store.mjs";
+
+useStore(c, 0, appStore, "count");
+bind(c, [0], () => { out.textContent = String(appStore.get("count")); });
+// handler:
+on(btn, "click", () => appStore.set("count", appStore.get("count") + 1));
+```
+
+### Notes
+
+- Adopted in a component's top-level setup (no open scope), the store keeps a live
+  reference for that component's lifetime; call the returned `detach()` from your
+  teardown path when needed.
+
+---
+
+## `subscribe`
+
+`subscribe` is a method on the `Store` (see [`createStore`](#createstore)) and on
+every field-shaped handle (including [`derivedStore`](#derivedstore) results). It
+is the **outside-component** channel:
+
+```ts
+store.subscribe(key, fn) => Unsubscribe
+```
+
+`fn(value)` runs **synchronously** on every write to `key` (not batched — there is
+no component flush to ride for a non-component listener). This is what the router
+uses to observe its `"route"` field, and what devtools/tests use to observe store
+state. It returns an unsubscribe function.
+
+```js
+const off = appStore.subscribe("user", (u) => render(u));
+// later: off();
+```
+
+---
+
+## `derivedStore`
+
+### Signature
+
+```ts
+function derivedStore<T extends Record<string, any>, R>(
+  store: Store<T>,
+  deps: (keyof T)[],
+  fn: () => R
+): StoreField<R> & { stop(): void }
+
+interface StoreField<R> {
+  readonly v: R;
+  attach(c: Context, i: number): void;
+  detach(c: Context): void;
+  subscribe(fn: (value: R) => void): Unsubscribe;
+}
+```
+
+### Description
+
+A read-only value derived from one or more fields of `store`, lazily recomputed
+and memoized (like [`computed`](./reactivity.md#computed)) but living at module
+scope. `deps` is the list of store keys it reads. The result is **field-shaped**:
+place it under a `createStore()` key to let a component `useStore` it, or
+`subscribe` to it directly from plain JS.
+
+For component reads it stays lazy (recompute deferred to the next `.v` read after
+a dep changes); for plain-JS subscribers it recomputes eagerly so `fn(value)`
+hands over the fresh value synchronously. `stop()` unsubscribes from every
+upstream field (rarely needed — derived stores are usually app-lifetime).
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `store` | `Store<T>` | The upstream store. |
+| `deps` | `(keyof T)[]` | The store keys it reads. |
+| `fn` | `() => R` | The compute function. |
+
+### Returns
+
+`StoreField<R> & { stop(): void }`.
+
+### Example
+
+```js
+import { createStore, derivedStore, useStore } from "lunas";
+
+const cart = createStore({ items: [] });
+const total = derivedStore(cart, ["items"], () =>
+  cart.get("items").reduce((sum, it) => sum + it.price, 0)
+);
+
+const app = createStore({ total });   // field-shaped value passes through
+useStore(c, 0, app, "total");         // component adopts the derived value
+```
+
+### Notes
+
+- Because the derived result is field-shaped, `createStore` accepts it directly
+  under a key without double-wrapping.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,226 @@
+# Architecture Overview
+
+This page explains how Lunas works end to end: how a `.lunas` file becomes a
+JavaScript module, how the runtime builds and updates the DOM, and the
+benchmark-locked decisions that shape both. It is a reader-friendly overview — for
+the exact contract, see the design docs linked at the bottom.
+
+Lunas has two halves:
+
+- a **compiler** written in Rust (a Cargo workspace under `crates/`), and
+- a **tiny, dependency-free JavaScript runtime** (`packages/lunas`, ES2015 + `Proxy`,
+  no build step, no `BigInt`).
+
+The compiler does all the analysis; the runtime does almost no thinking at
+runtime. That split is the source of Lunas's speed.
+
+---
+
+## The compile pipeline
+
+A `.lunas` single-file component bundles an `html:` template, a `style:` block, and
+a `script:` block (TypeScript or JavaScript). It flows through the crates like
+this:
+
+```
+.lunas
+  → lunas_parser        (.lunas syntax: split blocks/directives, build the
+                         ParsedFile + a binding-aware template IR)
+  → lunas_script        (JS/TS analysis via SWC: bindings, per-function mutation
+                         sets, free identifiers / dependency sets, TS→JS)
+  → lunas_compiler      (resolution: numbered reactive variables, each dynamic
+                         template part with its dependency set, each handler with
+                         its write set → a ResolvedComponent)
+  → codegen             (emit the JS module described below)
+  → JS module           (a component(...) / fragment(...) factory + runtime calls)
+```
+
+Key ideas along the way:
+
+- **Lossless, span-everywhere parsing.** Every node carries a file-absolute byte
+  range; line/column is derived on demand. This powers the language server
+  (go-to-definition, find-references) as well as diagnostics.
+- **Strict layering.** The `.lunas` syntax parser carries no JS/TS toolchain
+  dependency; all JS/TS work is isolated in `lunas_script`. Every crate builds for
+  `wasm32-unknown-unknown`, so the front end can run in the browser.
+- **Error recovery over hard failure.** The parser always returns a tree and
+  reports problems as diagnostics; public entry points never panic.
+- **Resolution, not codegen, computes the dependency graph.** `lunas_compiler`
+  produces a `ResolvedComponent`: each reactive variable gets an **index**, each
+  dynamic template part gets the **set of variable indices it reads** (already
+  expanded transitively through function calls), and each handler gets its **write
+  set**. The generator consumes this and does **not** re-analyze.
+
+> **Status:** the parser front end, the JS/TS analysis suite, and the resolution
+> layer are implemented and well-tested; code generation is the phase being built
+> out. The runtime that codegen targets already exists in `packages/lunas`.
+
+---
+
+## What the compiler emits
+
+A single-root component compiles to a `component(tag, attrs, HTML, setup)` factory
+(a multi-root template compiles to `fragment(...)` — no wrapper element). For a
+counter:
+
+```js
+import { component, box, deepBox, refs, on, bind, ifBlock, forBlock } from "lunas";
+
+// Static skeleton: comment-free, whitespace-free. Dynamic seams are NOT here —
+// they become runtime anchors. Hoisted once per module.
+const HTML = `<button>+1</button><p></p><ul></ul>`;
+
+export default component("div", { class: "counter" }, HTML, (c, props) => {
+  const count   = box(c, 0, props.start ?? 0);  // index 0: reassigned only
+  const history = deepBox(c, 1, []);            // index 1: deeply mutated
+
+  const [btn, p, ul] = refs(c.root, [[0], [1], [2]]);  // positional nav
+  on(btn, "click", () => { count.v++; history.v.push(count.v); });
+
+  bind(c, [0], () => { p.textContent = `count: ${count.v}`; });   // reactive text
+  ifBlock(c, ul, [0], () => count.v > 0, POSITIVE);               // :if
+  forBlock(c, ul, [1], () => history.v, ITEM);                    // :for
+});
+```
+
+The [syntax → output mapping](#pointers-to-the-design-docs) table in the design doc
+lists every directive's emitted shape (`${expr}`, `:attr`, `::model`, `@event`,
+`:if`/`:for`, child components, slots, `:class`/`:style`, `:html`, `:ref`,
+`<component :is>`, `<teleport>`).
+
+---
+
+## The runtime model
+
+The runtime is deliberately small — the whole reactive core fits in a few
+functions. Its shape follows from a handful of decisions.
+
+### 1. Static DOM is built in bulk by `innerHTML`
+
+The static skeleton is kept as one large, contiguous, **comment-free,
+whitespace-free** string and parsed in a single `root.innerHTML = HTML` off-DOM.
+A mostly-static component is essentially one native parse. This beats
+`cloneNode`-based construction on every machine measured (see below).
+
+### 2. Runtime text anchors mark the dynamic seams
+
+Dynamic insertion points (`:if`, `:for`, child components, text interpolations
+inside a run) are **not** in the static HTML. Instead, empty text nodes are
+created at wiring time and `insertBefore`d at their positions
+(`anchorBefore` / `anchorBeforeSplit` / `anchorAppend`). This keeps the static
+HTML on the browser's fast-path parser (comments would knock it off) while still
+marking every place content can appear or disappear.
+
+### 3. Positional refs, not ids
+
+Dynamic elements are reached by **positional navigation** — walking
+`childNodes[i]` from the root (`refs(root, paths)`) — not `id` + `getElementById`.
+Positional nav is ~2× faster, works on a **detached** tree (so all wiring happens
+before the tree is attached), and needs no id bytes or cleanup.
+
+### 4. Build detached → wire → attach once
+
+`document.createElement` → `innerHTML` → positional refs → create anchors → wire
+(`on`, `bind`, blocks) → return the detached root. The caller touches the live DOM
+exactly **once** via [`attach(root, host)`](./api/lifecycle.md#attach), which also
+fires the subtree's `onMount` hooks.
+
+### 5. Compile-time dependency dispatch (adjacency), no VDOM
+
+This is the reactive heart. Each reactive variable has an index; each dynamic part
+knows the exact set of indices it reads (its `deps`), resolved at compile time. The
+graph is stored as **adjacency**: each variable holds the list of update functions
+(`bind` records) that read it — the inverse of the parts' dependency sets.
+
+- A **write** enqueues that variable's dependent update functions, deduplicated by
+  a per-function flag.
+- A microtask **flush** runs the queue — only the affected parts, never every
+  dynamic part. Cost is O(affected).
+- There is **no runtime dependency discovery**, no per-node effect objects, no
+  virtual DOM diff. Updates are targeted node mutations and anchored
+  insert/remove; `innerHTML` is never used on update (re-parsing would destroy
+  state, listeners, focus, and selection).
+
+Adjacency is plain arrays, so it has **no width limit and no overflow case**. The
+compiler may specialize small components (≤ 31 reactive vars) to a single `number`
+bitmask for the smallest constant factor. `BigInt` is rejected outright: it is
+slower than `number` **and** raises the compatibility floor above the competition.
+The floor is `Proxy` (ES2015 / Safari 10+) — the same as Vue 3 / Svelte 5 / Solid.
+
+### 6. Per-variable box specialization
+
+The compiler classifies each reactive variable from its analysis and picks the
+lightest reactive cell:
+
+| Classification | Box | Cost |
+| --- | --- | --- |
+| Reassigned only (`x = …`) | [`box`](./api/reactivity.md#box) — plain getter/setter | lightest, no Proxy |
+| Deeply mutated (`arr.push`, `obj.k = …`) | [`deepBox`](./api/reactivity.md#deepbox) — `Proxy` sets the bit on mutation | Proxy only where needed |
+| Shared across components (prop passed down + mutated) | [`shared`](./api/reactivity.md#shared) — marks every dependent component | cross-component, no signals |
+
+Module-level state generalizes `shared` into a [store](./api/store.md): created
+once and imported by many components, same adjacency contract.
+
+### 7. Control-flow blocks and scopes
+
+Each block ([`ifBlock`](./api/blocks-and-control-flow.md#ifblock),
+[`ifChain`](./api/blocks-and-control-flow.md#ifchain),
+[`forBlock`](./api/blocks-and-control-flow.md#forblock), and the child/slot/teleport
+helpers) is anchored at a permanent text node and collects the binds created
+inside its content into a **scope**. When the content is removed, the scope is
+dropped — every inner bind is unregistered recursively, so removed content never
+receives updates and never leaks. Scope homing keeps the scope tree congruent with
+the block tree, so dropping a `:for` item's scope also drops the binds of any
+nested `:if`/`:for` alive inside it.
+
+`:for` is special: the **initial render** builds all items as one concatenated
+`innerHTML` parse (the fast path), then wires each item. **Updates** run a keyed
+reconciler — prefix/suffix trimming, a key→index map, and a
+longest-increasing-subsequence pass to minimize node moves. `items` is read lazily
+at flush time, so one flush sees the final state of any number of synchronous
+mutations.
+
+---
+
+## Benchmark-locked decisions
+
+Every non-obvious construction decision is backed by a cross-hardware
+micro-benchmark (Apple Silicon Mac + three GCP Xeon VMs, Chrome/Blink 149). The
+highlights (design doc §2 and §4):
+
+| Decision | Why (measured) |
+| --- | --- |
+| Static build = `innerHTML`, not `cloneNode` | `clone+append` is **1.1–1.32× slower** on every machine; the browser's parse beats the copy. |
+| No comments in the static HTML | A single comment node drops Blink out of its fast-path parser — the whole `innerHTML` becomes **~4–6× slower**. |
+| Anchors = runtime text nodes | Keeps the static HTML comment-free (fast path) while still marking dynamic insertion points. |
+| Element refs = positional navigation | ~2× faster than `getElementById`, works on a detached tree, no id bytes or cleanup. |
+| Whitespace-free static HTML | Stable `childNodes` positions for nav, plus smaller output. |
+| Adjacency dispatch, `number`/`Uint32Array`, never `BigInt` | O(affected) flush, no width limit; keeps the compatibility floor at `Proxy` (ES2015). |
+
+> The fast-path-parser penalty is a Blink characteristic; Gecko/WebKit were not
+> measured, so re-verify the comment penalty there before relying on it.
+
+**SSR is designed-for but deferred.** The static HTML string is exactly what a
+server would emit, and because anchors are created at runtime (not embedded),
+hydration can reuse the client wiring path — skip `innerHTML`, then run the same
+positional-nav + anchor-creation + `bind` steps against the server-rendered
+subtree. The SSR codegen mode is a later phase; nothing in the current design
+blocks it.
+
+---
+
+## Pointers to the design docs
+
+- **`crates/lunas_compiler/docs/output-design.md`** — the authoritative
+  compiled-output shape and runtime contract. §1–2 (where the speed comes from,
+  construction strategy), §4 (the reactivity model and box specialization), §5 (the
+  minimal runtime, every export sketched), §6 (the full syntax → output mapping),
+  §7–8 (build/mount lifecycle and control-flow details), §9 (SSR readiness).
+- **`crates/lunas_compiler/docs/for-diff-design.md`** — the keyed `:for`
+  reconciliation (update-path) algorithm.
+- **`crates/lunas_parser/DESIGN.md`** and
+  **`crates/lunas_parser/docs/template-design.md`** — the span model, layering, the
+  parser-vs-AST-parser split, and the template binding layer.
+- **`packages/lunas/README.md`** — the runtime package's own export table.
+- The [API reference](./README.md#api-reference) documents every runtime symbol
+  per-signature.


### PR DESCRIPTION
## Summary

Adds the runtime **API reference**, the top-level **docs index**, and an
**architecture overview** for Lunas. This PR writes only `docs/api/*`,
`docs/README.md`, and `docs/architecture.md` — no conflicts with the parallel
guide/components/built-ins/scaling docs agents.

### API reference (`docs/api/`)
- `reactivity.md` — `box`, `deepBox`, `shared`, `computed`, `watch`,
  `watchEffect`, `batch`, `nextTick`, `afterFlush`, plus the low-level core
  (`bind`, `markVar`, `flush`, `createContext`, `unbind`, scopes) marked as
  internal.
- `component.md` — `component` (+ `fragment` note), `refs`, `on`, `normClass`,
  `normStyle`, `mountChild`.
- `blocks-and-control-flow.md` — anchor helpers, `ifBlock`, `ifChain`,
  `forBlock`, `dynamicBlock`, `teleportBlock`, `slotBlock`, `slotContent`.
- `router.md` — `createRouter`, route shape, guards, `routerOutlet`,
  `routerLink`, `memoryHistory` (+ `historyAdapter` note).
- `store.md` — `createStore`, `useStore`, `subscribe`, `derivedStore`.
- `async.md` — `asyncComponent`, `mountAsyncChild`, `suspenseBlock`.
- `lifecycle.md` — `onMount`/`onDestroy`/`onUpdate`/`onActivated`/
  `onDeactivated`, `attach`, `emit`/`eventPropName`, `provide`/`inject`/
  `hasInjection`, `withTransition`, `keepAlive`.

Each symbol follows a consistent Signature / Description / Parameters / Returns /
Example / Notes format, with types taken from the `.d.ts` and behavior verified
against the `.mjs` sources.

### Docs index (`docs/README.md`)
Intro plus a linked table of contents for the entire docs tree (guide,
components, built-ins, scaling, api, architecture). Notes that SSR is
planned/deferred.

### Architecture (`docs/architecture.md`)
The compile pipeline (`.lunas` → parser → script analysis → resolve → codegen →
JS module), the runtime model (bulk `innerHTML`, runtime text anchors, positional
refs, compile-time adjacency dispatch, box specialization, no VDOM), the
benchmark-locked construction decisions (summarizing output-design.md §2/§4), and
pointers to the design docs.

## Notes
Sources of truth: `packages/lunas/src/*.mjs` + `types/*.d.ts`,
`packages/lunas/README.md`, and `crates/lunas_compiler/docs/output-design.md` /
`for-diff-design.md`. Cross-links to guide pages (produced by parallel agents)
use correct relative paths. Does not touch `roadmap.yml` or anything outside the
allowed doc paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)