### PR TITLE
test(runtime): expand router/store/async/lifecycle/emits/provide/transition/keepalive

### DIFF
--- a/packages/lunas/test/async.edge.test.mjs
+++ b/packages/lunas/test/async.edge.test.mjs
@@ -1,0 +1,294 @@
+// async.edge.test.mjs — additional edge-focused coverage for async.mjs
+// (asyncComponent / suspenseBlock) beyond async.test.mjs: throwing loaders,
+// props passthrough to loading/error factories, delay=0, timeout racing a
+// slow-but-eventual resolve, suspense with 3 children, destroying a suspense
+// AFTER it settled, and re-entrant nested boundary teardown order.
+// Run: node packages/lunas/test/async.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import {
+  asyncComponent,
+  mountAsyncChild,
+  suspenseBlock,
+} from "../src/async.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const after = (ms) => new Promise((r) => setTimeout(r, ms + 5));
+
+function defer() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const leaf = (tag, text) => () => {
+  const el = document.createElement(tag);
+  if (text != null) el.appendChild(document.createTextNode(text));
+  return el;
+};
+
+function host() {
+  const c = createContext(document.createElement("div"));
+  const container = c.root;
+  const anchor = anchorAppend(container);
+  return { c, container, anchor };
+}
+
+function html(container) {
+  return container.childNodes
+    .filter((n) => !(n.kind === "text" && n.data === ""))
+    .map((n) => n.outerHTML)
+    .join("");
+}
+
+// -- loader errors + props passthrough ---------------------------------------
+
+test("a loader that throws synchronously is treated as a rejection", async () => {
+  const { c, container, anchor } = host();
+  const factory = asyncComponent(
+    () => {
+      throw new Error("sync boom");
+    },
+    { error: leaf("em", "caught") }
+  );
+  mountAsyncChild(c, anchor, factory, {});
+  await tick();
+  assert.equal(html(container), "<em>caught</em>");
+});
+
+test("error factory receives {error, ...props} so it can render the message", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  let received = null;
+  const errorFactory = (props) => {
+    received = props;
+    const el = document.createElement("em");
+    el.appendChild(document.createTextNode(String(props.error && props.error.message)));
+    return el;
+  };
+  const factory = asyncComponent(() => d.promise, { error: errorFactory });
+  mountAsyncChild(c, anchor, factory, { userId: 42 });
+  d.reject(new Error("nope"));
+  await tick();
+  assert.equal(html(container), "<em>nope</em>");
+  assert.equal(received.userId, 42, "original props passed through alongside error");
+});
+
+test("delay: 0 shows loading immediately (no wait)", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    loading: leaf("p", "now"),
+    delay: 0,
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  await tick();
+  assert.equal(html(container), "<p>now</p>");
+  d.resolve(leaf("span", "done"));
+  await tick();
+  assert.equal(html(container), "<span>done</span>");
+});
+
+test("no loading factory configured: pending state renders nothing (no crash)", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, { delay: 0 });
+  mountAsyncChild(c, anchor, factory, {});
+  await tick();
+  assert.equal(html(container), "");
+  d.resolve(leaf("span", "x"));
+  await tick();
+  assert.equal(html(container), "<span>x</span>");
+});
+
+test("timeout longer than the actual resolve time never fires (no error flash)", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    error: leaf("em", "timed-out"),
+    timeout: 100,
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  d.resolve(leaf("span", "fast"));
+  await tick();
+  assert.equal(html(container), "<span>fast</span>");
+  await after(105); // let the timeout timer would-be fire
+  assert.equal(html(container), "<span>fast</span>", "resolve wins; timeout timer was cleared");
+});
+
+test("rejecting after a successful resolve has no further effect (settle is one-shot per token)", async () => {
+  const { c, container, anchor } = host();
+  // Two separate mounts of independently-loadable components share nothing;
+  // this exercises that a factory's own token only reacts to its own promise.
+  const d = defer();
+  const factory = asyncComponent(() => d.promise, {
+    error: leaf("em", "err"),
+  });
+  mountAsyncChild(c, anchor, factory, {});
+  d.resolve(leaf("span", "ok"));
+  await tick();
+  assert.equal(html(container), "<span>ok</span>");
+});
+
+// -- suspense: 3 children, partial settle ordering ---------------------------
+
+test("suspense waits for THREE children; order of resolution doesn't matter", async () => {
+  const { c, container, anchor } = host();
+  const d1 = defer();
+  const d2 = defer();
+  const d3 = defer();
+  const a1 = asyncComponent(() => d1.promise);
+  const a2 = asyncComponent(() => d2.promise);
+  const a3 = asyncComponent(() => d3.promise);
+
+  const s = suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      for (const a of [a1, a2, a3]) {
+        const an = anchorAppend(wrap);
+        mountAsyncChild(cc, an, a, {});
+      }
+      return wrap;
+    },
+    leaf("div", "wait3")
+  );
+
+  assert.equal(html(container), "<div>wait3</div>");
+  d2.resolve(leaf("b", "two"));
+  await tick();
+  assert.equal(s.isSettled(), false);
+  d3.resolve(leaf("i", "three"));
+  await tick();
+  assert.equal(s.isSettled(), false, "still waiting on the first child");
+  d1.resolve(leaf("u", "one"));
+  await tick();
+  assert.equal(s.isSettled(), true);
+  assert.equal(
+    html(container),
+    "<section><u>one</u><b>two</b><i>three</i></section>"
+  );
+});
+
+test("destroy() after the boundary already settled is a safe no-op teardown", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const child = asyncComponent(() => d.promise);
+  const s = suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const a = anchorAppend(wrap);
+      mountAsyncChild(cc, a, child, {});
+      return wrap;
+    },
+    leaf("div", "fallback")
+  );
+  d.resolve(leaf("span", "content"));
+  await tick();
+  assert.equal(s.isSettled(), true);
+  assert.equal(html(container), "<section><span>content</span></section>");
+  s.destroy(); // should remove the (now-revealed) content cleanly
+  assert.equal(html(container), "");
+});
+
+test("suspense fallback is optional: no fallback factory renders nothing while pending", async () => {
+  const { c, container, anchor } = host();
+  const d = defer();
+  const child = asyncComponent(() => d.promise);
+  suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const a = anchorAppend(document.createElement("section"));
+      const wrap = a.parentNode;
+      mountAsyncChild(cc, a, child, {});
+      return wrap;
+    },
+    null
+  );
+  assert.equal(html(container), "");
+  d.resolve(leaf("span", "later"));
+  await tick();
+  assert.equal(html(container), "<section><span>later</span></section>");
+});
+
+test("nested boundary: outer resolves first, inner still pending — outer waits on inner via its own anchor only", async () => {
+  // The outer boundary's pending count is driven only by async deps registered
+  // directly under it (its OWN contentFactory build), not by the inner
+  // boundary's internal pending count — the inner boundary absorbs its own
+  // child's pending state and only ever settles/reveals independently.
+  const { c, container, anchor } = host();
+  const dOuter = defer();
+  const dInner = defer();
+  const outerChild = asyncComponent(() => dOuter.promise);
+  const innerChild = asyncComponent(() => dInner.promise);
+
+  suspenseBlock(
+    c,
+    anchor,
+    (cc) => {
+      const wrap = document.createElement("section");
+      const ao = anchorAppend(wrap);
+      mountAsyncChild(cc, ao, outerChild, {});
+      const innerAnchor = anchorAppend(wrap);
+      suspenseBlock(
+        cc,
+        innerAnchor,
+        (ic) => {
+          const iwrap = document.createElement("article");
+          const ia = anchorAppend(iwrap);
+          mountAsyncChild(ic, ia, innerChild, {});
+          return iwrap;
+        },
+        leaf("small", "inner-fallback")
+      );
+      return wrap;
+    },
+    leaf("div", "outer-fallback")
+  );
+
+  assert.equal(html(container), "<div>outer-fallback</div>");
+  // Resolve outer first: outer boundary settles and reveals its content. The
+  // inner boundary's fallback is inserted at the inner anchor's own position
+  // (a sibling in `wrap`, not nested inside the not-yet-revealed `<article>`
+  // content), since the inner boundary manages its own insertion point
+  // independent of its (still-hidden) content nodes.
+  dOuter.resolve(leaf("b", "outer-done"));
+  await tick();
+  assert.equal(
+    html(container),
+    "<section><b>outer-done</b><small>inner-fallback</small></section>"
+  );
+  dInner.resolve(leaf("span", "inner-done"));
+  await tick();
+  assert.equal(
+    html(container),
+    "<section><b>outer-done</b><article><span>inner-done</span></article></section>"
+  );
+});
+
+test("mountAsyncChild unmount before the anchor is attached cancels the queued insert", async () => {
+  // Reproduces the buffered-insert path: build the async root but never let
+  // mountChild's anchor-attach step run (simulated by calling the async root's
+  // own unmount before draining), verifying no exception and no leaked timers.
+  const { c, container, anchor } = host();
+  const d = defer();
+  const factory = asyncComponent(() => d.promise);
+  const m = mountAsyncChild(c, anchor, factory, {});
+  m.unmount();
+  d.resolve(leaf("span", "late"));
+  await tick();
+  assert.equal(html(container), "", "unmounted before resolve never renders");
+});

--- a/packages/lunas/test/emits.edge.test.mjs
+++ b/packages/lunas/test/emits.edge.test.mjs
@@ -1,0 +1,173 @@
+// emits.edge.test.mjs — additional edge-focused coverage for emits.mjs beyond
+// emits.test.mjs: kebab-case edge cases, payload passthrough shapes, multiple
+// emits on one child, re-registering emits, and the "child emit never marks
+// parent dirty" contract exercised with markVar-driven reactivity more deeply.
+// Run: node packages/lunas/test/emits.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind } from "../src/core.mjs";
+import { box } from "../src/boxes.mjs";
+import { emit, registerEmits, eventPropName } from "../src/emits.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// -- eventPropName edge cases -------------------------------------------------
+
+test("eventPropName: single-letter and already-capitalized names", () => {
+  assert.equal(eventPropName("a"), "onA");
+  // "Close" (already capitalized) -> charAt(0).toUpperCase() is a no-op.
+  assert.equal(eventPropName("Close"), "onClose");
+});
+
+test("eventPropName: multiple consecutive hyphens collapse per hyphen-letter pair", () => {
+  assert.equal(eventPropName("a-b-c-d"), "onABCD");
+});
+
+test("eventPropName: trailing hyphen leaves nothing to capitalize after it", () => {
+  // "save-" -> replace(/-([a-z])/g,...) finds no letter after the trailing '-',
+  // so it's left as-is; "on" + "Save-" charAt(0) uppercased.
+  assert.equal(eventPropName("save-"), "onSave-");
+});
+
+// -- payload passthrough shapes -----------------------------------------------
+
+test("emit passes through primitive, object, array, and undefined payloads unchanged", () => {
+  const c = createContext(document.createElement("div"));
+  const got = [];
+  registerEmits(c, {
+    onA: (p) => got.push(p),
+  });
+  emit(c, "a", 42);
+  emit(c, "a", "str");
+  emit(c, "a", { x: 1 });
+  emit(c, "a", [1, 2, 3]);
+  emit(c, "a", undefined);
+  emit(c, "a", null);
+  assert.deepEqual(got, [42, "str", { x: 1 }, [1, 2, 3], undefined, null]);
+});
+
+test("emit with zero-arg payload (undefined) still invokes the handler", () => {
+  const c = createContext(document.createElement("div"));
+  let called = false;
+  let receivedArgCount = -1;
+  registerEmits(c, {
+    onPing: function () {
+      called = true;
+      receivedArgCount = arguments.length;
+    },
+  });
+  emit(c, "ping");
+  assert.equal(called, true);
+  assert.equal(receivedArgCount, 1, "emit always calls handler with exactly one arg (payload, possibly undefined)");
+});
+
+// -- multiple distinct events on one child ------------------------------------
+
+test("a child can emit several distinct event names, each routed independently", () => {
+  const c = createContext(document.createElement("div"));
+  const calls = [];
+  registerEmits(c, {
+    onSave: (p) => calls.push(["save", p]),
+    onCancel: (p) => calls.push(["cancel", p]),
+  });
+  emit(c, "save", 1);
+  emit(c, "cancel", 2);
+  emit(c, "save", 3);
+  assert.deepEqual(calls, [
+    ["save", 1],
+    ["cancel", 2],
+    ["save", 3],
+  ]);
+});
+
+test("emitting a name with no matching on<Name> prop is a no-op even when other handlers exist", () => {
+  const c = createContext(document.createElement("div"));
+  let saveCalled = false;
+  registerEmits(c, { onSave: () => (saveCalled = true) });
+  const ran = emit(c, "delete", {});
+  assert.equal(ran, false);
+  assert.equal(saveCalled, false);
+});
+
+// -- re-registering emits (e.g. prop update mid-life) -------------------------
+
+test("calling registerEmits again replaces the prior handler set entirely", () => {
+  const c = createContext(document.createElement("div"));
+  let firstCalled = false;
+  let secondCalled = false;
+  registerEmits(c, { onSave: () => (firstCalled = true) });
+  registerEmits(c, { onSave: () => (secondCalled = true) }); // fresh props object
+  emit(c, "save", {});
+  assert.equal(firstCalled, false, "old handler set discarded");
+  assert.equal(secondCalled, true);
+});
+
+test("registerEmits with declared list allows the declared event silently (no warning)", () => {
+  const c = createContext(document.createElement("div"));
+  let warned = false;
+  const orig = console.warn;
+  console.warn = () => (warned = true);
+  try {
+    registerEmits(c, { onSave: () => {} }, ["save", "cancel"]);
+    emit(c, "save", 1);
+    assert.equal(warned, false);
+  } finally {
+    console.warn = orig;
+  }
+});
+
+// -- emit does not mark the parent dirty: deeper multi-bind exercise ---------
+
+test("emit handler mutating a DIFFERENT parent box than the one a bind reads leaves that bind untouched", async () => {
+  const parent = createContext(document.createElement("div"));
+  const watched = box(parent, 0, "a");
+  const unrelated = box(parent, 1, "z");
+  let runs = 0;
+  bind(parent, [0], () => {
+    watched.v;
+    runs++;
+  });
+  runs = 0;
+
+  const child = createContext(document.createElement("span"));
+  registerEmits(child, {
+    onPing: () => {
+      unrelated.v = "changed"; // marks index 1, not 0
+    },
+  });
+  emit(child, "ping", {});
+  await tick();
+  assert.equal(runs, 0, "bind on index 0 unaffected by a write to index 1");
+});
+
+test("emit synchronously invokes the handler; any parent mark is still batched to a microtask", async () => {
+  const parent = createContext(document.createElement("div"));
+  const v = box(parent, 0, 0);
+  const order = [];
+  bind(parent, [0], () => {
+    order.push("bind:" + v.v);
+  });
+  order.length = 0;
+
+  const child = createContext(document.createElement("span"));
+  registerEmits(child, {
+    onBump: () => {
+      v.v = v.v + 1;
+      order.push("handler-done");
+    },
+  });
+  emit(child, "bump", {});
+  order.push("after-emit-call");
+  assert.deepEqual(order, ["handler-done", "after-emit-call"], "flush hasn't run yet — it's a microtask");
+  await tick();
+  assert.deepEqual(order, ["handler-done", "after-emit-call", "bind:1"]);
+});
+
+test("emit returns false and does not throw when c is null/undefined", () => {
+  assert.equal(emit(null, "x", 1), false);
+  assert.equal(emit(undefined, "x", 1), false);
+});

--- a/packages/lunas/test/keepalive.edge.test.mjs
+++ b/packages/lunas/test/keepalive.edge.test.mjs
@@ -1,0 +1,188 @@
+// keepalive.edge.test.mjs — additional edge-focused coverage for
+// keepalive.mjs beyond keepalive.test.mjs: no-cap (Infinity) never evicts,
+// max:1 forces eviction on every switch, has()/size across the eviction
+// lifecycle, showing the currently-active key again is a true no-op (identity
+// + no DOM churn), destroy() on an empty cache, and re-showing an evicted key
+// rebuilds a fresh instance (new node identity + fresh onMount).
+// Run: node packages/lunas/test/keepalive.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { keepAlive } from "../src/keepalive.mjs";
+import { onDestroy, onActivated, onDeactivated, onMount } from "../src/lifecycle.mjs";
+
+installDom();
+
+function comp(id, log) {
+  return () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-id", id);
+    root.appendChild(document.createTextNode(id));
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    onMount(c, () => log.push("mount:" + id));
+    onDestroy(c, () => log.push("destroy:" + id));
+    onActivated(c, () => log.push("activate:" + id));
+    onDeactivated(c, () => log.push("deactivate:" + id));
+    return root;
+  };
+}
+
+function host() {
+  const c = createContext(document.createElement("div"));
+  c.root._lunasAttached = true;
+  const anchor = anchorAppend(c.root);
+  return { c, container: c.root, anchor };
+}
+
+const shown = (container) =>
+  container.childNodes
+    .filter((n) => !(n.kind === "text" && n.data === ""))
+    .map((n) => n.getAttribute("data-id"))
+    .join(",");
+
+// -- unbounded cache never evicts ---------------------------------------------
+
+test("no max option: cache never evicts however many keys are shown", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({}); // no max => Infinity
+  for (const id of ["A", "B", "C", "D", "E"]) {
+    ka.show(c, anchor, id, comp(id, log), {});
+  }
+  assert.equal(ka.size, 5);
+  assert.equal(log.filter((e) => e.startsWith("destroy:")).length, 0);
+});
+
+// -- max:1 forces eviction on every switch ------------------------------------
+
+test("max:1 evicts the previous instance on every single switch", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 1 });
+  ka.show(c, anchor, "A", comp("A", log), {});
+  ka.show(c, anchor, "B", comp("B", log), {});
+  assert.equal(ka.size, 1);
+  assert.equal(ka.has("A"), false, "A evicted immediately, no keepalive with max:1");
+  assert.ok(log.includes("destroy:A"));
+  ka.show(c, anchor, "C", comp("C", log), {});
+  assert.equal(ka.has("B"), false);
+  assert.ok(log.includes("destroy:B"));
+});
+
+// -- has()/size across full lifecycle -----------------------------------------
+
+test("has() and size track cache membership precisely through mount/evict", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 2 });
+  assert.equal(ka.size, 0);
+  ka.show(c, anchor, "A", comp("A", log), {});
+  assert.equal(ka.size, 1);
+  assert.equal(ka.has("A"), true);
+  ka.show(c, anchor, "B", comp("B", log), {});
+  assert.equal(ka.size, 2);
+  ka.show(c, anchor, "C", comp("C", log), {}); // evicts A
+  assert.equal(ka.size, 2);
+  assert.equal(ka.has("A"), false);
+  assert.equal(ka.has("B"), true);
+  assert.equal(ka.has("C"), true);
+});
+
+// -- re-showing the active key: true no-op ------------------------------------
+
+test("re-showing the currently active key does not touch the DOM node at all", () => {
+  const { c, container, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  const A = comp("A", log);
+  const h1 = ka.show(c, anchor, "A", A, {});
+  const nodeBefore = h1.root;
+  const childCountBefore = container.childNodes.length;
+  const h2 = ka.show(c, anchor, "A", A, {});
+  assert.strictEqual(h2.root, nodeBefore);
+  assert.equal(container.childNodes.length, childCountBefore);
+  assert.equal(shown(container), "A");
+});
+
+// -- destroy() on an empty cache is a safe no-op ------------------------------
+
+test("destroy() on a cache with nothing shown is a safe no-op", () => {
+  const ka = keepAlive({});
+  assert.doesNotThrow(() => ka.destroy());
+  assert.equal(ka.size, 0);
+});
+
+test("destroy() then show() again works: a fresh keepAlive lifecycle after full teardown", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp("A", log), {});
+  ka.destroy();
+  assert.equal(ka.size, 0);
+  // Reuse the SAME keepAlive controller after destroy(): showing "A" again
+  // builds a brand-new instance (nothing cached anymore).
+  const h = ka.show(c, anchor, "A", comp("A", log), {});
+  assert.ok(h.root);
+  assert.equal(ka.size, 1);
+});
+
+// -- re-showing an evicted key rebuilds a fresh instance ----------------------
+
+test("showing a key again after it was LRU-evicted builds a brand-new instance (fresh node, fresh mount)", () => {
+  const { c, container, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 1 });
+  const h1 = ka.show(c, anchor, "A", comp("A", log), {});
+  const firstNode = h1.root;
+  ka.show(c, anchor, "B", comp("B", log), {}); // evicts A
+  assert.equal(ka.has("A"), false);
+  const h2 = ka.show(c, anchor, "A", comp("A", log), {}); // fresh A
+  assert.notStrictEqual(h2.root, firstNode, "a new node was built, not reused");
+  assert.equal(
+    log.filter((e) => e === "mount:A").length,
+    2,
+    "A mounted twice: once originally, once after eviction+rebuild"
+  );
+  assert.equal(shown(container), "A");
+});
+
+// -- deactivate is idempotent: showing the same non-active key repeatedly ----
+
+test("switching back and forth between two keys repeatedly never double-destroys", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({});
+  const A = comp("A", log);
+  const B = comp("B", log);
+  ka.show(c, anchor, "A", A, {});
+  ka.show(c, anchor, "B", B, {});
+  ka.show(c, anchor, "A", A, {});
+  ka.show(c, anchor, "B", B, {});
+  ka.show(c, anchor, "A", A, {});
+  assert.equal(log.filter((e) => e === "destroy:A").length, 0);
+  assert.equal(log.filter((e) => e === "destroy:B").length, 0);
+  assert.equal(log.filter((e) => e === "mount:A").length, 1, "A only ever mounted once (reactivated after)");
+  assert.equal(log.filter((e) => e === "mount:B").length, 1);
+});
+
+// -- keepAlive with max: 0 evicts everything immediately (edge boundary) -----
+
+test("max:0 evicts synchronously — nothing stays cached across a show", () => {
+  const { c, anchor } = host();
+  const log = [];
+  const ka = keepAlive({ max: 0 });
+  ka.show(c, anchor, "A", comp("A", log), {});
+  // trim() runs after the just-touched key is set as current and is never the
+  // victim, so with max:0 the JUST-shown entry survives trim (never evicting
+  // the just-touched key) — cache holds exactly the most recent entry.
+  assert.equal(ka.size, 1);
+  assert.equal(ka.has("A"), true);
+  ka.show(c, anchor, "B", comp("B", log), {});
+  assert.equal(ka.size, 1);
+  assert.equal(ka.has("A"), false, "A evicted to make room under max:0");
+  assert.equal(ka.has("B"), true);
+});

--- a/packages/lunas/test/lifecycle.edge.test.mjs
+++ b/packages/lunas/test/lifecycle.edge.test.mjs
@@ -1,0 +1,282 @@
+// lifecycle.edge.test.mjs — additional edge-focused coverage for
+// lifecycle.mjs beyond lifecycle.test.mjs: onDestroy across every unmount
+// path (forBlock/ifBlock content teardown, keepalive eviction), onUpdate
+// across multiple flushes, deep nesting order, and onActivated/onDeactivated
+// integration via keepAlive.
+// Run: node packages/lunas/test/lifecycle.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind, markVar } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { mountChild, ifBlock, forBlock } from "../src/blocks.mjs";
+import { keepAlive } from "../src/keepalive.mjs";
+import {
+  onMount,
+  onDestroy,
+  onUpdate,
+  onActivated,
+  onDeactivated,
+  attach,
+  isLive,
+} from "../src/lifecycle.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function makeComponent(tag, setup) {
+  return (props) => {
+    const root = document.createElement(tag);
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    if (setup) setup(c, props || {});
+    return root;
+  };
+}
+
+// -- onDestroy across ifBlock teardown ---------------------------------------
+
+// KNOWN GAP (filed, not fixed here — see PR note): output-design.md §7 states
+// plainly that "every unmount path (mountChild.unmount, block item teardown,
+// keep-alive eviction) funnels through runDestroy(c)". In practice, ifBlock /
+// ifChain / forBlock's teardown (`removeAll` / `host.remove`) only removes DOM
+// nodes and drops the reactive SCOPE (unregistering binds) — it never calls
+// `.unmount()` on a child mounted via `mountChild` inside that branch/item, so
+// that child's onDestroy queue never fires when the branch is hidden or the
+// item is removed from a :for list (only an explicit outer mountChild.unmount()
+// — e.g. via dynamicBlock/keepAlive, which DO call child.unmount() themselves —
+// reaches runDestroy). A fix belongs in blocks.mjs (e.g. having mountChild
+// piggyback an unmount hook onto `c.scope.subs` the same way store.mjs's
+// useStore does for detach — see its comment on the unbind-alive trick), which
+// is out of scope for this test-only PR (src/*.mjs is off-limits here). Skipped
+// with a failing-if-unskipped assertion preserved for whoever picks this up.
+test("onDestroy fires when an ifBlock branch containing a mounted child is torn down", { skip: "known gap: ifBlock teardown does not call runDestroy on children mounted inside the branch (see comment above / PR note)" }, () => {
+  const order = [];
+  const child = makeComponent("span", (c) => onDestroy(c, () => order.push("child-destroy")));
+  const parentCtx = createContext(document.createElement("div"));
+  const anchor = anchorAppend(parentCtx.root);
+  let show = true;
+  const block = ifBlock(
+    parentCtx,
+    anchor,
+    [0],
+    () => show,
+    () => {
+      const a = anchorAppend(document.createElement("div"));
+      const wrap = a.parentNode;
+      mountChild(parentCtx, a, child, {});
+      return wrap;
+    }
+  );
+  assert.deepEqual(order, []);
+  show = false;
+  block.update();
+  assert.deepEqual(order, ["child-destroy"], "hiding the branch destroys its mounted child");
+});
+
+test("onDestroy does not re-fire when the ifBlock branch is shown again after hiding", { skip: "known gap: see the ifBlock teardown note above" }, () => {
+  const counts = { d: 0 };
+  const child = makeComponent("span", (c) => onDestroy(c, () => counts.d++));
+  const parentCtx = createContext(document.createElement("div"));
+  const anchor = anchorAppend(parentCtx.root);
+  let show = true;
+  const block = ifBlock(
+    parentCtx,
+    anchor,
+    [0],
+    () => show,
+    () => {
+      const a = anchorAppend(document.createElement("div"));
+      const wrap = a.parentNode;
+      mountChild(parentCtx, a, child, {});
+      return wrap;
+    }
+  );
+  show = false;
+  block.update(); // destroy #1 (old instance)
+  show = true;
+  block.update(); // fresh instance built, no destroy
+  show = false;
+  block.update(); // destroy #2 (new instance) — each instance destroyed once
+  assert.equal(counts.d, 2, "one destroy per distinct mounted instance, none doubled");
+});
+
+// -- onDestroy across forBlock item removal ----------------------------------
+
+test("onDestroy fires for each item's mounted child when forBlock removes it", { skip: "known gap: forBlock's host.remove() does not call runDestroy on children mounted inside an item (see ifBlock note above)" }, () => {
+  const order = [];
+  const childFor = (id) =>
+    makeComponent("li", (c) => onDestroy(c, () => order.push("destroy:" + id)));
+  const parentCtx = createContext(document.createElement("ul"));
+  const anchor = anchorAppend(parentCtx.root);
+  let items = [1, 2, 3];
+  const block = forBlock(parentCtx, anchor, [0], () => items, {
+    make: (d) => {
+      const a = anchorAppend(document.createElement("li"));
+      const wrap = a.parentNode;
+      mountChild(parentCtx, a, childFor(d), {});
+      return wrap;
+    },
+    keyOf: (d) => d,
+  });
+  items = [1, 3]; // remove item 2
+  block.update();
+  assert.deepEqual(order, ["destroy:2"]);
+  items = [];
+  block.update();
+  assert.deepEqual(order.sort(), ["destroy:1", "destroy:2", "destroy:3"].sort());
+});
+
+test("forBlock destroy() tears down every remaining item's onDestroy", { skip: "known gap: forBlock destroy()'s per-item removal path shares host.remove(), same runDestroy gap as above" }, () => {
+  const order = [];
+  const childFor = (id) =>
+    makeComponent("li", (c) => onDestroy(c, () => order.push(id)));
+  const parentCtx = createContext(document.createElement("ul"));
+  const anchor = anchorAppend(parentCtx.root);
+  const items = ["a", "b"];
+  const block = forBlock(parentCtx, anchor, [0], () => items, {
+    make: (d) => {
+      const a = anchorAppend(document.createElement("li"));
+      const wrap = a.parentNode;
+      mountChild(parentCtx, a, childFor(d), {});
+      return wrap;
+    },
+    keyOf: (d) => d,
+  });
+  block.destroy();
+  assert.deepEqual(order.sort(), ["a", "b"]);
+});
+
+// -- onDestroy via keepalive eviction (not deactivation) ---------------------
+
+test("keepAlive deactivation does NOT fire onDestroy; only true eviction does", () => {
+  const order = [];
+  const comp = (id) =>
+    makeComponent("div", (c) => {
+      onDestroy(c, () => order.push("destroy:" + id));
+      onDeactivated(c, () => order.push("deactivate:" + id));
+    });
+  const c = createContext(document.createElement("div"));
+  const anchor = anchorAppend(c.root);
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp("A"), {});
+  ka.show(c, anchor, "B", comp("B"), {}); // deactivates A
+  assert.deepEqual(order, ["deactivate:A"]);
+  ka.destroy(); // now truly evicts both
+  assert.ok(order.includes("destroy:A"));
+  assert.ok(order.includes("destroy:B"));
+});
+
+// -- onUpdate: multi-flush + multiple onUpdate registrations -----------------
+
+test("onUpdate: two callbacks registered on the same context both fire every flush", async () => {
+  const c = createContext(document.createElement("div"));
+  let a = 0;
+  let b = 0;
+  onUpdate(c, () => a++);
+  onUpdate(c, () => b++);
+  bind(c, [0], () => {});
+  markVar(c, 0);
+  await tick();
+  assert.equal(a, 1);
+  assert.equal(b, 1);
+  markVar(c, 0);
+  await tick();
+  assert.equal(a, 2);
+  assert.equal(b, 2);
+});
+
+test("onUpdate registered after the first flush still fires on later flushes", async () => {
+  const c = createContext(document.createElement("div"));
+  bind(c, [0], () => {});
+  markVar(c, 0);
+  await tick(); // flush #1, no onUpdate registered yet
+  let updates = 0;
+  onUpdate(c, () => updates++);
+  markVar(c, 0);
+  await tick();
+  assert.equal(updates, 1);
+});
+
+// -- nested children mount/destroy ordering ----------------------------------
+
+test("three-level nesting: onMount fires deepest-first via one top-level attach", () => {
+  const order = [];
+  const grandchild = makeComponent("i", (c) => onMount(c, () => order.push("gc")));
+  const child = makeComponent("span", (c) => {
+    onMount(c, () => order.push("c"));
+    const a = anchorAppend(c.root);
+    mountChild(c, a, grandchild, {});
+  });
+  const parent = makeComponent("div", (c) => {
+    onMount(c, () => order.push("p"));
+    const a = anchorAppend(c.root);
+    mountChild(c, a, child, {});
+  });
+  const root = parent();
+  attach(root, document.createElement("body"));
+  assert.deepEqual(order, ["gc", "c", "p"]);
+});
+
+test("three-level nesting: onDestroy fires deepest-first on a single top unmount", () => {
+  const order = [];
+  const grandchild = makeComponent("i", (c) => onDestroy(c, () => order.push("gc")));
+  const child = makeComponent("span", (c) => {
+    onDestroy(c, () => order.push("c"));
+    const a = anchorAppend(c.root);
+    mountChild(c, a, grandchild, {});
+  });
+  const parentCtx = createContext(document.createElement("div"));
+  const a = anchorAppend(parentCtx.root);
+  const h = mountChild(parentCtx, a, child, {});
+  h.unmount();
+  assert.deepEqual(order, ["gc", "c"]);
+});
+
+// -- isLive edge cases --------------------------------------------------------
+
+test("isLive returns false for a detached node with no _lunasAttached ancestor", () => {
+  const el = document.createElement("div");
+  assert.equal(isLive(el), false);
+});
+
+test("isLive returns true once an ancestor is flagged _lunasAttached", () => {
+  const root = document.createElement("div");
+  const child = document.createElement("span");
+  root.appendChild(child);
+  root._lunasAttached = true;
+  assert.equal(isLive(child), true);
+});
+
+test("isLive(null) is false, not a throw", () => {
+  assert.equal(isLive(null), false);
+});
+
+// -- onActivated fires immediately on first activation, every reactivation --
+
+test("onActivated fires on first mount AND every subsequent reactivation", () => {
+  const order = [];
+  const comp = () =>
+    makeComponent("div", (c) => onActivated(c, () => order.push("activated")));
+  const c = createContext(document.createElement("div"));
+  const anchor = anchorAppend(c.root);
+  const ka = keepAlive({});
+  ka.show(c, anchor, "A", comp(), {});
+  ka.show(c, anchor, "B", comp(), {});
+  ka.show(c, anchor, "A", comp(), {}); // reactivate
+  assert.deepEqual(order, ["activated", "activated", "activated"]);
+});
+
+// -- onMount/onDestroy are no-ops for a non-function argument ----------------
+
+test("onMount/onDestroy/onUpdate silently ignore a non-function fn (never-panic)", () => {
+  const c = createContext(document.createElement("div"));
+  assert.doesNotThrow(() => {
+    onMount(c, null);
+    onMount(c, undefined);
+    onDestroy(c, 42);
+    onUpdate(c, "nope");
+  });
+});

--- a/packages/lunas/test/provide.edge.test.mjs
+++ b/packages/lunas/test/provide.edge.test.mjs
@@ -1,0 +1,203 @@
+// provide.edge.test.mjs — additional edge-focused coverage for provide.mjs
+// beyond provide.test.mjs: deeper chains (4-5 levels), sibling isolation
+// (one branch's provide doesn't leak to another), overwriting a provide on
+// the same context, provide after a child already mounted (late provide),
+// and inject reading a falsy-but-defined value correctly.
+// Run: node packages/lunas/test/provide.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext } from "../src/core.mjs";
+import { anchorAppend } from "../src/dom.mjs";
+import { mountChild } from "../src/blocks.mjs";
+import { provide, inject, hasInjection } from "../src/provide.mjs";
+
+installDom();
+
+// Build a chain of N contexts linked as real mountChild children.
+function chain(depth, setups) {
+  const ctxs = [];
+  const makeFactory = (i) => (props) => {
+    const root = document.createElement("div");
+    const c = createContext(root);
+    root.__lunasCtx = c;
+    ctxs[i] = c;
+    if (setups[i]) setups[i](c);
+    if (i + 1 < depth) {
+      const a = anchorAppend(root);
+      mountChild(c, a, makeFactory(i + 1), {});
+    }
+    return root;
+  };
+  makeFactory(0)();
+  return ctxs;
+}
+
+// Build a tree with a branching factor: root -> [branchA, branchB], each
+// with its own linear chain of `depth` further levels.
+function tree(setupRoot, branches) {
+  const root = document.createElement("div");
+  const rootCtx = createContext(root);
+  root.__lunasCtx = rootCtx;
+  if (setupRoot) setupRoot(rootCtx);
+  const branchCtxs = branches.map((setups) => {
+    const a = anchorAppend(root);
+    const ctxs = [];
+    const makeFactory = (i) => (props) => {
+      const r = document.createElement("div");
+      const c = createContext(r);
+      r.__lunasCtx = c;
+      c.parent = null; // will be set by mountChild for the top of this branch
+      ctxs[i] = c;
+      if (setups[i]) setups[i](c);
+      if (i + 1 < setups.length) {
+        const aa = anchorAppend(r);
+        mountChild(c, aa, makeFactory(i + 1), {});
+      }
+      return r;
+    };
+    mountChild(rootCtx, a, makeFactory(0), {});
+    return ctxs;
+  });
+  return { rootCtx, branchCtxs };
+}
+
+// -- deeper chains -------------------------------------------------------------
+
+test("inject resolves through a 5-level chain", () => {
+  const ctxs = chain(5, [
+    (c) => provide(c, "k", "root-value"),
+    () => {},
+    () => {},
+    () => {},
+    () => {},
+  ]);
+  assert.equal(inject(ctxs[4], "k"), "root-value");
+});
+
+test("shadowing at the middle of a 5-level chain only affects descendants below it", () => {
+  const ctxs = chain(5, [
+    (c) => provide(c, "k", "L0"),
+    () => {},
+    (c) => provide(c, "k", "L2"), // shadow starting here
+    () => {},
+    () => {},
+  ]);
+  assert.equal(inject(ctxs[0], "k"), "L0");
+  assert.equal(inject(ctxs[1], "k"), "L0");
+  assert.equal(inject(ctxs[2], "k"), "L2");
+  assert.equal(inject(ctxs[3], "k"), "L2");
+  assert.equal(inject(ctxs[4], "k"), "L2");
+});
+
+// -- sibling branch isolation --------------------------------------------------
+
+test("a provide in one branch never leaks into a sibling branch", () => {
+  const { branchCtxs } = tree(null, [
+    [(c) => provide(c, "theme", "dark")],
+    [() => {}],
+  ]);
+  assert.equal(inject(branchCtxs[0][0], "theme"), "dark");
+  assert.equal(inject(branchCtxs[1][0], "theme", "fallback"), "fallback",
+    "sibling branch never saw branch A's provide");
+});
+
+test("root-level provide is visible to every branch (common ancestor)", () => {
+  const { branchCtxs } = tree((root) => provide(root, "app", "shared"), [
+    [() => {}],
+    [() => {}],
+  ]);
+  assert.equal(inject(branchCtxs[0][0], "app"), "shared");
+  assert.equal(inject(branchCtxs[1][0], "app"), "shared");
+});
+
+// -- overwriting a provide on the same context ---------------------------------
+
+test("a second provide() call with the same key on the same context overwrites the first", () => {
+  const c = createContext(document.createElement("div"));
+  provide(c, "k", "first");
+  assert.equal(inject(c, "k"), "first");
+  provide(c, "k", "second");
+  assert.equal(inject(c, "k"), "second");
+});
+
+test("provide() returns the value it stored", () => {
+  const c = createContext(document.createElement("div"));
+  const ret = provide(c, "k", { a: 1 });
+  assert.deepEqual(ret, { a: 1 });
+});
+
+// -- late provide: child mounted before parent's provide() runs ---------------
+
+test("a provide registered on the parent after the child already mounted is still visible (chain is live, walked lazily on inject)", () => {
+  const parentCtx = createContext(document.createElement("div"));
+  const a = anchorAppend(parentCtx.root);
+  let childCtx;
+  const childFactory = () => {
+    const root = document.createElement("span");
+    childCtx = createContext(root);
+    root.__lunasCtx = childCtx;
+    return root;
+  };
+  mountChild(parentCtx, a, childFactory, {});
+  // Parent provides AFTER the child was already mounted — inject walks the
+  // live chain at call time, so this still resolves.
+  provide(parentCtx, "late", "value");
+  assert.equal(inject(childCtx, "late"), "value");
+});
+
+// -- falsy-but-provided values --------------------------------------------------
+
+test("inject distinguishes a provided falsy value (0, '', false) from absent", () => {
+  const ctxs = chain(2, [
+    (c) => {
+      provide(c, "zero", 0);
+      provide(c, "empty", "");
+      provide(c, "falseVal", false);
+    },
+    () => {},
+  ]);
+  assert.strictEqual(inject(ctxs[1], "zero", "def"), 0);
+  assert.strictEqual(inject(ctxs[1], "empty", "def"), "");
+  assert.strictEqual(inject(ctxs[1], "falseVal", "def"), false);
+  assert.strictEqual(hasInjection(ctxs[1], "zero"), true);
+});
+
+// -- multiple distinct keys on one context --------------------------------------
+
+test("a single context can provide many independent keys", () => {
+  const c = createContext(document.createElement("div"));
+  provide(c, "a", 1);
+  provide(c, "b", 2);
+  provide(c, "c", 3);
+  assert.equal(inject(c, "a"), 1);
+  assert.equal(inject(c, "b"), 2);
+  assert.equal(inject(c, "c"), 3);
+  assert.equal(hasInjection(c, "d"), false);
+});
+
+// -- Symbol keys don't collide with same-named string keys across levels ------
+
+test("a Symbol key and a same-spelled string key coexist without collision across the chain", () => {
+  const SYM = Symbol("theme");
+  const ctxs = chain(3, [
+    (c) => {
+      provide(c, SYM, "symbol-value");
+      provide(c, "theme", "string-value");
+    },
+    () => {},
+    () => {},
+  ]);
+  assert.equal(inject(ctxs[2], SYM), "symbol-value");
+  assert.equal(inject(ctxs[2], "theme"), "string-value");
+});
+
+test("two distinct Symbol() calls with the same description are different keys", () => {
+  const a = Symbol("dup");
+  const b = Symbol("dup");
+  const c = createContext(document.createElement("div"));
+  provide(c, a, "A");
+  assert.equal(inject(c, a), "A");
+  assert.equal(inject(c, b, "missing"), "missing");
+});

--- a/packages/lunas/test/router.edge.test.mjs
+++ b/packages/lunas/test/router.edge.test.mjs
@@ -1,0 +1,394 @@
+// router.edge.test.mjs — additional edge-focused coverage for router.mjs:
+// nested/param/catch-all precedence details, query-string edge cases, more
+// navigation sequencing, guard redirects, outlet remount rules, and link
+// fallthrough behavior not already covered by router.test.mjs.
+// Run: node packages/lunas/test/router.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { installDom } from "./dom-shim.mjs";
+import { createContext, bind } from "../src/core.mjs";
+import { component, anchorAppend } from "../src/dom.mjs";
+import {
+  createRouter,
+  memoryHistory,
+  routerOutlet,
+  routerLink,
+  parseQuery,
+  normalizePath,
+} from "../src/router.mjs";
+
+installDom();
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function makeComponent(tag, sink) {
+  return component("div", {}, "", (c, props) => {
+    c.root.setAttribute("data-page", tag);
+    if (sink) sink.push({ tag, props });
+  });
+}
+
+// -- matching precedence, deeper nesting -------------------------------------
+
+test("nested static beats nested param at every depth", () => {
+  const routes = [
+    { path: "/a/:x/b", component: makeComponent("param") },
+    { path: "/a/lit/b", component: makeComponent("static") },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/a/lit/b") });
+  assert.strictEqual(router.current.matched.path, "/a/lit/b");
+});
+
+test("catch-all only wins when nothing more specific matches", async () => {
+  const routes = [
+    { path: "/a/:x", component: makeComponent("param") },
+    { path: "/*rest", component: makeComponent("catch") },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/a/1") });
+  assert.strictEqual(router.current.matched.path, "/a/:x");
+  await router.push("/a/1/2/3");
+  assert.strictEqual(router.current.matched.path, "/*rest");
+});
+
+test("declaration order breaks ties between equally-ranked routes", () => {
+  const routes = [
+    { path: "/:a/:b", component: makeComponent("first") },
+    { path: "/:x/:y", component: makeComponent("second") },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/1/2") });
+  assert.strictEqual(
+    router.current.matched.path,
+    "/:a/:b",
+    "first declared route wins a tie"
+  );
+});
+
+test("segment count must match exactly when there's no catch-all", () => {
+  const routes = [{ path: "/a/:x", component: makeComponent("p") }];
+  const router = createRouter(routes, { history: memoryHistory("/a/1/2") });
+  assert.strictEqual(
+    router.current.matched,
+    null,
+    "extra trailing segment does not match a fixed-length spec"
+  );
+});
+
+// -- trailing slash + root ----------------------------------------------------
+
+test("trailing slash on root path normalizes to /", () => {
+  const router = createRouter(
+    [{ path: "/", component: makeComponent("home") }],
+    { history: memoryHistory("/") }
+  );
+  assert.strictEqual(router.current.path, "/");
+  assert.strictEqual(router.current.matched.path, "/");
+});
+
+test("multiple trailing slashes collapse the same as one", () => {
+  const router = createRouter(
+    [{ path: "/a/b", component: makeComponent("ab") }],
+    { history: memoryHistory("/a/b///") }
+  );
+  assert.strictEqual(router.current.path, "/a/b");
+  assert.strictEqual(router.current.matched.path, "/a/b");
+});
+
+// -- query parsing edge cases -------------------------------------------------
+
+test("query parse: empty query string yields an empty object", () => {
+  assert.deepStrictEqual(parseQuery("/x"), {});
+  assert.deepStrictEqual(parseQuery("/x?"), {});
+});
+
+test("query parse: repeated keys keep the LAST value", () => {
+  assert.deepStrictEqual(parseQuery("/x?a=1&a=2&a=3"), { a: "3" });
+});
+
+test("query parse: percent-encoded keys and values decode correctly", () => {
+  assert.deepStrictEqual(parseQuery("/x?na%20me=%E2%98%83"), {
+    "na me": "☃",
+  });
+});
+
+test("query parse: malformed percent-sequence falls back to raw text", () => {
+  // decode() catches the URIError and returns the raw (still-encoded) string.
+  assert.deepStrictEqual(parseQuery("/x?bad=%E0%A4%A"), { bad: "%E0%A4%A" });
+});
+
+test("query parse: value-less key (no '=') yields empty string", () => {
+  assert.deepStrictEqual(parseQuery("/x?flag"), { flag: "" });
+  assert.deepStrictEqual(parseQuery("/x?flag&a=1"), { flag: "", a: "1" });
+});
+
+test("normalizePath: query string is stripped", () => {
+  assert.strictEqual(normalizePath("/a/b?x=1"), "/a/b");
+});
+
+// -- navigation: push/replace/back/forward stack semantics -------------------
+
+test("push after back drops the forward stack (browser semantics)", async () => {
+  const hist = memoryHistory("/a");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+  });
+  await router.push("/b");
+  await router.push("/c");
+  router.back(); // -> /b
+  await tick();
+  assert.strictEqual(router.current.path, "/b");
+  await router.push("/d"); // drop the "/c" forward entry
+  assert.strictEqual(router.current.path, "/d");
+  router.forward(); // nothing beyond /d
+  await tick();
+  assert.strictEqual(
+    router.current.path,
+    "/d",
+    "forward stack cleared by the intervening push"
+  );
+});
+
+test("forward() at the end of history is a no-op", async () => {
+  const hist = memoryHistory("/a");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+  });
+  await router.push("/b");
+  router.forward();
+  await tick();
+  assert.strictEqual(router.current.path, "/b", "already at the end");
+});
+
+test("back() at the start of history is a no-op", async () => {
+  const hist = memoryHistory("/only");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+  });
+  router.back();
+  await tick();
+  assert.strictEqual(router.current.path, "/only");
+});
+
+// -- guards: cancel (sync + async), redirect-in-guard ------------------------
+
+test("beforeEach returning a rejected promise propagates (never silently commits)", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/start"),
+    beforeEach: () => Promise.reject(new Error("guard blew up")),
+  });
+  await assert.rejects(() => router.push("/blocked"), /guard blew up/);
+  assert.strictEqual(
+    router.current.path,
+    "/start",
+    "route unchanged when the guard's promise rejects"
+  );
+});
+
+test("beforeEach can redirect by calling push() itself inside the guard", async () => {
+  const seen = [];
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/start"),
+    beforeEach: (to) => {
+      seen.push(to.path);
+      if (to.path === "/private") {
+        // Deny this navigation, then redirect to /login. This inner push runs
+        // its own beforeEach pass too, but /login isn't guarded away.
+        router.push("/login");
+        return false;
+      }
+      return true;
+    },
+  });
+  const ok = await router.push("/private");
+  assert.strictEqual(ok, false, "the original navigation reports cancelled");
+  await tick();
+  assert.strictEqual(
+    router.current.path,
+    "/login",
+    "the guard's own redirect commits"
+  );
+});
+
+test("guard cancel leaves history untouched (no orphan entry)", async () => {
+  const hist = memoryHistory("/start");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+    beforeEach: (to) => to.path !== "/blocked",
+  });
+  await router.push("/blocked");
+  assert.strictEqual(hist.location, "/start", "history.push never ran");
+});
+
+// -- outlet: remount only on route-def change --------------------------------
+
+test("outlet remounts when navigating between two distinct route defs, even with overlapping params", async () => {
+  const hits = [];
+  const routes = [
+    { path: "/users/:id", component: makeComponent("user", hits) },
+    { path: "/posts/:id", component: makeComponent("post", hits) },
+  ];
+  const router = createRouter(routes, { history: memoryHistory("/users/1") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  routerOutlet(c, anchor, router);
+
+  const firstRoot = parent.childNodes[0];
+  await router.push("/posts/1"); // same param value, different route def
+  assert.notStrictEqual(
+    parent.childNodes[0],
+    firstRoot,
+    "distinct route def remounts even though the param value is identical"
+  );
+  assert.strictEqual(hits.length, 2);
+});
+
+test("outlet 404 -> match -> 404 toggles mount/unmount without a catch-all", async () => {
+  const hits = [];
+  const routes = [{ path: "/home", component: makeComponent("home", hits) }];
+  const router = createRouter(routes, { history: memoryHistory("/home") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  routerOutlet(c, anchor, router);
+  assert.strictEqual(parent.childNodes.length, 2, "home mounted + anchor");
+
+  await router.push("/missing");
+  assert.strictEqual(
+    parent.childNodes.length,
+    1,
+    "no match unmounts, leaving only the anchor"
+  );
+
+  await router.push("/home");
+  assert.strictEqual(parent.childNodes.length, 2, "remounted on match again");
+  assert.strictEqual(hits.length, 2, "mounted twice total (not on the miss)");
+});
+
+test("outlet with options.props overrides the default params-as-props mapping", () => {
+  const hits = [];
+  const routes = [{ path: "/users/:id", component: makeComponent("u", hits) }];
+  const router = createRouter(routes, { history: memoryHistory("/users/9") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  routerOutlet(c, anchor, router, {
+    props: (route) => ({ userId: route.params.id, extra: true }),
+  });
+  assert.deepStrictEqual(hits[0].props, { userId: "9", extra: true });
+});
+
+test("destroy() before any navigation still leaves the anchor and no listener", async () => {
+  const hits = [];
+  const routes = [{ path: "/home", component: makeComponent("home", hits) }];
+  const router = createRouter(routes, { history: memoryHistory("/home") });
+  const parent = document.createElement("div");
+  const anchor = anchorAppend(parent);
+  const c = createContext(parent);
+  const outlet = routerOutlet(c, anchor, router);
+  outlet.destroy();
+  assert.strictEqual(parent.childNodes.length, 1, "unmounted, anchor remains");
+  // A navigation after destroy must not resurrect the outlet.
+  await router.push("/home");
+  assert.strictEqual(parent.childNodes.length, 1, "outlet stays torn down");
+});
+
+// -- links: modified-click / non-primary-button fallthrough ------------------
+
+test("routerLink: non-primary mouse button falls through", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/"),
+  });
+  const a = document.createElement("a");
+  routerLink(a, router, "/target");
+  for (const fn of a._listeners.click.slice()) {
+    fn({ type: "click", button: 1, preventDefault() {} }); // middle click
+  }
+  await tick();
+  assert.strictEqual(
+    router.current.path,
+    "/",
+    "auxiliary button click does not navigate"
+  );
+});
+
+test("routerLink: an already-defaultPrevented event is left alone", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/"),
+  });
+  const a = document.createElement("a");
+  routerLink(a, router, "/target");
+  let calledPreventDefault = false;
+  for (const fn of a._listeners.click.slice()) {
+    fn({
+      type: "click",
+      defaultPrevented: true,
+      preventDefault() {
+        calledPreventDefault = true;
+      },
+    });
+  }
+  await tick();
+  assert.strictEqual(router.current.path, "/");
+  assert.strictEqual(calledPreventDefault, false);
+});
+
+test("routerLink: options.replace uses history.replace instead of push", async () => {
+  const hist = memoryHistory("/start");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+  });
+  await router.push("/mid"); // so we have a back-entry to prove replace didn't add one
+  const a = document.createElement("a");
+  routerLink(a, router, "/final", { replace: true });
+  for (const fn of a._listeners.click.slice()) {
+    fn({ type: "click", preventDefault() {} });
+  }
+  await tick();
+  assert.strictEqual(router.current.path, "/final");
+  router.back();
+  await tick();
+  assert.strictEqual(
+    router.current.path,
+    "/start",
+    "replace did not push a new history entry for /final"
+  );
+});
+
+// -- reactive current-route wired through a plain store-adopting context ----
+
+test("two components adopting the same router route independently at different indices", async () => {
+  const router = createRouter([{ path: "*", component: null }], {
+    history: memoryHistory("/one"),
+  });
+  const c1 = createContext(null);
+  const c2 = createContext(null);
+  router.adopt(c1, 2);
+  router.adopt(c2, 5);
+  const seen1 = [];
+  const seen2 = [];
+  bind(c1, [2], () => seen1.push(router.current.path));
+  bind(c2, [5], () => seen2.push(router.current.path));
+
+  await router.push("/two");
+  await tick();
+  assert.deepStrictEqual(seen1, ["/one", "/two"]);
+  assert.deepStrictEqual(seen2, ["/one", "/two"]);
+});
+
+test("router.destroy() detaches the history listener (pop no longer updates the store)", async () => {
+  const hist = memoryHistory("/a");
+  const router = createRouter([{ path: "*", component: null }], {
+    history: hist,
+  });
+  await router.push("/b");
+  router.destroy();
+  router.back();
+  await tick();
+  assert.strictEqual(
+    router.current.path,
+    "/b",
+    "history moved but the router no longer listens"
+  );
+  assert.strictEqual(hist.location, "/a", "history itself still moved back");
+});

--- a/packages/lunas/test/store.edge.test.mjs
+++ b/packages/lunas/test/store.edge.test.mjs
@@ -1,0 +1,246 @@
+// store.edge.test.mjs — additional edge-focused coverage for store.mjs:
+// per-field isolation details, useStore adoption at index, derivedStore
+// staleness edge cases, two independent contexts/stores, and scope-drop
+// interplay with derived values. Complements store.test.mjs.
+// Run: node packages/lunas/test/store.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import {
+  createContext,
+  bind,
+  beginScope,
+  endScope,
+  dropScope,
+} from "../src/core.mjs";
+import { createStore, useStore, derivedStore } from "../src/store.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// -- per-field isolation, unknown-key auto-creation --------------------------
+
+test("reading an undeclared key lazily creates an (undefined) field", () => {
+  const store = createStore({});
+  assert.strictEqual(store.get("ghost"), undefined);
+  const c = createContext(null);
+  useStore(c, 0, store, "ghost");
+  let seen;
+  bind(c, [0], () => {
+    seen = store.get("ghost");
+  });
+  store.set("ghost", "now-set");
+  return tick().then(() => {
+    assert.strictEqual(seen, "now-set");
+  });
+});
+
+test("two independent stores never cross-notify each other's subscribers", async () => {
+  const storeA = createStore({ v: 1 });
+  const storeB = createStore({ v: 1 });
+  const seenA = [];
+  const seenB = [];
+  storeA.subscribe("v", (x) => seenA.push(x));
+  storeB.subscribe("v", (x) => seenB.push(x));
+  storeA.set("v", 2);
+  assert.deepStrictEqual(seenA, [2]);
+  assert.deepStrictEqual(seenB, [], "store B untouched by store A's write");
+});
+
+test("adopting the same field twice at different indices on the same context both fire", async () => {
+  const store = createStore({ n: 0 });
+  const c = createContext(null);
+  useStore(c, 0, store, "n");
+  useStore(c, 1, store, "n"); // same field, second reactive index
+  let a = 0;
+  let b = 0;
+  bind(c, [0], () => {
+    a++;
+    void store.get("n");
+  });
+  bind(c, [1], () => {
+    b++;
+    void store.get("n");
+  });
+  a = b = 0;
+  store.set("n", 1);
+  await tick();
+  assert.strictEqual(a, 1);
+  assert.strictEqual(b, 1);
+});
+
+// -- useStore adoption returns a working detach + scope interplay -----------
+
+test("useStore outside a scope requires an explicit detach() call", async () => {
+  const store = createStore({ n: 0 });
+  const c = createContext(null);
+  // No beginScope: c.scope is null, so no automatic scope-drop wiring.
+  const detach = useStore(c, 0, store, "n");
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  runs = 0;
+  store.set("n", 1);
+  await tick();
+  assert.strictEqual(runs, 1, "still attached");
+  detach();
+  runs = 0;
+  store.set("n", 2);
+  await tick();
+  assert.strictEqual(runs, 0, "detached manually");
+});
+
+test("dropScope on a scope containing useStore also tears down a plain bind in the same scope", async () => {
+  const store = createStore({ n: 0 });
+  const c = createContext(null);
+  const scope = beginScope(c);
+  useStore(c, 0, store, "n");
+  let runs = 0;
+  bind(c, [0], () => {
+    runs++;
+    void store.get("n");
+  });
+  endScope(c);
+  dropScope(c, scope);
+  runs = 0;
+  store.set("n", 5);
+  await tick();
+  assert.strictEqual(runs, 0, "both the adoption and the bind are gone");
+});
+
+// -- batched writes across multiple stores in one microtask ------------------
+
+test("writes to two different stores adopted by one context still coalesce to one flush", async () => {
+  const s1 = createStore({ a: 0 });
+  const s2 = createStore({ b: 0 });
+  const c = createContext(null);
+  useStore(c, 0, s1, "a");
+  useStore(c, 1, s2, "b");
+  let paints = 0;
+  bind(c, [0, 1], () => {
+    paints++;
+    void s1.get("a");
+    void s2.get("b");
+  });
+  paints = 0;
+  s1.set("a", 1);
+  s2.set("b", 2);
+  assert.strictEqual(paints, 0);
+  await tick();
+  assert.strictEqual(paints, 1);
+});
+
+// -- derivedStore: multi-dep staleness, chained derivations ------------------
+
+test("derivedStore recomputes once per flush window even with two deps both changing", () => {
+  const store = createStore({ a: 1, b: 1 });
+  let computes = 0;
+  const sum = derivedStore(store, ["a", "b"], () => {
+    computes++;
+    return store.get("a") + store.get("b");
+  });
+  assert.strictEqual(sum.v, 2);
+  computes = 0;
+  store.set("a", 10);
+  store.set("b", 10);
+  // Each set synchronously invalidates+recomputes (no batching inside
+  // derivedStore itself — it recomputes eagerly on every upstream write to
+  // keep plain-JS subscribers synchronous).
+  assert.strictEqual(sum.v, 20);
+});
+
+test("derivedStore chained off another derivedStore stays consistent", () => {
+  const store = createStore({ n: 2 });
+  const doubled = derivedStore(store, ["n"], () => store.get("n") * 2);
+  const wrapped = createStore({ doubled });
+  const quadrupled = derivedStore(wrapped, ["doubled"], () =>
+    wrapped.get("doubled") * 2
+  );
+  assert.strictEqual(quadrupled.v, 8);
+  store.set("n", 5);
+  assert.strictEqual(doubled.v, 10);
+  assert.strictEqual(quadrupled.v, 20);
+});
+
+test("derivedStore.stop() unsubscribes from upstream fields (no more recompute-on-write)", () => {
+  const store = createStore({ n: 1 });
+  let computes = 0;
+  const doubled = derivedStore(store, ["n"], () => {
+    computes++;
+    return store.get("n") * 2;
+  });
+  assert.strictEqual(doubled.v, 2);
+  computes = 0;
+  doubled.stop();
+  store.set("n", 100);
+  // No subscribe-driven recompute happened (stop unsubscribed); but note
+  // reading .v afterward may recompute lazily if implementation marks stale.
+  // Since stop() only removes the invalidate subscription, .v was never
+  // invalidated, so it stays memoized at the old value.
+  assert.strictEqual(doubled.v, 2, "stale value retained after stop()");
+  assert.strictEqual(computes, 0);
+});
+
+test("derivedStore field passed into createStore is not double-wrapped (isField passthrough)", () => {
+  const cart = createStore({ items: [{ price: 3 }] });
+  const total = derivedStore(cart, ["items"], () =>
+    cart.get("items").reduce((s, it) => s + it.price, 0)
+  );
+  const app = createStore({ total, other: 1 });
+  // app.get("total") should read through the SAME derived field, not a fresh
+  // plain field wrapping the derived object.
+  assert.strictEqual(app.get("total"), 3);
+  cart.get("items").push({ price: 7 });
+  assert.strictEqual(app.get("total"), 10, "derived passthrough recomputes live");
+});
+
+test("subscribing to a derivedStore's output does not receive upstream-unrelated writes", () => {
+  const store = createStore({ a: 1, b: 100 });
+  const seen = [];
+  const onlyA = derivedStore(store, ["a"], () => store.get("a") * 10);
+  onlyA.subscribe((v) => seen.push(v));
+  store.set("b", 200); // unrelated field
+  assert.deepStrictEqual(seen, [], "derivedStore only depends on declared deps");
+  store.set("a", 2);
+  assert.deepStrictEqual(seen, [20]);
+});
+
+// -- scope-drop cleanup for a derived value adopted into a component ---------
+
+test("dropScope detaches a component from a derivedStore-backed field too", async () => {
+  const cart = createStore({ items: [1, 2] });
+  const count = derivedStore(cart, ["items"], () => cart.get("items").length);
+  const app = createStore({ count });
+  const c = createContext(null);
+  const scope = beginScope(c);
+  useStore(c, 0, app, "count");
+  let seen = null;
+  bind(c, [0], () => {
+    seen = app.get("count");
+  });
+  endScope(c);
+  assert.strictEqual(seen, 2);
+
+  dropScope(c, scope);
+  cart.get("items").push(3);
+  await tick();
+  assert.strictEqual(seen, 2, "detached component does not observe the derived update");
+  assert.strictEqual(app.get("count"), 3, "the derived value itself still updates");
+});
+
+// -- deep mutation isolation between fields -----------------------------------
+
+test("deep mutation on one array field does not notify a sibling field's subscribers", () => {
+  const store = createStore({ list: [1], other: "x" });
+  const seenOther = [];
+  store.subscribe("other", (v) => seenOther.push(v));
+  store.get("list").push(2);
+  assert.deepStrictEqual(seenOther, [], "unrelated field's subscribers silent");
+});
+
+test("replacing a store field's whole value with a new object gets its own fresh proxy identity", () => {
+  const store = createStore({ obj: { a: 1 } });
+  const first = store.get("obj");
+  store.set("obj", { a: 2 });
+  const second = store.get("obj");
+  assert.notStrictEqual(first, second);
+  assert.strictEqual(second.a, 2);
+});

--- a/packages/lunas/test/transition.edge.browser.mjs
+++ b/packages/lunas/test/transition.edge.browser.mjs
@@ -1,0 +1,118 @@
+// transition.edge.browser.mjs — the browser-path half of
+// transition.edge.test.mjs. Spawned as a child process so we can install a
+// fake requestAnimationFrame BEFORE importing transition.mjs (read at import
+// time). Exits 0 on success, throws (nonzero) on failure. Not a *.test.mjs
+// file, so run-all skips it; transition.edge.test.mjs invokes it.
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+
+installDom();
+
+let rafQueue = [];
+globalThis.requestAnimationFrame = (fn) => {
+  rafQueue.push(fn);
+  return rafQueue.length;
+};
+function drainRaf() {
+  const q = rafQueue;
+  rafQueue = [];
+  for (const fn of q) fn();
+}
+function settleFrames() {
+  let guard = 0;
+  while (rafQueue.length && guard++ < 10) drainRaf();
+}
+
+const { withTransition, runPhase } = await import("../src/transition.mjs");
+
+const cls = (el) => el.classList.toArray().sort();
+
+// --- runPhase leave: full class sequence (from/active -> active/to -> gone) --
+{
+  const el = document.createElement("div");
+  let finished = false;
+  runPhase(el, "fade", "leave", { duration: 10000 }, () => (finished = true));
+  assert.deepEqual(cls(el), ["fade-leave-active", "fade-leave-from"]);
+  settleFrames();
+  assert.deepEqual(cls(el), ["fade-leave-active", "fade-leave-to"]);
+  el.dispatch("transitionend");
+  assert.equal(finished, true);
+  assert.deepEqual(cls(el), []);
+}
+
+// --- cancel() before frame 1 stops the sequence and cleans up classes --------
+{
+  const el = document.createElement("div");
+  let finished = false;
+  const cancel = runPhase(el, "v", "enter", { duration: 10000 }, () => (finished = true));
+  assert.deepEqual(cls(el), ["v-enter-active", "v-enter-from"]);
+  cancel();
+  assert.equal(finished, false, "cancel does not itself call done()");
+  // cleanup() only ever removes `-active`/`-to` (mirroring the natural finish
+  // path); `-from` was added at frame 0 and step2 (which swaps it for `-to`)
+  // never ran since we cancelled before frame 1, so `-from` is left behind.
+  assert.deepEqual(cls(el), ["v-enter-from"], "cancel cleans up active/to, leaves -from since step2 never ran");
+  // A transitionend arriving after cancel must not re-trigger finish — cleanup()
+  // already removed the transitionend listener.
+  el.dispatch("transitionend");
+  assert.equal(finished, false);
+}
+
+// --- multiple calls to the returned cancel() are safe (idempotent) ----------
+{
+  const el = document.createElement("div");
+  const cancel = runPhase(el, "v", "enter", {}, () => {});
+  cancel();
+  assert.doesNotThrow(() => cancel());
+}
+
+// --- no duration specified: fallback timer defaults to 0ms -------------------
+{
+  const el = document.createElement("div");
+  let finished = false;
+  runPhase(el, "v", "enter", {}, () => (finished = true)); // no opts.duration
+  settleFrames();
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(finished, true, "missing duration still arms a 0ms fallback");
+}
+
+// --- withTransition.enter with a NODE ARRAY runs each node's own choreography ---
+// (duration kept short and the phase settled+finished so no fallback timer is
+// left dangling for a later settleFrames() call in this shared-rafQueue script
+// to accidentally arm and never clear — see the finish() below.)
+{
+  const t = withTransition({ name: "grp", duration: 5 });
+  const a = document.createElement("div");
+  const b = document.createElement("div");
+  t.enter([a, b], () => {});
+  assert.deepEqual(cls(a), ["grp-enter-active", "grp-enter-from"]);
+  assert.deepEqual(cls(b), ["grp-enter-active", "grp-enter-from"]);
+  settleFrames();
+  a.dispatch("transitionend");
+  b.dispatch("transitionend");
+}
+
+// --- withTransition default class base is "v" when no name given ------------
+{
+  const t = withTransition({ duration: 5 });
+  const el = document.createElement("div");
+  t.enter(el, () => {});
+  assert.deepEqual(cls(el), ["v-enter-active", "v-enter-from"]);
+  settleFrames();
+  el.dispatch("transitionend");
+}
+
+// --- withTransition.leave with a single node still waits for its finish -----
+{
+  const t = withTransition({ name: "x", duration: 5 });
+  const el = document.createElement("div");
+  let removed = false;
+  t.leave(el, () => (removed = true)); // single node, not an array
+  settleFrames();
+  assert.equal(removed, false);
+  el.dispatch("transitionend");
+  assert.equal(removed, true);
+}
+
+console.log("transition.edge.browser.mjs: all assertions passed");

--- a/packages/lunas/test/transition.edge.test.mjs
+++ b/packages/lunas/test/transition.edge.test.mjs
@@ -1,0 +1,97 @@
+// transition.edge.test.mjs — additional edge-focused coverage for
+// transition.mjs beyond transition.test.mjs: withTransition custom class base,
+// leave with mixed node counts, non-browser (degraded) immediate finish
+// semantics for enter AND leave with real elements/classLists asserted, plus a
+// browser-path subprocess (transition.edge.browser.mjs) for the parts that
+// need a fake requestAnimationFrame installed before import.
+// Run: node packages/lunas/test/transition.edge.test.mjs
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { installDom } from "./dom-shim.mjs";
+
+installDom();
+
+const cls = (el) => el.classList.toArray();
+
+// --- degraded path (this process has no requestAnimationFrame) ---------------
+
+test("degraded: custom class base name is honored in the (collapsed) sequence", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "custom-fade" });
+  const el = document.createElement("div");
+  t.enter(el, () => {});
+  // Degraded mode collapses the whole sequence; regardless of base name, no
+  // transition classes remain (cleanup always removes active+to, and step2
+  // removes from before finish runs synchronously).
+  assert.deepEqual(cls(el), []);
+});
+
+test("degraded: leave with TWO nodes calls remove exactly once after both finish synchronously", () => {
+  return (async () => {
+    const { withTransition } = await import("../src/transition.mjs");
+    const t = withTransition({ name: "fade" });
+    const host = document.createElement("div");
+    const a = document.createElement("span");
+    const b = document.createElement("span");
+    host.appendChild(a);
+    host.appendChild(b);
+    let removedCount = 0;
+    t.leave([a, b], () => {
+      removedCount++;
+      a.remove();
+      b.remove();
+    });
+    assert.equal(removedCount, 1, "remove called exactly once for the whole group");
+    assert.equal(a.parentNode, null);
+    assert.equal(b.parentNode, null);
+  })();
+});
+
+test("degraded: runPhase's returned cancel() is a safe no-op after synchronous finish", async () => {
+  const { runPhase } = await import("../src/transition.mjs");
+  const el = document.createElement("div");
+  let finished = false;
+  const cancel = runPhase(el, "v", "enter", {}, () => (finished = true));
+  assert.equal(finished, true, "degraded mode finishes synchronously");
+  assert.doesNotThrow(() => cancel());
+});
+
+test("degraded: enter without an insert callback does not throw (insert is optional)", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "v" });
+  const el = document.createElement("div");
+  assert.doesNotThrow(() => t.enter(el, undefined));
+  assert.doesNotThrow(() => t.enter(el, null));
+});
+
+test("degraded: leave without a remove callback does not throw", async () => {
+  const { withTransition } = await import("../src/transition.mjs");
+  const t = withTransition({ name: "v" });
+  const el = document.createElement("div");
+  assert.doesNotThrow(() => t.leave(el, undefined));
+  assert.doesNotThrow(() => t.leave([], undefined));
+});
+
+test("degraded: runPhase adds and fully removes from/active/to even with no done callback", async () => {
+  const { runPhase } = await import("../src/transition.mjs");
+  const el = document.createElement("div");
+  assert.doesNotThrow(() => runPhase(el, "v", "leave", {}, null));
+  assert.deepEqual(cls(el), [], "sequence still collapses correctly without a done callback");
+});
+
+// --- browser path (subprocess with fake rAF + transitionend) -----------------
+
+test("browser path (edge cases): leave sequencing, cancel-before-frame1, missing duration, arrays, default base", () => {
+  const here = fileURLToPath(import.meta.url);
+  const dir = here.slice(0, here.lastIndexOf("/"));
+  const res = spawnSync(process.execPath, [dir + "/transition.edge.browser.mjs"], {
+    encoding: "utf8",
+  });
+  if (res.status !== 0) {
+    console.error(res.stdout, res.stderr);
+  }
+  assert.equal(res.status, 0, "browser-path edge-case subprocess should pass");
+});


### PR DESCRIPTION
## Summary
- Adds `packages/lunas/test/*.edge.test.mjs` for the runtime APPLICATION modules — router, store, async (asyncComponent/suspenseBlock), lifecycle, emits, provide, transition, keepalive — 105 new `test()` blocks / 227 assertions, auto-discovered by `run-all.mjs`'s `*.test.mjs` glob. No existing test files, `src/*.mjs`, `index.mjs`, `package.json`, or Rust touched.
- Coverage highlights: router nested/param/catch-all precedence ties, query-parse edge cases (repeated keys, malformed %-sequences, value-less keys), guard cancel/redirect/rejection, outlet remount-on-route-def-change; store per-field isolation, deep-mutation isolation, derivedStore staleness/chaining/`stop()`; async default-export unwrap, cache, delay/timeout races, suspense with 3 children and independent nested boundaries; lifecycle hook ordering across nesting, `onActivated`/`onDeactivated` via keepAlive, never-panic guards; emits kebab-case/payload edge cases and the "emit never marks parent dirty" contract; provide/inject through 5-level chains, sibling-branch isolation, Symbol-key collisions; transition class choreography (degraded + browser-path subprocess) including `cancel()` mid-sequence; keepAlive `max:0`/`max:1`/unbounded boundaries and re-show-after-eviction identity.

## Real bug found (not fixed here — out of scope)
`output-design.md` §7 states plainly that "every unmount path (mountChild.unmount, block item teardown, keep-alive eviction) funnels through `runDestroy(c)`". In practice, `ifBlock`/`ifChain`/`forBlock`'s teardown (`removeAll` / `host.remove` in `blocks.mjs`) only removes DOM nodes and drops the reactive scope (unregistering binds) — it never calls `.unmount()` on a child mounted via `mountChild` inside that branch/item, so that child's `onDestroy` queue never fires when the branch is hidden or the item is removed from a `:for` list. (Only an explicit outer `mountChild.unmount()` call — e.g. from `dynamicBlock` or `keepAlive`, which do call `child.unmount()` themselves — reaches `runDestroy`.)

A minimal fix (prototyped and verified locally, then reverted since `src/*.mjs` is out of scope for this test-only PR) is for `mountChild` to piggyback an unmount hook onto `c.scope.subs` the same way `store.mjs`'s `useStore` does for `detach()` (the `{ deps: [], get alive() {...}, set alive(v) { ... } }` trick — `dropScope` already calls `unbind()` on every scope sub, and `unbind` sets `.alive = false`, which is enough to trigger the teardown with zero changes to `core.mjs`). Filed as 4 `.skip`-marked assertions in `lifecycle.edge.test.mjs` with the failing behavior preserved (removing `.skip` reproduces the gap against `blocks.mjs` as it stands on `main`) for whoever picks up the `blocks.mjs` fix.

## Test plan
- [x] `node packages/lunas/test/run-all.mjs` — all 25 test files (17 existing + 8 new) pass, exit 0.
- [x] Verified the 4 skipped assertions fail (reproduce the bug) when un-skipped against unmodified `blocks.mjs`.
- [x] `git status` clean of any `src/*.mjs`/`roadmap.yml`/existing-test edits — only new `*.edge.test.mjs` / `*.edge.browser.mjs` files added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)