### PR TITLE
test(parser): expand lunas_parser + html_parser edge/fuzz suites

### DIFF
--- a/crates/lunas_html_parser/tests/fuzz_property.rs
+++ b/crates/lunas_html_parser/tests/fuzz_property.rs
@@ -1,0 +1,235 @@
+//! Extended never-panic fuzzing plus structural property checks for the HTML
+//! parser.
+//!
+//! Two invariant strengths are asserted:
+//!
+//! * **Soundness** (holds for *any* input, well-formed or not): every node range
+//!   is within the source bounds and lands on a valid UTF-8 char boundary, so
+//!   `.slice` always succeeds. A rebasing or off-by-one bug trips this even when
+//!   no panic occurs. Asserted by [`assert_sound`].
+//! * **Containment** (parent-child nesting): a child's range sits inside its
+//!   parent's, and an attribute's range inside the open tag. This only holds for
+//!   *well-formed* input — an unterminated open tag (e.g. `<a b="x"` at EOF)
+//!   currently emits an attribute range that runs past the truncated
+//!   `open_tag_range`, so containment is asserted only on the balanced-nesting
+//!   generator, matching `tests/span_invariants.rs`.
+
+use lunas_html_parser::{parse_html, Element, Node};
+use lunas_span::TextRange;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+fn within(inner: TextRange, outer: TextRange) -> bool {
+    outer.start() <= inner.start() && inner.end() <= outer.end()
+}
+
+/// Soundness for one element subtree: in-bounds and on char boundaries.
+fn check_element_sound(el: &Element, file: TextRange, source: &str) {
+    assert!(within(el.range, file), "element out of file bounds");
+    assert!(
+        el.range.slice(source).is_some(),
+        "element range off char boundary"
+    );
+    for attr in &el.attributes {
+        assert!(within(attr.range, file), "attr out of file bounds");
+        assert!(
+            attr.range.slice(source).is_some(),
+            "attr range off char boundary"
+        );
+        if let Some(vr) = attr.value_range {
+            assert!(vr.slice(source).is_some(), "value range off char boundary");
+        }
+    }
+    for child in &el.children {
+        assert!(within(child.range(), file), "child out of file bounds");
+        if let Node::Element(c) = child {
+            check_element_sound(c, file, source);
+        }
+    }
+}
+
+/// Parent-child containment for one element subtree (well-formed input only).
+fn check_element_containment(el: &Element, file: TextRange) {
+    assert!(within(el.range, file), "element out of file bounds");
+    assert!(
+        within(el.open_tag_range, el.range),
+        "open tag not within element"
+    );
+    for attr in &el.attributes {
+        assert!(
+            within(attr.range, el.open_tag_range),
+            "attr not within open tag"
+        );
+        if let Some(vr) = attr.value_range {
+            assert!(within(vr, attr.range), "value not within attr");
+        }
+    }
+    for child in &el.children {
+        assert!(within(child.range(), el.range), "child escapes parent");
+        if let Node::Element(c) = child {
+            check_element_containment(c, file);
+        }
+    }
+}
+
+/// Parse `input`, asserting it neither panics nor violates the always-true
+/// soundness invariant (in-bounds ranges on valid char boundaries).
+fn assert_sound(input: &str) {
+    let ok = catch_unwind(AssertUnwindSafe(|| {
+        let dom = parse_html(input).dom;
+        let file = TextRange::at(0, input.len() as u32);
+        for node in &dom.children {
+            assert!(within(node.range(), file), "top node out of bounds");
+            assert!(
+                node.range().slice(input).is_some(),
+                "node range not on a char boundary: {:?}",
+                node.range()
+            );
+            if let Node::Element(e) = node {
+                check_element_sound(e, file, input);
+            }
+        }
+    }));
+    assert!(ok.is_ok(), "parse_html misbehaved on input: {input:?}");
+}
+
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+}
+
+#[test]
+fn adversarial_recovery_corpus_is_sound() {
+    let cases = [
+        "<a><b></a></b>",
+        "<div><br></br></div>",
+        "<script>a<b</script></script>",
+        "<style>.x{}</style extra>",
+        "<!--><div>",
+        "<a b=\"</a>\">text</a>",
+        "<a b='c\"d'></a>",
+        "<a ::x=\"1\" :y=\"2\" @z=\"3\">",
+        "<textarea><div></textarea>",
+        "<title></title></title>",
+        "<a\n\tb=1\n\tc=2\n>",
+        "<a b=\"\u{1F600}\" c=\"あ\">",
+        "<><!--<-->",
+        "<a/></a>",
+        "<img src=x/>text",
+        "<p>a</p><p>b</p><p>c",
+        "</div></div></div>",
+        "<DIV CLASS=X></div>",
+        "<a =b =c>",
+        "<a b= c= d=>",
+        "<!DOCTYPE html><html><head></head><body><p>x</p></body></html>",
+    ];
+    for c in cases {
+        assert_sound(c);
+    }
+}
+
+#[test]
+fn pseudo_random_structural_fuzz_is_sound() {
+    // Token fragments biased toward tag structure so the tree builder exercises
+    // its open/close/auto-close paths often.
+    let fragments: &[&str] = &[
+        "<div>",
+        "</div>",
+        "<span>",
+        "</span>",
+        "<br>",
+        "<img ",
+        "src=x",
+        "/>",
+        ">",
+        "<script>",
+        "</script>",
+        "<style>",
+        "</style>",
+        "<!--",
+        "-->",
+        "<!DOCTYPE html>",
+        "\"q\"",
+        "'s'",
+        ":if=",
+        "@click=",
+        "::v=",
+        "=",
+        " ",
+        "\n",
+        "\t",
+        "text",
+        "あ",
+        "\u{1F600}",
+        "<",
+        ">",
+        "</",
+        "<a",
+        "<Comp ",
+        "\0",
+    ];
+    let mut rng = Lcg(0x0bad_c0de_dead_10cc);
+    for _ in 0..6000 {
+        let parts = (rng.next() % 14) as usize;
+        let mut s = String::new();
+        for _ in 0..parts {
+            s.push_str(fragments[(rng.next() as usize) % fragments.len()]);
+        }
+        assert_sound(&s);
+    }
+}
+
+#[test]
+fn random_byte_soup_never_panics() {
+    // Pure random ASCII-ish bytes (kept valid UTF-8 by construction) to catch
+    // states the structural fuzzer biases away from.
+    let mut rng = Lcg(0xabcd_1234_5678_ef01);
+    for _ in 0..4000 {
+        let len = (rng.next() % 60) as usize;
+        let mut s = String::with_capacity(len);
+        for _ in 0..len {
+            // Printable ASCII range 0x20..0x7e plus occasional control chars.
+            let b = (0x20 + (rng.next() % 0x5f)) as u8;
+            s.push(b as char);
+        }
+        assert_sound(&s);
+    }
+}
+
+#[test]
+fn balanced_random_nesting_has_no_diagnostics() {
+    // Well-formed nestings of known non-void tags must parse cleanly with span
+    // invariants intact and zero diagnostics.
+    let tags = ["div", "span", "p", "section", "ul", "li", "b", "em"];
+    let mut rng = Lcg(0x5555_aaaa_5555_aaaa);
+    for _ in 0..800 {
+        let depth = 1 + (rng.next() % 8) as usize;
+        let mut open = String::new();
+        let mut close = String::new();
+        for _ in 0..depth {
+            let t = tags[(rng.next() as usize) % tags.len()];
+            open.push_str(&format!("<{t}>"));
+            close.insert_str(0, &format!("</{t}>"));
+        }
+        let src = format!("{open}text{close}");
+        let r = parse_html(&src);
+        assert!(
+            r.diagnostics.is_empty(),
+            "unexpected diagnostics on {src:?}: {:?}",
+            r.diagnostics
+        );
+        assert_sound(&src);
+        // Well-formed: the stronger parent-child containment invariant holds.
+        let file = TextRange::at(0, src.len() as u32);
+        for node in &r.dom.children {
+            if let Node::Element(e) = node {
+                check_element_containment(e, file);
+            }
+        }
+    }
+}

--- a/crates/lunas_html_parser/tests/html_recovery.rs
+++ b/crates/lunas_html_parser/tests/html_recovery.rs
@@ -1,0 +1,373 @@
+//! Error-recovery and structural edge cases for the HTML tree builder. The
+//! parser must recover from malformed input (never `Err`, never panic) and
+//! preserve span-containment invariants. Complements `tests/parser.rs`.
+
+use lunas_html_parser::{parse_html, Dom, Element, Node, ParseResult};
+use lunas_span::{Severity, TextRange};
+
+fn dom(source: &str) -> Dom {
+    parse_html(source).dom
+}
+
+fn result(source: &str) -> ParseResult {
+    parse_html(source)
+}
+
+fn first_element(dom: &Dom) -> &Element {
+    dom.children
+        .iter()
+        .find_map(|n| match n {
+            Node::Element(e) => Some(e),
+            _ => None,
+        })
+        .expect("an element")
+}
+
+fn within(inner: TextRange, outer: TextRange) -> bool {
+    outer.start() <= inner.start() && inner.end() <= outer.end()
+}
+
+/// Recursively assert every child range is contained in its parent, and every
+/// element range is within the source bounds.
+fn check_containment(el: &Element, file: TextRange) {
+    assert!(within(el.range, file), "{} out of file bounds", el.name);
+    assert!(
+        within(el.open_tag_range, el.range),
+        "{}: open tag not within element",
+        el.name
+    );
+    for attr in &el.attributes {
+        assert!(
+            within(attr.range, el.open_tag_range),
+            "{}: attr {:?} not within open tag",
+            el.name,
+            attr.name
+        );
+        if let Some(vr) = attr.value_range {
+            assert!(within(vr, attr.range), "{}: value not within attr", el.name);
+        }
+    }
+    for child in &el.children {
+        assert!(
+            within(child.range(), el.range),
+            "{}: child not within parent",
+            el.name
+        );
+        if let Node::Element(c) = child {
+            check_containment(c, file);
+        }
+    }
+}
+
+fn assert_spans_ok(source: &str) {
+    let d = dom(source);
+    let file = TextRange::at(0, source.len() as u32);
+    for node in &d.children {
+        assert!(within(node.range(), file), "top node out of bounds");
+        if let Node::Element(e) = node {
+            check_containment(e, file);
+        }
+    }
+}
+
+// --- Auto-close / mismatched tags ---
+
+#[test]
+fn mismatched_close_auto_closes_multiple_levels() {
+    let r = result("<a><b><c></a>");
+    let a = first_element(&r.dom);
+    assert_eq!(a.name, "a");
+    // Warnings for the two implicitly closed elements.
+    assert!(
+        r.diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+            .count()
+            >= 2
+    );
+    assert_spans_ok("<a><b><c></a>");
+}
+
+#[test]
+fn stray_close_tag_with_no_open_errors() {
+    let r = result("<p>hi</span></p>");
+    assert!(r.diagnostics.iter().any(|d| d.is_error()));
+    // The <p> still parses with its text.
+    let p = first_element(&r.dom);
+    assert_eq!(p.name, "p");
+}
+
+#[test]
+fn interleaved_tags_recover() {
+    // Classic misnesting `<b><i></b></i>` — must not panic and must recover.
+    let r = result("<b><i>x</b>y</i>");
+    assert!(!r.dom.children.is_empty());
+    assert_spans_ok("<b><i>x</b>y</i>");
+}
+
+#[test]
+fn unclosed_at_eof_warns_for_each() {
+    let r = result("<div><section><p>text");
+    let warnings = r
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warning)
+        .count();
+    assert!(
+        warnings >= 3,
+        "expected an unclosed warning per open element"
+    );
+    assert_spans_ok("<div><section><p>text");
+}
+
+#[test]
+fn case_insensitive_close_matches() {
+    let r = result("<Section></SECTION>");
+    assert!(r.diagnostics.is_empty());
+    assert_eq!(first_element(&r.dom).name, "section");
+}
+
+// --- Void elements ---
+
+#[test]
+fn void_element_does_not_swallow_siblings() {
+    let d = dom("<div><br><span>x</span></div>");
+    let div = first_element(&d);
+    // br (void) and span are both direct children of div.
+    let names: Vec<&str> = div
+        .children
+        .iter()
+        .filter_map(|n| match n {
+            Node::Element(e) => Some(e.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names, ["br", "span"]);
+}
+
+#[test]
+fn void_with_close_tag_produces_stray_close() {
+    // `</br>` has no matching open (br is void) — recovered as a stray close.
+    let r = result("<br></br>");
+    assert!(r.diagnostics.iter().any(|d| d.is_error()));
+}
+
+#[test]
+fn all_void_elements_have_no_children() {
+    for name in [
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+        "source", "track", "wbr",
+    ] {
+        let d = dom(&format!("<{name}>text-after"));
+        let e = first_element(&d);
+        assert!(e.children.is_empty(), "{name} should have no children");
+        assert_eq!(e.name, name);
+    }
+}
+
+// --- Raw text elements ---
+
+#[test]
+fn script_with_nested_close_lookalike() {
+    let d = dom("<script>const s = '</scriptx>';</script>");
+    let e = first_element(&d);
+    match &e.children[0] {
+        Node::Text(t) => assert_eq!(t.value, "const s = '</scriptx>';"),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn style_with_braces_and_comments() {
+    let css = "/* c */ .a { color: red } @media(x){.b{}}";
+    let d = dom(&format!("<style>{css}</style>"));
+    match &first_element(&d).children[0] {
+        Node::Text(t) => assert_eq!(t.value, css),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn textarea_preserves_interpolation_and_markup() {
+    let body = "before ${x} <b>not-an-element</b> after";
+    let d = dom(&format!("<textarea>{body}</textarea>"));
+    match &first_element(&d).children[0] {
+        Node::Text(t) => assert_eq!(t.value, body),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn unterminated_raw_text_runs_to_eof() {
+    let d = dom("<script>never closed");
+    match &first_element(&d).children[0] {
+        Node::Text(t) => assert_eq!(t.value, "never closed"),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn self_closing_script_has_no_raw_text() {
+    // `<script/>` self-closes: the following text is a sibling, not raw content.
+    let d = dom("<script/>after");
+    assert_eq!(d.children.len(), 2);
+    assert!(first_element(&d).children.is_empty());
+}
+
+// --- Attributes ---
+
+#[test]
+fn empty_quoted_value_kept() {
+    let d = dom("<a x=\"\" y=''></a>");
+    let e = first_element(&d);
+    assert_eq!(e.attributes[0].value.as_deref(), Some(""));
+    assert_eq!(e.attributes[1].value.as_deref(), Some(""));
+}
+
+#[test]
+fn attribute_value_with_reserved_chars() {
+    let d = dom("<a data=\"a>b<c\"></a>");
+    assert_eq!(
+        first_element(&d).attributes[0].value.as_deref(),
+        Some("a>b<c")
+    );
+}
+
+#[test]
+fn many_boolean_attributes() {
+    let d = dom("<input a b c d e f g>");
+    let e = first_element(&d);
+    assert_eq!(e.attributes.len(), 7);
+    assert!(e.attributes.iter().all(|a| a.value.is_none()));
+}
+
+#[test]
+fn attribute_names_preserve_case_and_prefixes() {
+    // Lunas needs `:if`, `@click`, `::v` verbatim.
+    let d = dom("<div :if=\"a\" @click=\"go\" ::model=\"m\" DataX=\"1\"></div>");
+    let names: Vec<&str> = first_element(&d)
+        .attributes
+        .iter()
+        .map(|a| a.name.as_str())
+        .collect();
+    assert_eq!(names, [":if", "@click", "::model", "DataX"]);
+}
+
+#[test]
+fn value_range_slices_back_to_value() {
+    let src = "<a href=\"/path\"></a>";
+    let d = dom(src);
+    let attr = &first_element(&d).attributes[0];
+    assert_eq!(attr.value_range.unwrap().slice(src), Some("/path"));
+}
+
+// --- Comments & doctype ---
+
+#[test]
+fn doctype_uppercase_and_lowercase() {
+    assert_eq!(
+        dom("<!DOCTYPE html>").kind,
+        lunas_html_parser::DomKind::Document
+    );
+    assert_eq!(
+        dom("<!doctype html>").kind,
+        lunas_html_parser::DomKind::Document
+    );
+}
+
+#[test]
+fn comment_with_dashes_inside() {
+    let d = dom("<!-- a -- b -->");
+    match &d.children[0] {
+        Node::Comment(c) => assert_eq!(c.value, " a -- b "),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn unterminated_comment_recovers_to_eof() {
+    let d = dom("<div><!-- oops");
+    let div = first_element(&d);
+    assert!(div.children.iter().any(|n| matches!(n, Node::Comment(_))));
+}
+
+#[test]
+fn nested_comment_delimiters() {
+    // `<!--` inside a comment does not open a new one; first `-->` closes.
+    let d = dom("<!-- <!-- inner --> tail");
+    match &d.children[0] {
+        Node::Comment(c) => assert_eq!(c.value, " <!-- inner "),
+        other => panic!("got {other:?}"),
+    }
+}
+
+// --- Deep nesting & unicode ---
+
+#[test]
+fn deep_nesting_no_overflow_and_spans_ok() {
+    let depth = 200;
+    let src = "<div>".repeat(depth) + &"</div>".repeat(depth);
+    let r = result(&src);
+    assert!(r.diagnostics.is_empty());
+    assert_spans_ok(&src);
+}
+
+#[test]
+fn unicode_tag_content_and_attrs_span_ok() {
+    let src = "<p title=\"日本語\">こんにちは<b>あ</b>う</p>";
+    let r = result(src);
+    assert!(r.diagnostics.is_empty());
+    assert_spans_ok(src);
+    let p = first_element(&r.dom);
+    assert_eq!(p.attributes[0].value.as_deref(), Some("日本語"));
+}
+
+#[test]
+fn emoji_in_text_and_ranges_valid() {
+    let src = "<span>hi \u{1F600} there</span>";
+    let d = dom(src);
+    match &first_element(&d).children[0] {
+        Node::Text(t) => {
+            assert_eq!(t.value, "hi \u{1F600} there");
+            assert_eq!(t.range.slice(src), Some("hi \u{1F600} there"));
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+// --- Dangling / stray markup ---
+
+#[test]
+fn lone_lt_is_text() {
+    let d = dom("a < b");
+    // No element; the `<` is plain text content.
+    assert!(d.children.iter().all(|n| !matches!(n, Node::Element(_))));
+}
+
+#[test]
+fn empty_angle_brackets_recover() {
+    for s in ["<>", "</>", "< >", "<=>"] {
+        let r = result(s);
+        // Never panics and produces some children.
+        let _ = r.dom.children;
+    }
+    assert_spans_ok("before <> after");
+}
+
+#[test]
+fn trailing_open_tag_at_eof() {
+    let r = result("<div><span");
+    // The unclosed span at EOF still builds an element under div.
+    let div = first_element(&r.dom);
+    assert_eq!(div.name, "div");
+}
+
+// --- serde round-trip on a recovered tree ---
+
+#[test]
+fn recovered_tree_serde_round_trip() {
+    let d = dom("<div><span></div><!-- c --><br>");
+    let json = serde_json::to_string(&d).expect("serialize");
+    let back: Dom = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(d, back);
+}

--- a/crates/lunas_parser/tests/directives_edge.rs
+++ b/crates/lunas_parser/tests/directives_edge.rs
@@ -1,0 +1,357 @@
+//! Edge cases for directive parsing (`@use`, `@input`, `@useRouting`,
+//! `@useAutoRouting`) and attribute classification (`:` / `::` / `@` / static),
+//! driven through the public `parse` API. Malformed directives must produce
+//! diagnostics, never panic.
+
+use lunas_parser::{parse, Directive, Severity, TemplateAttr, TemplateElement, TemplateNode};
+
+fn parse_ok(src: &str) -> lunas_parser::ParsedFile {
+    let (file, diags) = parse(src);
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "unexpected errors for {src:?}: {:?}",
+        diags
+    );
+    file
+}
+
+fn directives(src: &str) -> Vec<Directive> {
+    parse(src).0.directives
+}
+
+fn html(body: &str) -> String {
+    format!("html:\n    {}\n", body)
+}
+
+fn first_element(nodes: &[TemplateNode]) -> &TemplateElement {
+    nodes
+        .iter()
+        .find_map(|n| match n {
+            TemplateNode::Element(e) => Some(e),
+            _ => None,
+        })
+        .expect("an element")
+}
+
+fn attrs_of(src: &str) -> Vec<TemplateAttr> {
+    let file = parse_ok(src);
+    first_element(&file.html.unwrap().template.nodes)
+        .attrs
+        .clone()
+}
+
+// --- @use forms ---
+
+#[test]
+fn use_inline_double_quotes() {
+    let ds = directives("@use Button from \"./Button\"\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::UseComponent(u) => {
+            assert_eq!(u.component_name, "Button");
+            assert_eq!(u.path, "./Button");
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn use_inline_single_quotes() {
+    let ds = directives("@use Card from './widgets/Card.lunas'\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::UseComponent(u) => assert_eq!(u.path, "./widgets/Card.lunas"),
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn use_block_form_next_line() {
+    // `@use()` header with the declaration on the following line.
+    let ds = directives("@use()\nButton from \"./Button\"\n\nhtml:\n    <p/>\n");
+    assert!(matches!(&ds[0], Directive::UseComponent(u) if u.component_name == "Button"));
+}
+
+#[test]
+fn use_extra_whitespace_tolerated() {
+    let ds = directives("@use   Widget   from   \"./W\"  \nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::UseComponent(u) => {
+            assert_eq!(u.component_name, "Widget");
+            assert_eq!(u.path, "./W");
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn use_missing_from_errors() {
+    let (_f, diags) = parse("@use Button \"./x\"\nhtml:\n    <p/>\n");
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("@use")));
+}
+
+#[test]
+fn use_unquoted_path_errors() {
+    let (_f, diags) = parse("@use Button from ./x\nhtml:\n    <p/>\n");
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("@use")));
+}
+
+#[test]
+fn use_mismatched_quotes_errors() {
+    let (_f, diags) = parse("@use Button from \"./x'\nhtml:\n    <p/>\n");
+    assert!(diags.iter().any(|d| d.is_error()));
+}
+
+#[test]
+fn use_empty_name_errors() {
+    let (_f, diags) = parse("@use from \"./x\"\nhtml:\n    <p/>\n");
+    assert!(diags.iter().any(|d| d.is_error()));
+}
+
+// --- @input forms ---
+
+#[test]
+fn input_name_only_is_error() {
+    // No `:` type separator — invalid.
+    let (_f, diags) = parse("@input count\nhtml:\n    <p/>\n");
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("@input")));
+}
+
+#[test]
+fn input_type_and_default() {
+    let ds = directives("@input count: number = 0\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::Input(p) => {
+            assert_eq!(p.name, "count");
+            assert_eq!(p.type_annotation.as_deref(), Some("number"));
+            assert_eq!(p.default_value.as_deref(), Some("0"));
+            assert!(!p.nullable);
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn input_nullable_marker() {
+    let ds = directives("@input name: string?\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::Input(p) => {
+            assert!(p.nullable);
+            assert_eq!(p.type_annotation.as_deref(), Some("string"));
+            assert_eq!(p.default_value, None);
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn input_nullable_with_default() {
+    let ds = directives("@input name: string? = \"x\"\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::Input(p) => {
+            assert!(p.nullable);
+            assert_eq!(p.default_value.as_deref(), Some("\"x\""));
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn input_no_type_after_colon() {
+    // `name:` with nothing after — type is None, still valid.
+    let ds = directives("@input flag:\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::Input(p) => {
+            assert_eq!(p.name, "flag");
+            assert_eq!(p.type_annotation, None);
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn input_default_with_equals_in_value() {
+    // The default value itself contains `=` (comparison / arrow).
+    let ds = directives("@input cmp: string = a === b\nhtml:\n    <p/>\n");
+    match &ds[0] {
+        Directive::Input(p) => {
+            // split_once('=') keeps everything after the first `=` as the default.
+            assert_eq!(p.type_annotation.as_deref(), Some("string"));
+            assert!(p.default_value.as_deref().unwrap().contains("=="));
+        }
+        other => panic!("got {other:?}"),
+    }
+}
+
+#[test]
+fn input_invalid_ident_name_errors() {
+    let (_f, diags) = parse("@input 1bad: number\nhtml:\n    <p/>\n");
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("@input")));
+}
+
+#[test]
+fn input_empty_name_errors() {
+    let (_f, diags) = parse("@input : number\nhtml:\n    <p/>\n");
+    assert!(diags.iter().any(|d| d.is_error()));
+}
+
+#[test]
+fn multiple_inputs_all_captured() {
+    let src = "@input a: number\n@input b: string?\n@input c: boolean = true\nhtml:\n    <p/>\n";
+    let ds = directives(src);
+    let inputs = ds
+        .iter()
+        .filter(|d| matches!(d, Directive::Input(_)))
+        .count();
+    assert_eq!(inputs, 3);
+}
+
+// --- Routing directives ---
+
+#[test]
+fn use_routing_directive() {
+    let ds = directives("@useRouting\nhtml:\n    <p/>\n");
+    assert!(matches!(&ds[0], Directive::UseRouting));
+}
+
+#[test]
+fn use_auto_routing_directive() {
+    let ds = directives("@useAutoRouting\nhtml:\n    <p/>\n");
+    assert!(matches!(&ds[0], Directive::UseAutoRouting));
+}
+
+#[test]
+fn unknown_directive_warns_and_is_dropped() {
+    let (file, diags) = parse("@somethingElse foo\nhtml:\n    <p/>\n");
+    assert!(diags
+        .iter()
+        .any(|d| d.severity == Severity::Warning && d.message.contains("unknown directive")));
+    // Unknown directives are not surfaced in the directive list.
+    assert!(file.directives.is_empty());
+}
+
+// --- Attribute classification ---
+
+#[test]
+fn bound_attribute_strips_single_colon() {
+    let a = attrs_of(&html("<input :value=\"title\" />"));
+    assert!(
+        matches!(&a[0], TemplateAttr::Bound { name, expr, .. } if name == "value" && expr.text == "title")
+    );
+}
+
+#[test]
+fn two_way_attribute_strips_double_colon() {
+    let a = attrs_of(&html("<input ::value=\"title\" />"));
+    assert!(matches!(&a[0], TemplateAttr::TwoWay { name, .. } if name == "value"));
+}
+
+#[test]
+fn event_attribute_strips_at() {
+    let a = attrs_of(&html("<button @click=\"go()\">x</button>"));
+    assert!(
+        matches!(&a[0], TemplateAttr::Event { event, handler, .. } if event == "click" && handler.text == "go()")
+    );
+}
+
+#[test]
+fn double_colon_takes_precedence_over_single() {
+    // `::` must classify as TwoWay, not Bound with a leading `:` name.
+    let a = attrs_of(&html("<input ::checked=\"on\" />"));
+    assert!(matches!(&a[0], TemplateAttr::TwoWay { name, .. } if name == "checked"));
+}
+
+#[test]
+fn event_with_dotted_name_preserved() {
+    let a = attrs_of(&html("<div @keydown.enter=\"go\"></div>"));
+    assert!(matches!(&a[0], TemplateAttr::Event { event, .. } if event == "keydown.enter"));
+}
+
+#[test]
+fn bound_attribute_with_expression_value() {
+    let a = attrs_of(&html("<div :class=\"on ? 'a' : 'b'\"></div>"));
+    assert!(matches!(&a[0], TemplateAttr::Bound { expr, .. } if expr.text == "on ? 'a' : 'b'"));
+}
+
+#[test]
+fn static_boolean_attr_no_value() {
+    let a = attrs_of(&html("<input disabled />"));
+    assert!(
+        matches!(&a[0], TemplateAttr::Static { name, value, .. } if name == "disabled" && value.is_none())
+    );
+}
+
+#[test]
+fn mixed_static_and_bound_and_event() {
+    let a = attrs_of(&html(
+        "<button id=\"b\" :class=\"c\" @click=\"go\" disabled>x</button>",
+    ));
+    assert!(a
+        .iter()
+        .any(|x| matches!(x, TemplateAttr::Static { name, .. } if name == "id")));
+    assert!(a
+        .iter()
+        .any(|x| matches!(x, TemplateAttr::Bound { name, .. } if name == "class")));
+    assert!(a
+        .iter()
+        .any(|x| matches!(x, TemplateAttr::Event { event, .. } if event == "click")));
+    assert!(a.iter().any(|x| matches!(x, TemplateAttr::Static { name, value, .. } if name == "disabled" && value.is_none())));
+}
+
+#[test]
+fn reserved_bound_names_error() {
+    for name in ["innerHtml", "textContent", "INNERHTML"] {
+        let (_f, diags) = parse(&html(&format!("<div :{name}=\"x\"></div>")));
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.is_error() && d.message.contains("not supported")),
+            "expected error for :{name}"
+        );
+    }
+}
+
+#[test]
+fn bound_without_value_errors() {
+    let (_f, diags) = parse(&html("<input :value />"));
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("expects an expression")));
+}
+
+#[test]
+fn event_without_value_errors() {
+    let (_f, diags) = parse(&html("<button @click>x</button>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("expects an expression")));
+}
+
+#[test]
+fn duplicate_static_attribute_warns() {
+    // The HTML parser deduplicates; the diagnostic bubbles up through `parse`.
+    let (_f, diags) = parse(&html("<div id=\"a\" id=\"b\"></div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.severity == Severity::Warning && d.message.contains("duplicate attribute")));
+}
+
+#[test]
+fn directive_ranges_are_file_absolute() {
+    let src = "@input count: number = 0\nhtml:\n    <p/>\n";
+    let (file, _) = parse(src);
+    match &file.directives[0] {
+        Directive::Input(p) => {
+            // The stored range slices back to the directive body text.
+            let sliced = p.range.slice(src).expect("in-bounds range");
+            assert!(sliced.contains("count"));
+        }
+        other => panic!("got {other:?}"),
+    }
+}

--- a/crates/lunas_parser/tests/fuzz_extra.rs
+++ b/crates/lunas_parser/tests/fuzz_extra.rs
@@ -1,0 +1,188 @@
+//! Extended never-panic fuzzing plus span-soundness property checks for the
+//! full `.lunas` parse pipeline (Pest grammar, HTML sub-parser, template pass,
+//! directive lowering). Complements `tests/robustness.rs`.
+//!
+//! Beyond "does not panic", every produced template node, interpolation, and
+//! diagnostic range must slice on a valid char boundary of the source — a
+//! rebasing bug in the block-offset shift would surface here.
+
+use lunas_parser::{parse, TemplateNode, TextSegment};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Assert every interpolation and diagnostic range is in-bounds and lands on a
+/// UTF-8 char boundary of `src` (so `.slice` succeeds).
+fn assert_ranges_sound(src: &str) {
+    let (file, diags) = parse(src);
+
+    for d in &diags {
+        assert!(
+            d.range.slice(src).is_some(),
+            "diagnostic range {:?} not on a char boundary of {src:?}",
+            d.range
+        );
+    }
+
+    if let Some(html) = &file.html {
+        fn walk(nodes: &[TemplateNode], src: &str) {
+            for n in nodes {
+                match n {
+                    TemplateNode::Text(t) => {
+                        for seg in &t.segments {
+                            if let TextSegment::Interpolation(i) = seg {
+                                assert_eq!(
+                                    i.expr_range.slice(src),
+                                    Some(i.expr.as_str()),
+                                    "interpolation expr_range mismatch"
+                                );
+                                assert!(i.range.slice(src).is_some());
+                            }
+                        }
+                    }
+                    TemplateNode::Element(e) => walk(&e.children, src),
+                    TemplateNode::Component(c) => walk(&c.children, src),
+                    TemplateNode::If(chain) => {
+                        for b in &chain.branches {
+                            walk(std::slice::from_ref(&b.body), src);
+                        }
+                    }
+                    TemplateNode::For(fb) => walk(std::slice::from_ref(&fb.body), src),
+                    TemplateNode::Comment(_) => {}
+                }
+            }
+        }
+        walk(&html.template.nodes, src);
+    }
+}
+
+fn assert_no_panic(input: &str) {
+    let ok = catch_unwind(AssertUnwindSafe(|| {
+        let _ = parse(input);
+    }));
+    assert!(ok.is_ok(), "parse panicked on: {input:?}");
+}
+
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+}
+
+#[test]
+fn adversarial_template_corpus_is_sound() {
+    let cases = [
+        "html:\n    <div>${ {a:{b:1}} }</div>",
+        "html:\n    <div>${ `t${x}` }${y}</div>",
+        "html:\n    <div>${ /}/.test(x) }</div>",
+        "html:\n    <div>${ a // }\n }</div>",
+        "html:\n    <div>${ /* } */ z }</div>",
+        "html:\n    <li :for=\"const [i,v] of xs\">${v}</li>",
+        "html:\n    <div :if=\"a\">1</div>\n    <div :elseif=\"b\">2</div>\n    <div :else>3</div>",
+        "@use A from \"./A\"\nhtml:\n    <A :for=\"x of xs\" :data=\"x\" />",
+        "@input n: number = 0\n@input s: string?\nhtml:\n    <p>${n}${s}</p>",
+        "html:\n    <div title=\"${ {k:1}.k }\" :class=\"c\">あ${x}</div>",
+        "html:\n    <textarea>${not-parsed}</textarea>",
+        "html:\n    <script>if (a<b) { ${nope} }</script>",
+        // Adversarial / malformed — must recover, not panic.
+        "html:\n    <div>${",
+        "html:\n    <div>${ \"unterminated",
+        "html:\n    <div :for=\"\" :if=\"\" :else>x</div>",
+        "@use\n@input\n@useRouting\nhtml:\n    <>",
+        "html:\n    <あ ::=\"x\" @=\"y\" :=\"z\">",
+    ];
+    for c in cases {
+        assert_no_panic(c);
+        assert_ranges_sound(c);
+    }
+}
+
+#[test]
+fn pseudo_random_pipeline_fuzz_is_sound() {
+    let fragments: &[&str] = &[
+        "html:",
+        "style:",
+        "script:",
+        "@input",
+        "@use",
+        "@useRouting",
+        "@useAutoRouting",
+        "\n",
+        "    ",
+        "\t",
+        "<div>",
+        "</div>",
+        "<li ",
+        "<Comp ",
+        "/>",
+        ">",
+        ":if=",
+        ":elseif=",
+        ":else",
+        ":for=",
+        "::v=",
+        "@click=",
+        "\"x of xs\"",
+        "\"cond\"",
+        "'y'",
+        "${",
+        "}",
+        "${count}",
+        "${ {a:1} }",
+        "${ `t${x}` }",
+        "from",
+        "\"./p\"",
+        " of ",
+        " in ",
+        "name:string",
+        "name:string?",
+        "= 0",
+        "=",
+        "あ",
+        "\u{1F600}",
+        "\0",
+        "\r",
+    ];
+    let mut rng = Lcg(0xfeed_0000_beef_1111);
+    for _ in 0..5000 {
+        let parts = (rng.next() % 14) as usize;
+        let mut s = String::new();
+        for _ in 0..parts {
+            s.push_str(fragments[(rng.next() as usize) % fragments.len()]);
+        }
+        assert_no_panic(&s);
+        // Only run the (heavier) soundness walk when an html block plausibly
+        // exists, but it's safe either way.
+        assert_ranges_sound(&s);
+    }
+}
+
+#[test]
+fn multibyte_offsets_stay_sound() {
+    // Multi-byte leading content shifts every downstream span; verify the block
+    // rebasing keeps interpolation ranges on char boundaries.
+    let bodies = [
+        "html:\n    <div>あ${x}い</div>",
+        "html:\n    <div title=\"日本${n}語\">🎉${m}</div>",
+        "@input 名前: string\nhtml:\n    <p>${名前}</p>",
+    ];
+    for b in bodies {
+        assert_no_panic(b);
+        assert_ranges_sound(b);
+    }
+}
+
+#[test]
+fn nested_interpolation_stress_is_sound() {
+    // Many interpolations with awkward inner content, all in one run.
+    let mut body = String::from("html:\n    <div>");
+    for i in 0..200 {
+        body.push_str(&format!("${{ {{k:{i}}}.k /* }} */ }}"));
+    }
+    body.push_str("</div>\n");
+    assert_no_panic(&body);
+    assert_ranges_sound(&body);
+}

--- a/crates/lunas_parser/tests/interpolation.rs
+++ b/crates/lunas_parser/tests/interpolation.rs
@@ -1,0 +1,431 @@
+//! Deep edge-case coverage for the `${…}` interpolation scanner
+//! (`src/template/scan.rs`), driven through the public `parse` API.
+//!
+//! The scanner is brace/string/regex/comment aware; these tests pin down the
+//! trickier balancing behavior and the never-panic recovery paths.
+
+use lunas_parser::{
+    parse, Diagnostic, Severity, TemplateAttr, TemplateElement, TemplateNode, TextSegment,
+};
+
+/// Wrap an html body line so it forms a valid `.lunas` file.
+fn html(body: &str) -> String {
+    format!("html:\n    {}\n", body)
+}
+
+fn parse_template(src: &str) -> (Vec<TemplateNode>, Vec<Diagnostic>) {
+    let (file, diags) = parse(src);
+    (file.html.expect("html block").template.nodes, diags)
+}
+
+fn nodes_ok(src: &str) -> Vec<TemplateNode> {
+    let (ns, diags) = parse_template(src);
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "unexpected errors: {:?}",
+        diags
+    );
+    ns
+}
+
+fn first_element(nodes: &[TemplateNode]) -> &TemplateElement {
+    nodes
+        .iter()
+        .find_map(|n| match n {
+            TemplateNode::Element(e) => Some(e),
+            _ => None,
+        })
+        .expect("an element")
+}
+
+/// The first text-child interpolation expression under the first element.
+fn first_interp(src: &str) -> String {
+    let ns = nodes_ok(src);
+    let el = first_element(&ns);
+    for child in &el.children {
+        if let TemplateNode::Text(t) = child {
+            for seg in &t.segments {
+                if let TextSegment::Interpolation(i) = seg {
+                    return i.expr.clone();
+                }
+            }
+        }
+    }
+    panic!("no interpolation found in {:?}", el.children);
+}
+
+/// Count interpolations across the first element's direct text children.
+fn interp_count(src: &str) -> usize {
+    let ns = nodes_ok(src);
+    let el = first_element(&ns);
+    el.children
+        .iter()
+        .filter_map(|c| match c {
+            TemplateNode::Text(t) => Some(t),
+            _ => None,
+        })
+        .flat_map(|t| t.segments.iter())
+        .filter(|s| matches!(s, TextSegment::Interpolation(_)))
+        .count()
+}
+
+// --- Nested braces ---
+
+#[test]
+fn deeply_nested_object_braces() {
+    assert_eq!(
+        first_interp(&html("<div>${ {a:{b:{c:1}}}.a }</div>")),
+        " {a:{b:{c:1}}}.a "
+    );
+}
+
+#[test]
+fn arrow_function_with_block_body() {
+    assert_eq!(
+        first_interp(&html("<div>${ (() => { return 1 })() }</div>")),
+        " (() => { return 1 })() "
+    );
+}
+
+#[test]
+fn object_spread_in_call() {
+    assert_eq!(
+        first_interp(&html("<div>${ f({...a, b:1}) }</div>")),
+        " f({...a, b:1}) "
+    );
+}
+
+// --- Strings containing braces / delimiters ---
+
+#[test]
+fn double_quoted_string_with_open_brace() {
+    assert_eq!(
+        first_interp(&html("<div>${ \"{\" + x }</div>")),
+        " \"{\" + x "
+    );
+}
+
+#[test]
+fn single_quoted_string_with_close_brace() {
+    assert_eq!(first_interp(&html("<div>${ '}' }</div>")), " '}' ");
+}
+
+#[test]
+fn string_with_escaped_quote_and_brace() {
+    // Escaped quote inside the string must not terminate it early.
+    assert_eq!(
+        first_interp(&html("<div>${ \"a\\\"}\\\"b\" }</div>")),
+        " \"a\\\"}\\\"b\" "
+    );
+}
+
+#[test]
+fn string_with_backslash_before_close_delim() {
+    assert_eq!(
+        first_interp(&html("<div>${ '\\\\' + y }</div>")),
+        " '\\\\' + y "
+    );
+}
+
+// --- Template literals with ${} substitutions ---
+
+#[test]
+fn template_literal_with_brace_in_substitution() {
+    assert_eq!(
+        first_interp(&html("<div>${ `x${ {a:1}.a }y` }</div>")),
+        " `x${ {a:1}.a }y` "
+    );
+}
+
+#[test]
+fn nested_template_literals() {
+    // Template inside a template substitution.
+    assert_eq!(
+        first_interp(&html("<div>${ `a${`b${c}d`}e` }</div>")),
+        " `a${`b${c}d`}e` "
+    );
+}
+
+#[test]
+fn template_literal_with_string_containing_backtick_close() {
+    assert_eq!(
+        first_interp(&html("<div>${ `pre${ q ? '}' : '{' }post` }</div>")),
+        " `pre${ q ? '}' : '{' }post` "
+    );
+}
+
+// --- Regex literals ---
+
+#[test]
+fn regex_with_close_brace() {
+    assert_eq!(
+        first_interp(&html("<div>${ /}/.test(x) }</div>")),
+        " /}/.test(x) "
+    );
+}
+
+#[test]
+fn regex_char_class_with_braces() {
+    assert_eq!(
+        first_interp(&html("<div>${ /[{}]/.exec(s) }</div>")),
+        " /[{}]/.exec(s) "
+    );
+}
+
+#[test]
+fn regex_with_escaped_slash() {
+    assert_eq!(
+        first_interp(&html("<div>${ /a\\/b}/.test(x) }</div>")),
+        " /a\\/b}/.test(x) "
+    );
+}
+
+#[test]
+fn regex_with_flags() {
+    assert_eq!(
+        first_interp(&html("<div>${ s.replace(/}/gi, '') }</div>")),
+        " s.replace(/}/gi, '') "
+    );
+}
+
+#[test]
+fn division_after_identifier_is_not_regex() {
+    // `a` is a value, so `/` is division; the `}` after still closes.
+    assert_eq!(
+        first_interp(&html("<div>${ total / count }</div>")),
+        " total / count "
+    );
+}
+
+#[test]
+fn division_after_paren_is_not_regex() {
+    assert_eq!(
+        first_interp(&html("<div>${ (a + b) / 2 }</div>")),
+        " (a + b) / 2 "
+    );
+}
+
+// --- Comments inside interpolations ---
+
+#[test]
+fn line_comment_inside_interpolation() {
+    assert_eq!(
+        first_interp(&html("<div>${ a // }not-this\n }</div>")),
+        " a // }not-this\n "
+    );
+}
+
+#[test]
+fn block_comment_with_brace() {
+    assert_eq!(
+        first_interp(&html("<div>${ a /* } */ + b }</div>")),
+        " a /* } */ + b "
+    );
+}
+
+#[test]
+fn block_comment_with_star_slash_sequences() {
+    assert_eq!(
+        first_interp(&html("<div>${ x /* ** */ }</div>")),
+        " x /* ** */ "
+    );
+}
+
+// --- Empty / whitespace-only ---
+
+#[test]
+fn empty_interpolation_warns_not_errors() {
+    let (_ns, diags) = parse_template(&html("<div>${}</div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.severity == Severity::Warning && d.message.contains("empty interpolation")));
+    assert!(!diags.iter().any(|d| d.is_error()));
+}
+
+#[test]
+fn whitespace_only_interpolation_warns() {
+    let (_ns, diags) = parse_template(&html("<div>${   }</div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.severity == Severity::Warning && d.message.contains("empty interpolation")));
+}
+
+// --- Unterminated ---
+
+#[test]
+fn unterminated_reports_error_and_recovers() {
+    let (ns, diags) = parse_template(&html("<div>${ a + b </div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("unterminated")));
+    // Tree still built.
+    assert!(!ns.is_empty());
+}
+
+#[test]
+fn unterminated_by_unbalanced_open_brace() {
+    // The inner `{` is never closed, so the whole `${` is unterminated.
+    let (_ns, diags) = parse_template(&html("<div>${ {a: 1 }</div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("unterminated")));
+}
+
+#[test]
+fn unterminated_string_inside_interpolation_is_unterminated() {
+    let (_ns, diags) = parse_template(&html("<div>${ \"no close }</div>"));
+    assert!(diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains("unterminated")));
+}
+
+#[test]
+fn bare_dollar_without_brace_is_literal() {
+    // A `$` not followed by `{` is ordinary text — no interpolation, no error.
+    let (_ns, diags) = parse_template(&html("<div>price: $5</div>"));
+    assert_eq!(interp_count(&html("<div>price: $5</div>")), 0);
+    assert!(!diags.iter().any(|d| d.is_error()));
+}
+
+// --- Adjacency ---
+
+#[test]
+fn three_adjacent_interpolations() {
+    assert_eq!(interp_count(&html("<div>${a}${b}${c}</div>")), 3);
+}
+
+#[test]
+fn interpolations_separated_by_single_char() {
+    assert_eq!(interp_count(&html("<div>${a}/${b}</div>")), 2);
+}
+
+#[test]
+fn interpolation_at_start_and_end_of_run() {
+    let ns = nodes_ok(&html("<div>${a} mid ${b}</div>"));
+    let el = first_element(&ns);
+    let text = match &el.children[0] {
+        TemplateNode::Text(t) => t,
+        other => panic!("expected text, got {:?}", other),
+    };
+    // interp, literal, interp
+    assert!(matches!(text.segments[0], TextSegment::Interpolation(_)));
+    assert!(matches!(text.segments[1], TextSegment::Literal { .. }));
+    assert!(matches!(text.segments[2], TextSegment::Interpolation(_)));
+}
+
+// --- Interpolation in attributes ---
+
+#[test]
+fn interpolation_in_static_attribute_with_braces() {
+    let ns = nodes_ok(&html("<div data-x=\"${ {k:1}.k }\"></div>"));
+    let el = first_element(&ns);
+    match &el.attrs[0] {
+        TemplateAttr::Static { value, .. } => {
+            let segs = &value.as_ref().unwrap().segments;
+            assert!(segs
+                .iter()
+                .any(|s| matches!(s, TextSegment::Interpolation(i) if i.expr == " {k:1}.k ")));
+        }
+        other => panic!("got {:?}", other),
+    }
+}
+
+#[test]
+fn interpolation_in_attribute_with_regex() {
+    let ns = nodes_ok(&html("<div title=\"${ /}/.source }\"></div>"));
+    let el = first_element(&ns);
+    match &el.attrs[0] {
+        TemplateAttr::Static { value, .. } => {
+            let segs = &value.as_ref().unwrap().segments;
+            assert!(segs
+                .iter()
+                .any(|s| matches!(s, TextSegment::Interpolation(i) if i.expr == " /}/.source ")));
+        }
+        other => panic!("got {:?}", other),
+    }
+}
+
+#[test]
+fn multiple_interpolations_in_single_attr() {
+    let ns = nodes_ok(&html("<div class=\"${a} x ${b} y ${c}\"></div>"));
+    let el = first_element(&ns);
+    match &el.attrs[0] {
+        TemplateAttr::Static { value, .. } => {
+            let n = value
+                .as_ref()
+                .unwrap()
+                .segments
+                .iter()
+                .filter(|s| matches!(s, TextSegment::Interpolation(_)))
+                .count();
+            assert_eq!(n, 3);
+        }
+        other => panic!("got {:?}", other),
+    }
+}
+
+// --- Span invariants ---
+
+#[test]
+fn interp_ranges_slice_back_to_source() {
+    let src = html("<div>a ${ x + y } b</div>");
+    let (file, _) = parse(&src);
+    let ns = file.html.as_ref().unwrap().template.nodes.clone();
+    let el = first_element(&ns);
+    let text = match &el.children[0] {
+        TemplateNode::Text(t) => t,
+        other => panic!("expected text, got {:?}", other),
+    };
+    for seg in &text.segments {
+        if let TextSegment::Interpolation(i) = seg {
+            // The inner expr_range slices to the expr; the outer range wraps `${…}`.
+            assert_eq!(i.expr_range.slice(&src), Some(i.expr.as_str()));
+            let whole = i.range.slice(&src).unwrap();
+            assert!(whole.starts_with("${") && whole.ends_with('}'));
+            // The inner range is strictly contained in the outer range.
+            assert!(i.range.start() < i.expr_range.start());
+            assert!(i.expr_range.end() < i.range.end());
+        }
+    }
+}
+
+#[test]
+fn literal_segment_ranges_slice_back() {
+    let src = html("<div>hello ${x} world</div>");
+    let (file, _) = parse(&src);
+    let ns = file.html.as_ref().unwrap().template.nodes.clone();
+    let el = first_element(&ns);
+    let text = match &el.children[0] {
+        TemplateNode::Text(t) => t,
+        other => panic!("expected text, got {:?}", other),
+    };
+    for seg in &text.segments {
+        if let TextSegment::Literal { text, range } = seg {
+            assert_eq!(range.slice(&src), Some(text.as_str()));
+        }
+    }
+}
+
+// --- Multi-byte / unicode inside interpolations ---
+
+#[test]
+fn unicode_inside_interpolation_keeps_valid_spans() {
+    let src = html("<div>${ 名前 + 'あ' }</div>");
+    let (file, diags) = parse(&src);
+    assert!(!diags.iter().any(|d| d.is_error()), "{:?}", diags);
+    let ns = file.html.as_ref().unwrap().template.nodes.clone();
+    let el = first_element(&ns);
+    let text = match &el.children[0] {
+        TemplateNode::Text(t) => t,
+        other => panic!("expected text, got {:?}", other),
+    };
+    let interp = text
+        .segments
+        .iter()
+        .find_map(|s| match s {
+            TextSegment::Interpolation(i) => Some(i),
+            _ => None,
+        })
+        .expect("interpolation");
+    assert_eq!(interp.expr_range.slice(&src), Some(interp.expr.as_str()));
+}

--- a/crates/lunas_parser/tests/template_edge.rs
+++ b/crates/lunas_parser/tests/template_edge.rs
@@ -1,0 +1,331 @@
+//! Edge cases for control-flow grouping (`:if`/`:elseif`/`:else` cascades and
+//! `:for` loops) and structural template shapes, driven through `parse`. These
+//! complement `tests/template.rs`; malformed control flow must yield
+//! diagnostics, never panic.
+
+use lunas_parser::{parse, BranchKind, Diagnostic, IfChain, Severity, TemplateNode};
+
+fn html(body: &str) -> String {
+    format!("html:\n    {}\n", body)
+}
+
+fn parse_template(src: &str) -> (Vec<TemplateNode>, Vec<Diagnostic>) {
+    let (file, diags) = parse(src);
+    (file.html.expect("html block").template.nodes, diags)
+}
+
+fn nodes_ok(src: &str) -> Vec<TemplateNode> {
+    let (ns, diags) = parse_template(src);
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "unexpected errors: {:?}",
+        diags
+    );
+    ns
+}
+
+fn find_if(nodes: &[TemplateNode]) -> Option<&IfChain> {
+    nodes.iter().find_map(|n| match n {
+        TemplateNode::If(c) => Some(c),
+        _ => None,
+    })
+}
+
+fn find_for(nodes: &[TemplateNode]) -> Option<&lunas_parser::ForBlock> {
+    nodes.iter().find_map(|n| match n {
+        TemplateNode::For(f) => Some(f),
+        _ => None,
+    })
+}
+
+fn has_error(diags: &[Diagnostic], needle: &str) -> bool {
+    diags
+        .iter()
+        .any(|d| d.is_error() && d.message.contains(needle))
+}
+
+// --- :if cascades ---
+
+#[test]
+fn if_elseif_elseif_else_four_branches() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :elseif=\"b\">2</div>\n    <div :elseif=\"c\">3</div>\n    <div :else>4</div>\n";
+    let ns = nodes_ok(src);
+    let chain = find_if(&ns).expect("chain");
+    assert_eq!(chain.branches.len(), 4);
+    assert_eq!(chain.branches[0].kind, BranchKind::If);
+    assert_eq!(chain.branches[1].kind, BranchKind::ElseIf);
+    assert_eq!(chain.branches[2].kind, BranchKind::ElseIf);
+    assert_eq!(chain.branches[3].kind, BranchKind::Else);
+    assert!(chain.branches[3].condition.is_none());
+    // Only one grouped If node at top level.
+    assert_eq!(
+        ns.iter()
+            .filter(|n| matches!(n, TemplateNode::If(_)))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn if_then_else_no_elseif() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :else>2</div>\n";
+    let ns = nodes_ok(src);
+    let chain = find_if(&ns).expect("chain");
+    assert_eq!(chain.branches.len(), 2);
+    assert_eq!(chain.branches[1].kind, BranchKind::Else);
+}
+
+#[test]
+fn second_else_after_else_is_orphan() {
+    // Cascade ends at the first :else; a trailing :else has no matching :if.
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :else>2</div>\n    <div :else>3</div>\n";
+    let (ns, diags) = parse_template(src);
+    assert_eq!(find_if(&ns).unwrap().branches.len(), 2);
+    assert!(has_error(&diags, "without a matching"));
+}
+
+#[test]
+fn elseif_after_else_is_orphan() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :else>2</div>\n    <div :elseif=\"c\">3</div>\n";
+    let (_ns, diags) = parse_template(src);
+    assert!(has_error(&diags, "without a matching"));
+}
+
+#[test]
+fn orphan_elseif_errors() {
+    let (_ns, diags) = parse_template(&html("<div :elseif=\"b\">x</div>"));
+    assert!(has_error(&diags, "without a matching"));
+}
+
+#[test]
+fn orphan_else_errors() {
+    let (_ns, diags) = parse_template(&html("<div :else>x</div>"));
+    assert!(has_error(&diags, "without a matching"));
+}
+
+#[test]
+fn if_without_condition_errors() {
+    let (_ns, diags) = parse_template(&html("<div :if=\"\">x</div>"));
+    assert!(has_error(&diags, "expects a condition"));
+}
+
+#[test]
+fn elseif_without_condition_errors() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :elseif=\"\">2</div>\n";
+    let (_ns, diags) = parse_template(src);
+    assert!(has_error(&diags, "expects a condition"));
+}
+
+#[test]
+fn else_with_value_warns() {
+    let (_ns, diags) = parse_template(&{
+        let mut s = String::from("html:\n    <div :if=\"a\">1</div>\n");
+        s.push_str("    <div :else=\"nope\">2</div>\n");
+        s
+    });
+    assert!(diags
+        .iter()
+        .any(|d| d.severity == Severity::Warning && d.message.contains("does not take a value")));
+}
+
+#[test]
+fn two_independent_if_chains() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <p>sep</p>\n    <div :if=\"b\">2</div>\n";
+    let ns = nodes_ok(src);
+    let chains = ns
+        .iter()
+        .filter(|n| matches!(n, TemplateNode::If(_)))
+        .count();
+    assert_eq!(chains, 2);
+}
+
+#[test]
+fn cascade_ranges_cover_all_branches() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <div :else>2</div>\n";
+    let (file, _) = parse(src);
+    let ns = file.html.unwrap().template.nodes;
+    let chain = find_if(&ns).unwrap();
+    // The chain range covers from the first branch start to the last branch end.
+    assert!(chain.range.start() <= chain.branches[0].range.start());
+    assert!(chain.range.end() >= chain.branches.last().unwrap().range.end());
+}
+
+// --- :if + :for on the same element ---
+
+#[test]
+fn for_wraps_if_on_same_element() {
+    let ns = nodes_ok(&html("<li :for=\"x of xs\" :if=\"x.ok\">${x}</li>"));
+    let f = find_for(&ns).expect("for");
+    match &*f.body {
+        TemplateNode::If(chain) => {
+            assert_eq!(chain.branches.len(), 1);
+            assert_eq!(chain.branches[0].condition.as_ref().unwrap().text, "x.ok");
+        }
+        other => panic!("expected inner if, got {other:?}"),
+    }
+}
+
+#[test]
+fn for_with_elseif_on_same_element_errors() {
+    // `:for` cannot combine with `:elseif`/`:else`.
+    let (_ns, diags) = parse_template(&html("<li :for=\"x of xs\" :else>y</li>"));
+    assert!(diags.iter().any(|d| d.is_error()));
+}
+
+// --- :for headers ---
+
+#[test]
+fn for_of_header() {
+    let ns = nodes_ok(&html("<li :for=\"item of items\">${item}</li>"));
+    assert_eq!(find_for(&ns).unwrap().header.text, "item of items");
+}
+
+#[test]
+fn for_in_header() {
+    let ns = nodes_ok(&html("<li :for=\"key in obj\">${key}</li>"));
+    assert_eq!(find_for(&ns).unwrap().header.text, "key in obj");
+}
+
+#[test]
+fn for_destructuring_header() {
+    let ns = nodes_ok(&html(
+        "<li :for=\"const [i, v] of data.entries()\">${v}</li>",
+    ));
+    assert_eq!(
+        find_for(&ns).unwrap().header.text,
+        "const [i, v] of data.entries()"
+    );
+}
+
+#[test]
+fn for_object_destructuring_header() {
+    let ns = nodes_ok(&html("<li :for=\"const {id, name} of rows\">${name}</li>"));
+    assert_eq!(
+        find_for(&ns).unwrap().header.text,
+        "const {id, name} of rows"
+    );
+}
+
+#[test]
+fn for_header_kept_raw_not_split() {
+    // The header text is stored verbatim; splitting is the downstream concern.
+    let ns = nodes_ok(&html("<li :for=\"x, i of items\">y</li>"));
+    assert_eq!(find_for(&ns).unwrap().header.text, "x, i of items");
+}
+
+#[test]
+fn for_empty_header_errors() {
+    let (_ns, diags) = parse_template(&html("<li :for=\"\">x</li>"));
+    assert!(has_error(&diags, "`:for`"));
+}
+
+#[test]
+fn for_whitespace_only_header_errors() {
+    let (_ns, diags) = parse_template(&html("<li :for=\"   \">x</li>"));
+    assert!(has_error(&diags, "`:for`"));
+}
+
+#[test]
+fn for_missing_value_errors() {
+    let (_ns, diags) = parse_template(&html("<li :for>x</li>"));
+    assert!(has_error(&diags, "`:for`"));
+}
+
+#[test]
+fn for_header_range_slices_back() {
+    let src = html("<li :for=\"item of items\">y</li>");
+    let (file, _) = parse(&src);
+    let ns = file.html.unwrap().template.nodes;
+    let f = find_for(&ns).unwrap();
+    assert_eq!(f.header.range.slice(&src), Some("item of items"));
+}
+
+// --- Nesting ---
+
+#[test]
+fn for_inside_if_body() {
+    let src = "html:\n    <div :if=\"show\"><ul :for=\"x of xs\"><li>${x}</li></ul></div>\n";
+    let ns = nodes_ok(src);
+    let chain = find_if(&ns).expect("if");
+    let div = match &*chain.branches[0].body {
+        TemplateNode::Element(e) => e,
+        other => panic!("expected div, got {other:?}"),
+    };
+    assert!(div
+        .children
+        .iter()
+        .any(|n| matches!(n, TemplateNode::For(_))));
+}
+
+#[test]
+fn if_cascade_inside_for_body() {
+    let src = "html:\n    <ul :for=\"x of xs\"><li :if=\"x.a\">a</li><li :elseif=\"x.b\">b</li><li :else>c</li></ul>\n";
+    let ns = nodes_ok(src);
+    let f = find_for(&ns).expect("for");
+    let ul = match &*f.body {
+        TemplateNode::Element(e) => e,
+        other => panic!("expected ul, got {other:?}"),
+    };
+    let inner = ul
+        .children
+        .iter()
+        .find_map(|n| match n {
+            TemplateNode::If(c) => Some(c),
+            _ => None,
+        })
+        .expect("inner if chain");
+    assert_eq!(inner.branches.len(), 3);
+}
+
+#[test]
+fn triple_nested_for() {
+    let src =
+        "html:\n    <a :for=\"i of xs\"><b :for=\"j of i\"><c :for=\"k of j\">${k}</c></b></a>\n";
+    let ns = nodes_ok(src);
+    let outer = find_for(&ns).expect("outer for");
+    let a = match &*outer.body {
+        TemplateNode::Element(e) => e,
+        _ => panic!("expected a"),
+    };
+    let mid = a
+        .children
+        .iter()
+        .find_map(|n| match n {
+            TemplateNode::For(f) => Some(f),
+            _ => None,
+        })
+        .expect("middle for");
+    let b = match &*mid.body {
+        TemplateNode::Element(e) => e,
+        _ => panic!("expected b"),
+    };
+    assert!(b.children.iter().any(|n| matches!(n, TemplateNode::For(_))));
+}
+
+// --- Comments & whitespace boundaries ---
+
+#[test]
+fn comment_between_if_and_else_breaks_cascade() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n    <!-- c -->\n    <div :else>2</div>\n";
+    let (_ns, diags) = parse_template(src);
+    assert!(has_error(&diags, "without a matching"));
+}
+
+#[test]
+fn multiple_blank_lines_keep_cascade() {
+    let src = "html:\n    <div :if=\"a\">1</div>\n\n\n\n    <div :elseif=\"b\">2</div>\n";
+    let ns = nodes_ok(src);
+    assert_eq!(find_if(&ns).unwrap().branches.len(), 2);
+}
+
+// --- serde round-trip on rich control flow ---
+
+#[test]
+fn control_flow_serde_round_trip() {
+    let src = "html:\n    <ul :for=\"x of xs\"><li :if=\"x.a\">${x.v}</li><li :else>-</li></ul>\n";
+    let (file, _) = parse(src);
+    let ns = file.html.unwrap().template.nodes;
+    let json = serde_json::to_string(&ns).expect("serialize");
+    let back: Vec<TemplateNode> = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(ns, back);
+}


### PR DESCRIPTION
## Summary

Mass-expands the Rust test suites for `lunas_parser` and `lunas_html_parser` with **132 new edge/fuzz cases** across six new integration-test files. Test-only change: no source files touched, no `roadmap.yml` edits.

The never-panic guarantee is a core contract for these crates, so the new cases are edge- and recovery-focused, and the fuzz files add span-soundness *property* checks on top of "does not panic".

### `crates/lunas_parser/tests/`
- **`interpolation.rs`** (34) — `${…}` scanner: deeply nested braces, strings/regex/template-literals containing braces, line/block comments, empty (`${}`) and unterminated recovery, adjacency, interpolation inside attributes, and span slice-back invariants.
- **`directives_edge.rs`** (33) — `@use` (inline/block/quoting), `@input` (`name:Type[?][=default]`), `@useRouting`/`@useAutoRouting`, unknown-directive warnings; `:`/`::`/`@`/static attribute classification incl. malformed → diagnostics.
- **`template_edge.rs`** (28) — `:if`/`:elseif`/`:else` cascade grouping (orphans, double-`:else`, comment/whitespace boundaries), `:for` headers (`of`/`in`/destructuring/malformed), `:if`+`:for` precedence, deep nesting, serde round-trip.
- **`fuzz_extra.rs`** (4) — extends the never-panic corpus for the full pipeline and asserts every interpolation/diagnostic range slices on a UTF-8 boundary (multibyte-offset rebasing included).

### `crates/lunas_html_parser/tests/`
- **`html_recovery.rs`** (29) — mismatched/stray closes, multi-level auto-close, unclosed-at-EOF, void elements, raw-text (script/style/title/textarea) incl. unterminated + close-lookalikes, attribute quoting/prefix/case, comments/doctype, deep nesting, unicode, dangling markup, and parent-child span containment on well-formed input.
- **`fuzz_property.rs`** (4) — extends the never-panic corpus and adds a soundness property (ranges in-bounds + on char boundaries) for any input, plus full containment on a balanced-nesting generator.

## Follow-up found while writing tests

The HTML parser gives an **unterminated open tag** (e.g. `<a b="x"` at EOF) an `open_tag_range`/`range` that does not contain its own attribute spans, violating parent-child containment. `fuzz_property.rs` therefore asserts only the weaker (always-true) soundness invariant on adversarial input, with a documented carve-out. Filed as a separate fix task — not addressed here to keep this PR test-only.

## Quality gate
`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all green (exit 0, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)