### PR TITLE
test(css): expand lunas_css selector/at-rule/keyframes/fuzz suite

### DIFF
--- a/crates/lunas_css/tests/at_rules.rs
+++ b/crates/lunas_css/tests/at_rules.rs
@@ -1,0 +1,239 @@
+//! Edge-focused tests for at-rule handling: conditional-group recursion
+//! (`@media`/`@supports`/`@layer`/`@container`/`@scope`), vendor prefixes,
+//! nesting, and pass-through at-rules (`@font-face`/`@import`/`@charset`/
+//! `@page`/unknown). Complements the baseline cases in `tests/scoping.rs`.
+
+use lunas_css::scope_css;
+
+const S: &str = "data-lunas-x";
+
+fn scope(css: &str) -> String {
+    let (out, diags) = scope_css(css, S);
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {diags:?}\ninput: {css:?}"
+    );
+    out
+}
+
+// --- @media ------------------------------------------------------------------
+
+#[test]
+fn media_with_and_condition() {
+    let out = scope("@media screen and (min-width: 700px) { .a {} }");
+    assert_eq!(
+        out,
+        "@media screen and (min-width: 700px) { .a[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn media_with_multiple_rules_inside() {
+    let out = scope("@media screen { .a {} .b {} }");
+    assert_eq!(
+        out,
+        "@media screen { .a[data-lunas-x] {} .b[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn media_with_selector_list_inside() {
+    let out = scope("@media screen { a, b {} }");
+    assert_eq!(out, "@media screen { a[data-lunas-x], b[data-lunas-x] {} }");
+}
+
+// --- @supports -----------------------------------------------------------------
+
+#[test]
+fn supports_with_not_condition() {
+    let out = scope("@supports not (display: grid) { .a {} }");
+    assert_eq!(out, "@supports not (display: grid) { .a[data-lunas-x] {} }");
+}
+
+#[test]
+fn supports_nested_in_media() {
+    let out = scope("@media screen and (min-width: 1px) { @supports (display:grid) { .a { } } }");
+    assert_eq!(
+        out,
+        "@media screen and (min-width: 1px) { @supports (display:grid) { .a[data-lunas-x] { } } }"
+    );
+}
+
+// --- @layer ----------------------------------------------------------------
+
+#[test]
+fn layer_statement_multi_name_passthrough() {
+    assert_eq!(
+        scope("@layer base, components, utilities;"),
+        "@layer base, components, utilities;"
+    );
+}
+
+#[test]
+fn layer_statement_then_layer_block() {
+    let src = "@layer base, components, utilities;\n@layer base { .a {} }";
+    let out = scope(src);
+    assert_eq!(
+        out,
+        "@layer base, components, utilities;\n@layer base { .a[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn anonymous_layer_block_recurses() {
+    let out = scope("@layer { .a {} }");
+    assert_eq!(out, "@layer { .a[data-lunas-x] {} }");
+}
+
+#[test]
+fn nested_layer_inside_layer() {
+    let out = scope("@layer outer { @layer inner { .a {} } }");
+    assert_eq!(out, "@layer outer { @layer inner { .a[data-lunas-x] {} } }");
+}
+
+// --- @container --------------------------------------------------------------
+
+#[test]
+fn container_named_query() {
+    let out = scope("@container sidebar (min-width: 400px) { .a {} }");
+    assert_eq!(
+        out,
+        "@container sidebar (min-width: 400px) { .a[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn container_unnamed_query() {
+    let out = scope("@container (min-width: 400px) { .a {} }");
+    assert_eq!(out, "@container (min-width: 400px) { .a[data-lunas-x] {} }");
+}
+
+// --- @scope --------------------------------------------------------------------
+
+#[test]
+fn scope_at_rule_recurses() {
+    let out = scope("@scope (.a) { .b {} }");
+    assert_eq!(out, "@scope (.a) { .b[data-lunas-x] {} }");
+}
+
+#[test]
+fn scope_at_rule_with_to_clause() {
+    let out = scope("@scope (.a) to (.b) { .c {} }");
+    assert_eq!(out, "@scope (.a) to (.b) { .c[data-lunas-x] {} }");
+}
+
+// --- vendor prefixes on conditional groups -----------------------------------
+
+#[test]
+fn vendor_prefixed_media_treated_as_unknown_group_name() {
+    // `strip_vendor` recognizes `-webkit-keyframes` for @keyframes, but the
+    // conditional-group check (`is_conditional_group`) also strips vendor
+    // prefixes, so `@-webkit-media` still recurses like `@media`.
+    let out = scope("@-webkit-media (min-width: 1px) { .a {} }");
+    assert_eq!(
+        out,
+        "@-webkit-media (min-width: 1px) { .a[data-lunas-x] {} }"
+    );
+}
+
+#[test]
+fn moz_document_unknown_atrule_not_scoped() {
+    // `@-moz-document` (an unknown at-rule after vendor-stripping) is NOT a
+    // conditional group; its block is treated as declarations and is not
+    // scoped even though it looks like it contains a rule.
+    let out = scope("@-moz-document url(x) { .a {} }");
+    assert_eq!(out, "@-moz-document url(x) { .a {} }");
+}
+
+// --- deep nesting --------------------------------------------------------------
+
+#[test]
+fn triple_nested_conditional_groups() {
+    let out = scope("@media screen { @supports (display:grid) { @layer x { .a {} } } }");
+    assert_eq!(
+        out,
+        "@media screen { @supports (display:grid) { @layer x { .a[data-lunas-x] {} } } }"
+    );
+}
+
+// --- pass-through at-rules -----------------------------------------------------
+
+#[test]
+fn font_face_with_multiple_declarations_untouched() {
+    let src = "@font-face { font-family: 'X'; src: url(x.woff) format('woff'); font-weight: 400 }";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn page_with_pseudo_class_untouched() {
+    let src = "@page :first { margin: 1in }";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn page_without_pseudo_untouched() {
+    let src = "@page { size: A4 }";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn multiple_page_rules_untouched() {
+    let src = "@page :first { margin: 1in } @page { size: A4 }";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn import_with_media_query_untouched() {
+    let src = "@import url('x.css') screen;";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn import_with_layer_function_untouched() {
+    let src = "@import 'foo.css' layer(base);";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn charset_untouched_and_first() {
+    let src = "@charset \"utf-8\";\n.a {}";
+    let out = scope(src);
+    assert_eq!(out, "@charset \"utf-8\";\n.a[data-lunas-x] {}");
+}
+
+#[test]
+fn unknown_at_rule_with_block_not_scoped() {
+    // An unknown at-rule's block is treated as declarations, not rules — even
+    // though the content inside looks like a qualified rule, it must not be
+    // scoped, matching the documented non-goal.
+    let out = scope("@unknown-at-rule (foo) { .a { color: red } }");
+    assert_eq!(out, "@unknown-at-rule (foo) { .a { color: red } }");
+}
+
+#[test]
+fn unknown_at_rule_statement_form_untouched() {
+    let src = "@my-custom-rule foo bar;";
+    assert_eq!(scope(src), src);
+}
+
+#[test]
+fn font_face_inside_media_not_scoped() {
+    // `@font-face` nested inside a conditional group is still a declaration
+    // block, not scoped, even though the walker recurses into the @media body.
+    let out = scope("@media screen { @font-face { src: url(x) } }");
+    assert_eq!(out, "@media screen { @font-face { src: url(x) } }");
+}
+
+// --- comments around at-rules --------------------------------------------------
+
+#[test]
+fn comment_before_at_rule() {
+    let out = scope("/* c */ @media screen { .a {} }");
+    assert_eq!(out, "/* c */ @media screen { .a[data-lunas-x] {} }");
+}
+
+#[test]
+fn comment_inside_at_rule_prelude() {
+    let out = scope("@media /* c */ screen { .a {} }");
+    assert_eq!(out, "@media /* c */ screen { .a[data-lunas-x] {} }");
+}

--- a/crates/lunas_css/tests/deep_global.rs
+++ b/crates/lunas_css/tests/deep_global.rs
@@ -1,0 +1,183 @@
+//! Edge-focused tests for the `:deep()` / `:global()` escape hatches, and
+//! their interaction with selector lists, combinators, and each other.
+//! Complements the baseline cases in `tests/scoping.rs`.
+
+use lunas_css::scope_css;
+
+const S: &str = "data-lunas-x";
+
+fn scope(css: &str) -> String {
+    let (out, diags) = scope_css(css, S);
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {diags:?}\ninput: {css:?}"
+    );
+    out
+}
+
+// --- :deep() ------------------------------------------------------------------
+
+#[test]
+fn deep_in_middle_of_chain() {
+    // Everything at and after `:deep(...)`'s compound is left unscoped,
+    // including compounds that follow it in the chain.
+    assert_eq!(
+        scope(".a .b:deep(.c) .d {}"),
+        ".a[data-lunas-x] .b[data-lunas-x] .c .d {}"
+    );
+}
+
+#[test]
+fn deep_then_child_combinator_unscoped() {
+    assert_eq!(scope(".a:deep(.b) > .c {}"), ".a[data-lunas-x] .b > .c {}");
+}
+
+#[test]
+fn deep_as_first_compound_no_leading_scope() {
+    // `:deep(.a)` alone: "before" is empty, so nothing is scoped and no
+    // separating space is introduced.
+    assert_eq!(scope(":deep(.a) {}"), ".a {}");
+}
+
+#[test]
+fn deep_with_empty_argument() {
+    assert_eq!(scope(".a:deep() {}"), ".a[data-lunas-x] {}");
+}
+
+#[test]
+fn deep_in_selector_list_scopes_only_before() {
+    assert_eq!(
+        scope(".a:deep(.b), .c {}"),
+        ".a[data-lunas-x] .b, .c[data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn deep_only_affects_its_own_list_entry() {
+    assert_eq!(
+        scope(".x, .a:deep(.b) {}"),
+        ".x[data-lunas-x], .a[data-lunas-x] .b {}"
+    );
+}
+
+#[test]
+fn second_deep_is_left_as_literal_text() {
+    // Only the first `:deep()` boundary is honored; once `deep_reached` is
+    // set, remaining compounds (including a second `:deep(...)`) are emitted
+    // completely untouched.
+    assert_eq!(
+        scope(".x :deep(.y):deep(.z) {}"),
+        ".x[data-lunas-x] .y:deep(.z) {}"
+    );
+}
+
+#[test]
+fn deep_after_attribute_selector() {
+    assert_eq!(
+        scope(".a[data-x]:deep(.b) {}"),
+        ".a[data-x][data-lunas-x] .b {}"
+    );
+}
+
+#[test]
+fn deep_with_multi_word_inner_selector() {
+    assert_eq!(
+        scope(".a :deep(.b .c > .d) {}"),
+        ".a[data-lunas-x] .b .c > .d {}"
+    );
+}
+
+#[test]
+fn deep_without_parens_is_not_special() {
+    // `:deep` with no following `(` is just an (invalid) pseudo-class name,
+    // not our escape hatch — it gets scoped like any other pseudo.
+    assert_eq!(scope(".a:deep {}"), ".a[data-lunas-x]:deep {}");
+}
+
+#[test]
+fn deep_with_whitespace_before_paren_is_not_recognized() {
+    // Whitespace between `:deep` and `(` splits the compound at the space
+    // (whitespace always introduces a descendant combinator between units),
+    // so `find_deep` never sees `:deep(` as one token here: `:deep` is just
+    // scoped as an (invalid) pseudo-class on `.a`, and `(.b)` becomes its own
+    // compound, scoped independently as a descendant.
+    assert_eq!(
+        scope(".a:deep (.b) {}"),
+        ".a[data-lunas-x]:deep (.b)[data-lunas-x] {}"
+    );
+}
+
+// --- :global() ------------------------------------------------------------------
+
+#[test]
+fn global_empty_argument() {
+    assert_eq!(scope(":global() {}"), " {}");
+}
+
+#[test]
+fn global_with_internal_comma_kept_as_one_unit() {
+    // The comma lives inside `:global(...)`'s parens, so it's part of the
+    // argument, not a selector-list separator; the whole thing unwraps to one
+    // unscoped chunk.
+    assert_eq!(scope(":global(.a, .b) {}"), ".a, .b {}");
+}
+
+#[test]
+fn multiple_global_wrappers_all_unwrapped() {
+    assert_eq!(scope(":global(.a):global(.b) {}"), ".a.b {}");
+}
+
+#[test]
+fn global_with_combinator_inside() {
+    assert_eq!(scope(":global(.a > .b) {}"), ".a > .b {}");
+}
+
+#[test]
+fn global_mixed_with_deep_unwraps_deep_as_text() {
+    // A top-level `:global` anywhere makes the *entire* selector global; any
+    // `:deep(...)` present is not specially interpreted, it is just part of
+    // the (fully unscoped) selector text outside the global wrapper.
+    assert_eq!(scope(":global(.a) :deep(.b) {}"), ".a :deep(.b) {}");
+}
+
+#[test]
+fn global_after_scoped_prefix_makes_whole_thing_global() {
+    assert_eq!(scope(".a :global(.b) {}"), ".a .b {}");
+}
+
+#[test]
+fn global_prefixed_ident_not_treated_as_global_pseudo() {
+    // `:globalfoo(...)` is a longer ident, must not match `:global`.
+    assert_eq!(
+        scope("a:globalfoo(1) {}"),
+        "a[data-lunas-x]:globalfoo(1) {}"
+    );
+}
+
+#[test]
+fn global_list_only_that_entry_is_global() {
+    assert_eq!(
+        scope(":global(.a), .b, :global(.c) {}"),
+        ".a, .b[data-lunas-x], .c {}"
+    );
+}
+
+#[test]
+fn global_with_attribute_selector_inside() {
+    assert_eq!(scope(r#":global(a[href^="/"]) {}"#), r#"a[href^="/"] {}"#);
+}
+
+#[test]
+fn global_with_pseudo_class_inside() {
+    assert_eq!(scope(":global(.a:hover) {}"), ".a:hover {}");
+}
+
+#[test]
+fn global_with_leading_whitespace_in_arg_trimmed() {
+    assert_eq!(scope(":global(  .a  ) {}"), ".a {}");
+}
+
+#[test]
+fn global_with_nested_parens_in_arg() {
+    assert_eq!(scope(":global(.a:not(.b)) {}"), ".a:not(.b) {}");
+}

--- a/crates/lunas_css/tests/fuzz_more.rs
+++ b/crates/lunas_css/tests/fuzz_more.rs
@@ -1,0 +1,283 @@
+//! Extended never-panic fuzz corpus for `scope_css`, complementing
+//! `tests/robustness.rs`. This file uses different seeds, alphabets, and
+//! generation strategies (grammar-guided selector/at-rule assembly, byte-level
+//! mutation of valid CSS, and a much larger pure-random sweep at 10k+
+//! iterations) to widen coverage of the input space without duplicating the
+//! existing corpus.
+
+use lunas_css::scope_css;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+const SCOPE: &str = "data-lunas-fuzz9f8e";
+
+fn assert_ok(input: &str) {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let (out, diags) = scope_css(input, SCOPE);
+        for d in &diags {
+            assert!(
+                d.range.end().as_usize() <= input.len(),
+                "diagnostic range {:?} exceeds input len {} for {:?}",
+                d.range,
+                input.len(),
+                input
+            );
+            assert!(d.range.start().as_usize() <= d.range.end().as_usize());
+        }
+        // Re-running on the transform's own output must also never panic —
+        // exercises the transform being handed already-scoped CSS (e.g. if a
+        // build pipeline accidentally double-processes a stylesheet).
+        let (out2, _) = scope_css(&out, SCOPE);
+        // ...and a third pass, since some rewrites (keyframe renaming) grow
+        // the string each time a match is found in the accumulated suffixes.
+        let _ = scope_css(&out2, SCOPE);
+    }));
+    assert!(result.is_ok(), "scope_css panicked on input: {input:?}");
+}
+
+/// Small deterministic xorshift RNG, distinct from `robustness.rs`'s LCG, so
+/// the two corpora explore different sequences even with similar seeds.
+struct Xorshift(u64);
+impl Xorshift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn range(&mut self, n: usize) -> usize {
+        if n == 0 {
+            0
+        } else {
+            (self.next() as usize) % n
+        }
+    }
+}
+
+#[test]
+fn large_pure_random_byte_soup_10k_iterations() {
+    // Alphabet includes raw bytes beyond the structural-token set used in
+    // robustness.rs's pseudo_random_fuzz — more punctuation, digits, and a
+    // couple of malformed-UTF8-adjacent (but still valid) code points.
+    let alphabet: &[char] = &[
+        '{', '}', '(', ')', '[', ']', ':', ';', ',', '.', '#', '*', '>', '+', '~', '/', '"', '\'',
+        '\\', '@', '-', '_', '=', '^', '$', '|', '!', '%', '&', '?', ' ', '\n', '\t', '\r', '\0',
+        '0', '1', '2', '9', 'n', 'a', 'z', 'A', 'Z', 'ص', 'ñ', '\u{200D}', '\u{FE0F}', '\u{2028}',
+    ];
+    let mut rng = Xorshift(0x9e37_79b9_7f4a_7c15);
+    for _ in 0..10_000 {
+        let len = rng.range(80);
+        let mut s = String::with_capacity(len);
+        for _ in 0..len {
+            let idx = rng.range(alphabet.len());
+            s.push(alphabet[idx]);
+        }
+        assert_ok(&s);
+    }
+}
+
+#[test]
+fn grammar_guided_selector_fuzz_10k_iterations() {
+    // Assembles pseudo-CSS from fragments that look like real selectors/rules
+    // (rather than raw characters), so this corpus is more likely to hit
+    // "almost valid" structures the character-soup fuzzers rarely produce.
+    let selectors: &[&str] = &[
+        "a",
+        ".b",
+        "#c",
+        "*",
+        "a.b#c",
+        "[d]",
+        "[d=e]",
+        "[d=\"e,f\"]",
+        "a:hover",
+        "a::before",
+        "a:not(.x, .y)",
+        "a:is(.x, .y)",
+        ":deep(.x)",
+        ":global(.x)",
+        "a:deep(.b)",
+        "a:global(.b)",
+        "a\\:esc",
+        ".日本語",
+        "svg|circle",
+        "*|*",
+    ];
+    let combinators: &[&str] = &[" ", " > ", " + ", " ~ ", ">", "+", "~", "  ", ""];
+    let at_preludes: &[&str] = &[
+        "@media screen",
+        "@media (min-width: 1px)",
+        "@supports (display:grid)",
+        "@layer x",
+        "@container (min-width: 1px)",
+        "@scope (.a)",
+        "@keyframes spin",
+        "@-webkit-keyframes spin",
+        "@font-face",
+        "@page",
+        "@import url(x)",
+        "@charset \"utf-8\"",
+        "@weird-unknown-thing",
+    ];
+    let decls: &[&str] = &[
+        "color: red",
+        "animation: spin 1s",
+        "animation-name: spin",
+        "content: '→'",
+        "background: url(a,b)",
+        "",
+        ":",
+        "prop",
+    ];
+    let terminators: &[&str] = &["{", "}", ";", ""];
+
+    let mut rng = Xorshift(0xc2b2_ae3d_27d4_eb4f);
+    for _ in 0..10_000 {
+        let mut s = String::new();
+        let pieces = 1 + rng.range(12);
+        for _ in 0..pieces {
+            match rng.range(5) {
+                0 => s.push_str(selectors[rng.range(selectors.len())]),
+                1 => s.push_str(combinators[rng.range(combinators.len())]),
+                2 => s.push_str(at_preludes[rng.range(at_preludes.len())]),
+                3 => s.push_str(decls[rng.range(decls.len())]),
+                _ => s.push_str(terminators[rng.range(terminators.len())]),
+            }
+        }
+        assert_ok(&s);
+    }
+}
+
+#[test]
+fn mutated_valid_css_fuzz_5k_iterations() {
+    // Start from a corpus of *valid* stylesheets and randomly delete/duplicate
+    // bytes — a classic mutation-fuzzing strategy that tends to find
+    // off-by-one boundary bugs that pure generation misses.
+    let seeds: &[&str] = &[
+        ".a { color: red } .b:hover { color: blue }",
+        "@media screen { .a, .b > c { color: red } }",
+        "@keyframes spin { from { opacity: 0 } to { opacity: 1 } } .x { animation: spin 1s }",
+        ":global(.a) .b:deep(.c) {}",
+        "a[href^=\"https://\"]:not(.external, .internal) {}",
+        "@supports (display: grid) { @media (min-width: 1px) { .a {} } }",
+        "/* comment */ .a /* mid */ { /* in-block */ color: red /* trailing */ }",
+    ];
+    let mut rng = Xorshift(0x1656_67b1_9e37_79f9);
+    for seed in seeds {
+        for _ in 0..700 {
+            let bytes = seed.as_bytes();
+            if bytes.is_empty() {
+                continue;
+            }
+            let mut mutated: Vec<u8> = bytes.to_vec();
+            let ops = 1 + rng.range(6);
+            for _ in 0..ops {
+                if mutated.is_empty() {
+                    break;
+                }
+                match rng.range(4) {
+                    0 => {
+                        // Delete a byte at a random position.
+                        let i = rng.range(mutated.len());
+                        mutated.remove(i);
+                    }
+                    1 => {
+                        // Duplicate a byte at a random position.
+                        let i = rng.range(mutated.len());
+                        let b = mutated[i];
+                        mutated.insert(i, b);
+                    }
+                    2 => {
+                        // Overwrite a byte with a structural character.
+                        let structural: &[u8] = b"{}()[]:;,\"'\\@><+~ .#*";
+                        let i = rng.range(mutated.len());
+                        mutated[i] = structural[rng.range(structural.len())];
+                    }
+                    _ => {
+                        // Truncate from the end.
+                        let cut = rng.range(mutated.len() / 2 + 1);
+                        mutated.truncate(mutated.len() - cut);
+                    }
+                }
+            }
+            // Mutation can produce invalid UTF-8; lossily repair it so the
+            // fuzzer still explores *some* string, since scope_css only
+            // accepts &str.
+            let s = String::from_utf8_lossy(&mutated).into_owned();
+            assert_ok(&s);
+        }
+    }
+}
+
+#[test]
+fn adversarial_boundary_literals() {
+    // Hand-picked inputs targeting specific boundary conditions in the
+    // scanner/selector/rewrite modules that are easy to get subtly wrong.
+    let cases = [
+        // Scope attribute edge cases handled elsewhere, but paired with
+        // pathological CSS here.
+        ":not(:not(:not(:not(.a)))) {}",
+        ":is(:where(:is(:where(.a))))  {}",
+        "a:deep(:global(.b)) {}",
+        ":global(:deep(.a)) {}",
+        ".a:global(.b):deep(.c) {}",
+        "@keyframes k {} @keyframes k {} @keyframes k {} .x { animation: k 1s, k 2s, k 3s }",
+        "@media (min-width:1px){@media(min-width:2px){@media(min-width:3px){.a{}}}}",
+        "a[b=\"\\\"\"] {}",
+        "a[b='\\''] {}",
+        ".a\\  {}",
+        "@charset",
+        "@charset;",
+        "@charset \"a\" \"b\";",
+        "@page:first{}",
+        "@page :first{}",
+        "*{}",
+        "**{}",
+        "a::before::after {}",
+        "::before:hover {}",
+        "a,,,,,b{}",
+        ".a[",
+        ".a[b",
+        ".a[b=",
+        ".a[b=c",
+        ".a[b=c]",
+        ".a[b=c] {",
+        "\u{feff}.a {}",
+        "a\u{200b}.b {}",
+        "@media\u{a0}screen{.a{}}",
+        &"a".repeat(5000),
+        &format!("{}{{}}", ".a ".repeat(2000)),
+        &format!(".a{{{}}}", "color:red;".repeat(2000)),
+    ];
+    for c in cases {
+        assert_ok(c);
+    }
+}
+
+#[test]
+fn wide_scope_attribute_values_do_not_panic() {
+    // scope_css takes an arbitrary scope_attr string too; malformed/adversarial
+    // attrs must not cause panics regardless of the CSS input.
+    let attrs = [
+        "",
+        "data-lunas-",
+        "]",
+        "[",
+        "\"",
+        "'",
+        " ",
+        "\n",
+        "a b",
+        "🎉",
+    ];
+    for attr in attrs {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = scope_css(
+                ".a:hover { color: red } @keyframes k {} .b{animation:k 1s}",
+                attr,
+            );
+        }));
+        assert!(result.is_ok(), "panicked with scope_attr {attr:?}");
+    }
+}

--- a/crates/lunas_css/tests/keyframes.rs
+++ b/crates/lunas_css/tests/keyframes.rs
@@ -1,0 +1,207 @@
+//! Edge-focused tests for `@keyframes` renaming and `animation` /
+//! `animation-name` property rewriting, including forward references,
+//! shorthand parsing, and known limitations. Complements the baseline cases
+//! in `tests/scoping.rs`.
+
+use lunas_css::scope_css;
+
+const SCOPE: &str = "data-lunas-x";
+
+fn out(src: &str) -> String {
+    let (out, diags) = scope_css(src, SCOPE);
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {diags:?}\ninput: {src:?}"
+    );
+    out
+}
+
+#[test]
+fn percentage_keyframe_selectors_untouched_and_renamed() {
+    let src = "@keyframes spin { 0% { opacity: 0 } 50% { opacity: .5 } 100% { opacity: 1 } } \
+               .x { animation: spin 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes spin-x {"), "{o}");
+    assert!(o.contains("0% { opacity: 0 }"), "{o}");
+    assert!(o.contains("50% { opacity: .5 }"), "{o}");
+    assert!(o.contains("100% { opacity: 1 }"), "{o}");
+    assert!(o.contains("animation: spin-x 1s"), "{o}");
+}
+
+#[test]
+fn multiple_animations_comma_separated_both_rewritten() {
+    let src = "@keyframes a {} @keyframes b {} .x { animation: a 1s, b 2s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes a-x {}"), "{o}");
+    assert!(o.contains("@keyframes b-x {}"), "{o}");
+    assert!(o.contains("animation: a-x 1s, b-x 2s"), "{o}");
+}
+
+#[test]
+fn animation_property_uppercase_still_recognized() {
+    let src = "@keyframes fade {} .x { ANIMATION: fade 1s }";
+    let o = out(src);
+    assert!(o.contains("ANIMATION: fade-x 1s"), "{o}");
+}
+
+#[test]
+fn animation_name_property_mixed_case_recognized() {
+    let src = "@keyframes fade {} .x { animation-Name: fade }";
+    let o = out(src);
+    assert!(o.contains("animation-Name: fade-x"), "{o}");
+}
+
+#[test]
+fn animation_value_with_no_matching_keyframes_untouched() {
+    let src = ".x { animation: spin 1s }";
+    assert_eq!(out(src), ".x[data-lunas-x] { animation: spin 1s }");
+}
+
+#[test]
+fn keyframe_name_is_whole_token_not_substring() {
+    // `spin-thing` and `spin` are different idents; renaming must not treat
+    // one as a substring of the other.
+    let src = "@keyframes spin-thing {} .x { animation: spin 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes spin-thing-x {}"), "{o}");
+    // `spin` (used in the animation value) has no matching @keyframes name,
+    // so it is left untouched.
+    assert!(o.contains("animation: spin 1s"), "{o}");
+}
+
+#[test]
+fn animation_value_substring_of_keyframe_name_untouched() {
+    let src = "@keyframes spin {} .x { animation: spin-thing 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes spin-x {}"), "{o}");
+    assert!(o.contains("animation: spin-thing 1s"), "{o}");
+}
+
+#[test]
+fn duplicate_keyframes_declaration_dedups_mapping() {
+    let src = "@keyframes spin {} @keyframes spin {} .x { animation: spin 1s }";
+    let o = out(src);
+    assert!(
+        o.contains("@keyframes spin-x {} @keyframes spin-x {}"),
+        "{o}"
+    );
+    assert!(o.contains("animation: spin-x 1s"), "{o}");
+}
+
+#[test]
+fn multiple_declarations_in_one_block_all_rewritten() {
+    let src = "@keyframes spin {} .a { animation: spin 1s; color: red; animation-name: spin }";
+    let o = out(src);
+    assert!(
+        o.contains("animation: spin-x 1s; color: red; animation-name: spin-x"),
+        "{o}"
+    );
+}
+
+#[test]
+fn keyframe_name_inside_unrelated_property_value_untouched() {
+    // `url(spin.png)` contains the substring "spin" but is not the
+    // `animation`/`animation-name` property, so it must not be touched.
+    let src = "@keyframes spin {} .a { background: url(spin.png) }";
+    let o = out(src);
+    assert!(o.contains("background: url(spin.png)"), "{o}");
+}
+
+#[test]
+fn keyframe_name_matching_is_case_sensitive() {
+    let src = "@keyframes spin {} .a { animation: SPIN 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes spin-x {}"), "{o}");
+    // `SPIN` != `spin`, so it's left untouched.
+    assert!(o.contains("animation: SPIN 1s"), "{o}");
+}
+
+#[test]
+fn keyframes_nested_in_media_are_not_collected_by_pass_one() {
+    // Known limitation: the keyframe-name collection pass only scans
+    // top-level at-rules; a `@keyframes` nested inside `@media` is renamed
+    // when walked structurally... but since pass one never recorded its name,
+    // no rename mapping exists, so neither the `@keyframes` name nor any
+    // `animation` reference to it changes.
+    let src = "@media screen { @keyframes spin {} } .a { animation: spin 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes spin {}"), "{o}");
+    assert!(o.contains("animation: spin 1s"), "{o}");
+}
+
+#[test]
+fn keyframes_with_no_usage_still_renamed() {
+    let src = "@keyframes spin { from { transform: none } to { transform: rotate(1turn) } }";
+    let o = out(src);
+    assert!(o.starts_with("@keyframes spin-x {"), "{o}");
+    assert!(o.contains("from { transform: none }"), "{o}");
+    assert!(o.contains("to { transform: rotate(1turn) }"), "{o}");
+}
+
+#[test]
+fn animation_shorthand_multiple_tokens_only_name_rewritten() {
+    let src = "@keyframes fade {} .x { animation: 2s cubic-bezier(0.1, 0.7, 1, 0.1) 1s infinite alternate fade }";
+    let o = out(src);
+    assert!(
+        o.contains("animation: 2s cubic-bezier(0.1, 0.7, 1, 0.1) 1s infinite alternate fade-x"),
+        "{o}"
+    );
+}
+
+#[test]
+fn keyframe_suffix_derived_from_scope_hash_tail() {
+    let (o, _) = scope_css("@keyframes spin {}", "data-lunas-deadbeef");
+    assert!(o.contains("@keyframes spin-deadbeef"), "{o}");
+}
+
+#[test]
+fn keyframe_suffix_falls_back_when_attr_has_no_dash() {
+    // No trailing hash segment after a `-`: the whole attribute (minus
+    // non-ident bytes) is used as the suffix.
+    let (o, _) = scope_css("@keyframes spin {}", "customattr");
+    assert!(o.contains("@keyframes spin-customattr"), "{o}");
+}
+
+#[test]
+fn vendor_prefixed_keyframes_multiple_prefixes() {
+    let src = "@-moz-keyframes spin {} @-ms-keyframes spin {} .x { animation: spin 1s }";
+    let o = out(src);
+    assert!(o.contains("@-moz-keyframes spin-x {}"), "{o}");
+    assert!(o.contains("@-ms-keyframes spin-x {}"), "{o}");
+    assert!(o.contains("animation: spin-x 1s"), "{o}");
+}
+
+#[test]
+fn keyframes_name_with_hyphen_and_digits() {
+    let src = "@keyframes slide-2-left {} .x { animation: slide-2-left 1s }";
+    let o = out(src);
+    assert!(o.contains("@keyframes slide-2-left-x {}"), "{o}");
+    assert!(o.contains("animation: slide-2-left-x 1s"), "{o}");
+}
+
+#[test]
+fn animation_name_forward_and_backward_reference_both_work() {
+    let src = ".a { animation-name: spin } @keyframes spin {} .b { animation-name: spin }";
+    let o = out(src);
+    assert!(
+        o.contains(".a[data-lunas-x] { animation-name: spin-x }"),
+        "{o}"
+    );
+    assert!(o.contains("@keyframes spin-x {}"), "{o}");
+    assert!(
+        o.contains(".b[data-lunas-x] { animation-name: spin-x }"),
+        "{o}"
+    );
+}
+
+#[test]
+fn empty_keyframes_body_renamed() {
+    assert_eq!(out("@keyframes empty {}"), "@keyframes empty-x {}");
+}
+
+#[test]
+fn keyframes_with_comment_after_name() {
+    let src = "@keyframes spin /* c */ { to { opacity: 1 } }";
+    let o = out(src);
+    assert!(o.starts_with("@keyframes spin-x /* c */ {"), "{o}");
+}

--- a/crates/lunas_css/tests/malformed.rs
+++ b/crates/lunas_css/tests/malformed.rs
@@ -1,0 +1,243 @@
+//! Edge-focused tests for malformed CSS: never-panic, verbatim passthrough of
+//! unparseable regions, and diagnostics with correct `TextRange`s. Complements
+//! the never-panic fuzz corpus in `tests/robustness.rs` and the two basic
+//! diagnostic tests in `tests/scoping.rs`.
+
+use lunas_css::scope_css;
+
+const S: &str = "data-lunas-x";
+
+/// Every diagnostic range must be a valid, in-bounds, non-inverted range into
+/// the original input.
+fn assert_ranges_valid(input: &str, diags: &[lunas_span::Diagnostic]) {
+    for d in diags {
+        let start = d.range.start().as_usize();
+        let end = d.range.end().as_usize();
+        assert!(start <= end, "inverted range {start}..{end} for {input:?}");
+        assert!(
+            end <= input.len(),
+            "range {start}..{end} exceeds input len {} for {input:?}",
+            input.len()
+        );
+    }
+}
+
+#[test]
+fn unterminated_declaration_block_diagnostic_range() {
+    let src = ".a { color: red";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("unterminated block"));
+    // Range covers from just after `{` to EOF.
+    assert_eq!(diags[0].range.start().as_usize(), 4);
+    assert_eq!(diags[0].range.end().as_usize(), src.len());
+    // The selector is still scoped even though the block never closes.
+    assert_eq!(out, ".a[data-lunas-x] { color: red");
+}
+
+#[test]
+fn selector_with_no_brace_at_all_emitted_verbatim_unscoped() {
+    // No `{` anywhere: the walker can't tell this is a selector prelude vs.
+    // trailing junk, so it emits the raw text untouched (not scoped) and
+    // reports "missing `{`".
+    let src = ".a";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, ".a");
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("missing `{`"));
+    assert_eq!(diags[0].range.start().as_usize(), 0);
+    assert_eq!(diags[0].range.end().as_usize(), 2);
+}
+
+#[test]
+fn unterminated_comment_passthrough_no_diagnostic() {
+    // An unterminated `/* ...` consumes to EOF as an inert comment; this is
+    // not reported as a diagnostic (the tokenizer's `consume_comment` just
+    // swallows to EOF silently).
+    let src = "/* unterminated";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, src);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn unterminated_string_inside_declaration_block() {
+    let src = ".a { \"unterminated string";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("unterminated block"));
+    assert!(out.starts_with(".a[data-lunas-x] {"), "{out}");
+    assert!(out.ends_with("unterminated string"), "{out}");
+}
+
+#[test]
+fn unterminated_at_rule_block_diagnostic() {
+    let src = "@media screen {";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("unterminated at-rule block"));
+    assert_eq!(out, src);
+}
+
+#[test]
+fn unterminated_nested_rule_inside_at_rule_reports_two_diagnostics() {
+    // The @media block itself never closes, and neither does the qualified
+    // rule inside it — both diagnostics are produced, with ranges relative to
+    // the *original* source (base-shifted correctly for the nested one).
+    let src = "@media screen { .a { color: red";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(diags.len(), 2);
+    assert!(diags
+        .iter()
+        .any(|d| d.message.contains("unterminated at-rule block")));
+    assert!(diags
+        .iter()
+        .any(|d| d.message.contains("unterminated block (missing")));
+    assert!(out.contains(".a[data-lunas-x] { color: red"), "{out}");
+}
+
+#[test]
+fn unterminated_keyframes_block_diagnostic() {
+    let src = "@keyframes x { from {";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("unterminated @keyframes block"));
+    // The keyframes name is still renamed even though the block is broken.
+    assert!(out.starts_with("@keyframes x-x {"), "{out}");
+}
+
+#[test]
+fn stray_closing_braces_before_a_valid_rule() {
+    // Leading `}` characters become part of the "selector" prelude text for
+    // the next rule scan; the transform never panics and always makes
+    // progress. We assert only the never-panic + range-validity invariants
+    // here since the exact recovery shape is an implementation detail.
+    let src = "}}}{{{ .a {} ";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert!(!out.is_empty());
+}
+
+#[test]
+fn only_closing_brace() {
+    let src = "}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, "}");
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("missing `{`"));
+}
+
+#[test]
+fn extra_closing_brace_after_valid_rule() {
+    let src = ".a { color: red; } }";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, ".a[data-lunas-x] { color: red; } }");
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("missing `{`"));
+}
+
+#[test]
+fn unclosed_attribute_selector_bracket() {
+    let src = "a[href {}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    // Never panics; produces *some* best-effort output.
+    let _ = out;
+}
+
+#[test]
+fn unclosed_functional_pseudo_paren() {
+    let src = ".x:not(.a {}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn multiple_unterminated_strings_in_sequence() {
+    let src = "a[x=\"1] b[y='2] .c {}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn valid_rule_after_malformed_rule_still_scoped() {
+    // Even when an earlier rule is malformed, a well-formed rule later in the
+    // stream should still get scoped once the parser resynchronizes... though
+    // per the walker's design, an unterminated rule consumes to EOF, so a
+    // "valid rule after" only applies when the earlier issue is recoverable
+    // (e.g. a stray `;`).
+    let src = ".a; .b {}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, ".a; .b[data-lunas-x] {}");
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn diagnostic_range_never_exceeds_input_for_empty_input() {
+    let (out, diags) = scope_css("", S);
+    assert_ranges_valid("", &diags);
+    assert_eq!(out, "");
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn never_panics_on_lone_at_sign() {
+    let src = "@";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert_eq!(out, "@");
+}
+
+#[test]
+fn never_panics_on_null_bytes_mixed_with_valid_css() {
+    let src = ".a\0.b { color\0: red\0 }";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn never_panics_on_lone_high_surrogate_like_byte_sequences() {
+    // Rust `&str` is always valid UTF-8, but adversarial-looking multi-byte
+    // sequences (e.g. overlong-looking emoji clusters) must still not panic.
+    let src = "🏳️‍🌈 { color: red } \u{200D}\u{FE0F} {}";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn deeply_nested_unclosed_parens_in_selector() {
+    let src = format!(".x:not({}", "(".repeat(500));
+    let (out, diags) = scope_css(&src, S);
+    assert_ranges_valid(&src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn deeply_nested_unclosed_media_blocks() {
+    let src = "@media a {".repeat(500);
+    let (out, diags) = scope_css(&src, S);
+    assert_ranges_valid(&src, &diags);
+    let _ = out;
+}
+
+#[test]
+fn mixed_valid_and_invalid_rules_diagnostics_stay_in_bounds() {
+    let src = ".a {} @media { .b { .c {} @keyframes { from {";
+    let (out, diags) = scope_css(src, S);
+    assert_ranges_valid(src, &diags);
+    assert!(out.starts_with(".a[data-lunas-x] {}"), "{out}");
+}

--- a/crates/lunas_css/tests/scope_id_stability.rs
+++ b/crates/lunas_css/tests/scope_id_stability.rs
@@ -1,0 +1,131 @@
+//! Edge-focused tests for `scope_id`: determinism/stability across repeated
+//! calls, distinctness across different sources, format invariants, and the
+//! integration contract with `scope_css` (same id used for both DOM stamping
+//! and CSS rewriting must round-trip consistently).
+
+use lunas_css::{scope_css, scope_id};
+
+#[test]
+fn deterministic_across_calls() {
+    let src = "<template><div class=\"a\"></div></template>";
+    let a = scope_id(src);
+    let b = scope_id(src);
+    let c = scope_id(src);
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+}
+
+#[test]
+fn deterministic_across_many_repeated_calls() {
+    let src = "component source text with some content";
+    let first = scope_id(src);
+    for _ in 0..100 {
+        assert_eq!(scope_id(src), first);
+    }
+}
+
+#[test]
+fn distinct_for_different_sources() {
+    let a = scope_id("component A source");
+    let b = scope_id("component B source");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn distinct_for_whitespace_only_difference() {
+    // Even a single trailing space must (almost always) produce a different
+    // hash — scope_id has no normalization step.
+    let a = scope_id("<template></template>");
+    let b = scope_id("<template></template> ");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn distinct_for_case_difference() {
+    let a = scope_id("Component");
+    let b = scope_id("component");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn empty_source_has_stable_id() {
+    let a = scope_id("");
+    let b = scope_id("");
+    assert_eq!(a, b);
+    assert_eq!(a, "data-lunas-811c9dc5");
+}
+
+#[test]
+fn unicode_source_produces_valid_id() {
+    let id = scope_id("日本語コンポーネント");
+    assert!(id.starts_with("data-lunas-"));
+    let hex = id.strip_prefix("data-lunas-").unwrap();
+    assert_eq!(hex.len(), 8);
+    assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn long_source_produces_valid_fixed_length_id() {
+    let long_src = "x".repeat(10_000);
+    let id = scope_id(&long_src);
+    let hex = id.strip_prefix("data-lunas-").unwrap();
+    assert_eq!(hex.len(), 8);
+}
+
+#[test]
+fn id_format_is_always_lowercase_hex_of_fixed_length() {
+    let sources = ["", "a", "ab", "component X", "🎉", "\0\0\0"];
+    for src in sources {
+        let id = scope_id(src);
+        assert!(id.starts_with("data-lunas-"), "{id}");
+        let hex = &id["data-lunas-".len()..];
+        assert_eq!(hex.len(), 8, "unexpected hex length for {src:?}: {id}");
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "hex digits should be lowercase for {src:?}: {id}"
+        );
+    }
+}
+
+#[test]
+fn scope_id_output_is_a_valid_scope_css_attribute() {
+    // Round-trip: the id produced by scope_id must work as scope_attr for
+    // scope_css without any adaptation (the integration contract described in
+    // the README).
+    let attr = scope_id("<template><div class=\"x\"></div></template>");
+    let (out, diags) = scope_css(".x {}", &attr);
+    assert!(diags.is_empty());
+    assert_eq!(out, format!(".x[{attr}] {{}}"));
+}
+
+#[test]
+fn different_components_yield_different_scoped_output() {
+    let attr_a = scope_id("component A");
+    let attr_b = scope_id("component B");
+    assert_ne!(attr_a, attr_b);
+    let (out_a, _) = scope_css(".x {}", &attr_a);
+    let (out_b, _) = scope_css(".x {}", &attr_b);
+    assert_ne!(out_a, out_b);
+}
+
+#[test]
+fn near_duplicate_sources_rarely_collide() {
+    // A basic avalanche sanity-check: flipping a single character anywhere in
+    // a longer source should (almost certainly) change the hash.
+    let base = "abcdefghijklmnopqrstuvwxyz0123456789";
+    let base_id = scope_id(base);
+    let mut collisions = 0;
+    for i in 0..base.len() {
+        let mut mutated: Vec<u8> = base.as_bytes().to_vec();
+        mutated[i] = if mutated[i] == b'z' { b'y' } else { b'z' };
+        let mutated = String::from_utf8(mutated).unwrap();
+        if scope_id(&mutated) == base_id {
+            collisions += 1;
+        }
+    }
+    assert_eq!(
+        collisions, 0,
+        "expected no collisions from single-byte flips"
+    );
+}

--- a/crates/lunas_css/tests/selectors_edge.rs
+++ b/crates/lunas_css/tests/selectors_edge.rs
@@ -1,0 +1,435 @@
+//! Edge-focused selector tests: combinators, attribute selectors, pseudo-
+//! classes/elements, compound selectors, escapes, unicode, `:is()`/`:where()`.
+//! Complements `tests/scoping.rs`, which covers the baseline/happy paths.
+
+use lunas_css::scope_css;
+
+const S: &str = "data-lunas-x";
+
+/// Convenience: scope with the default attribute and assert no diagnostics.
+fn scope(css: &str) -> String {
+    let (out, diags) = scope_css(css, S);
+    assert!(
+        diags.is_empty(),
+        "unexpected diagnostics: {diags:?}\ninput: {css:?}"
+    );
+    out
+}
+
+// --- basic simple-selector variants -----------------------------------------
+
+#[test]
+fn tight_selector_list_no_whitespace() {
+    assert_eq!(
+        scope(".a,.b,.c{}"),
+        ".a[data-lunas-x],.b[data-lunas-x],.c[data-lunas-x]{}"
+    );
+}
+
+#[test]
+fn no_whitespace_between_rules() {
+    assert_eq!(
+        scope(".a{color:red}.b{color:blue}"),
+        ".a[data-lunas-x]{color:red}.b[data-lunas-x]{color:blue}"
+    );
+}
+
+#[test]
+fn namespace_universal_selector() {
+    assert_eq!(scope("*|* {}"), "*|*[data-lunas-x] {}");
+}
+
+#[test]
+fn namespaced_type_selector() {
+    assert_eq!(scope("svg|circle {}"), "svg|circle[data-lunas-x] {}");
+}
+
+// --- combinators -------------------------------------------------------------
+
+#[test]
+fn all_combinators_in_one_chain() {
+    assert_eq!(
+        scope("a b > c + d ~ e {}"),
+        "a[data-lunas-x] b[data-lunas-x] > c[data-lunas-x] + d[data-lunas-x] ~ e[data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn combinator_no_space_before_only() {
+    assert_eq!(scope("a> b {}"), "a[data-lunas-x]> b[data-lunas-x] {}");
+}
+
+#[test]
+fn combinator_no_space_after_only() {
+    assert_eq!(scope("a >b {}"), "a[data-lunas-x] >b[data-lunas-x] {}");
+}
+
+#[test]
+fn combinator_tabs_and_newlines() {
+    let out = scope("a\t>\nb {}");
+    assert_eq!(out, "a[data-lunas-x]\t>\nb[data-lunas-x] {}");
+}
+
+#[test]
+fn combinator_with_comment_between() {
+    // A comment sits between the whitespace and the combinator symbol.
+    let out = scope("a /* c */ > b {}");
+    assert_eq!(out, "a[data-lunas-x] /* c */ > b[data-lunas-x] {}");
+}
+
+// --- attribute selectors -----------------------------------------------------
+
+#[test]
+fn attribute_equals_no_quotes() {
+    assert_eq!(
+        scope("input[type=text] {}"),
+        "input[type=text][data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn attribute_tilde_equals() {
+    assert_eq!(
+        scope(r#"a[data-x~="foo"] {}"#),
+        r#"a[data-x~="foo"][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_pipe_equals() {
+    assert_eq!(
+        scope(r#"a[lang|="en"] {}"#),
+        r#"a[lang|="en"][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_pipe_equals_no_quotes() {
+    assert_eq!(scope("a[lang|=en] {}"), "a[lang|=en][data-lunas-x] {}");
+}
+
+#[test]
+fn attribute_caret_equals_prefix() {
+    assert_eq!(
+        scope(r#"a[href^="https://"] {}"#),
+        r#"a[href^="https://"][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_dollar_equals_suffix() {
+    assert_eq!(
+        scope(r#"a[href$=".pdf"] {}"#),
+        r#"a[href$=".pdf"][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_star_equals_substring() {
+    assert_eq!(
+        scope(r#"a[class*="foo"] {}"#),
+        r#"a[class*="foo"][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_case_insensitive_flag() {
+    assert_eq!(
+        scope(r#"a[href^="foo" i] {}"#),
+        r#"a[href^="foo" i][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_case_sensitive_flag() {
+    assert_eq!(
+        scope(r#"a[href^="foo" s] {}"#),
+        r#"a[href^="foo" s][data-lunas-x] {}"#
+    );
+}
+
+#[test]
+fn attribute_single_quoted_value() {
+    assert_eq!(scope("a[title='x'] {}"), "a[title='x'][data-lunas-x] {}");
+}
+
+#[test]
+fn attribute_bracket_in_single_quoted_value() {
+    let out = scope(r#"a[href='a]b'] {}"#);
+    assert_eq!(out, r#"a[href='a]b'][data-lunas-x] {}"#);
+}
+
+#[test]
+fn attribute_equals_in_string_value() {
+    let out = scope(r#"a[title="a=b"] {}"#);
+    assert_eq!(out, r#"a[title="a=b"][data-lunas-x] {}"#);
+}
+
+#[test]
+fn attribute_escaped_bracket_no_quotes() {
+    // An escaped `]` inside an (unquoted, technically-invalid) attribute value
+    // must not prematurely close the bracket.
+    let out = scope(r"a[data-x=foo\]bar] {}");
+    assert_eq!(out, r"a[data-x=foo\]bar][data-lunas-x] {}");
+}
+
+#[test]
+fn multiple_attribute_selectors_chained() {
+    assert_eq!(
+        scope("input[type=text][disabled] {}"),
+        "input[type=text][disabled][data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn attribute_selector_before_combinator() {
+    assert_eq!(
+        scope("a[href] > b[title] {}"),
+        "a[href][data-lunas-x] > b[title][data-lunas-x] {}"
+    );
+}
+
+// --- pseudo-classes / pseudo-elements ----------------------------------------
+
+#[test]
+fn hover_pseudo_class() {
+    assert_eq!(scope("a:hover {}"), "a[data-lunas-x]:hover {}");
+}
+
+#[test]
+fn nth_child_formula() {
+    assert_eq!(
+        scope("li:nth-child(2n+1) {}"),
+        "li[data-lunas-x]:nth-child(2n+1) {}"
+    );
+}
+
+#[test]
+fn nth_child_odd_keyword() {
+    assert_eq!(
+        scope("li:nth-child(odd) {}"),
+        "li[data-lunas-x]:nth-child(odd) {}"
+    );
+}
+
+#[test]
+fn nth_of_type_odd() {
+    assert_eq!(
+        scope(".a:nth-of-type(odd) {}"),
+        ".a[data-lunas-x]:nth-of-type(odd) {}"
+    );
+}
+
+#[test]
+fn nth_child_of_selector() {
+    // `:nth-child(An+B of S)` — the comma-free functional form.
+    assert_eq!(
+        scope(".a:nth-child(2n+1 of .b) {}"),
+        ".a[data-lunas-x]:nth-child(2n+1 of .b) {}"
+    );
+}
+
+#[test]
+fn not_with_multiple_args_not_split() {
+    assert_eq!(
+        scope(".x:not(.a, .b, .c) {}"),
+        ".x[data-lunas-x]:not(.a, .b, .c) {}"
+    );
+}
+
+#[test]
+fn chained_not_pseudo_classes() {
+    assert_eq!(
+        scope("a:not(.a):not(.b) {}"),
+        "a[data-lunas-x]:not(.a):not(.b) {}"
+    );
+}
+
+#[test]
+fn is_pseudo_class_commas_not_split() {
+    assert_eq!(scope(".x:is(.a, .b) {}"), ".x[data-lunas-x]:is(.a, .b) {}");
+}
+
+#[test]
+fn where_pseudo_class_commas_not_split() {
+    assert_eq!(
+        scope(".x:where(.a, .b) {}"),
+        ".x[data-lunas-x]:where(.a, .b) {}"
+    );
+}
+
+#[test]
+fn has_pseudo_class_commas_not_split() {
+    assert_eq!(
+        scope(".x:has(.a, > .b) {}"),
+        ".x[data-lunas-x]:has(.a, > .b) {}"
+    );
+}
+
+#[test]
+fn nested_functional_pseudo_commas_not_split() {
+    // `:not(:is(.a, .b))` — nested parens, comma is two levels deep.
+    assert_eq!(
+        scope(".x:not(:is(.a, .b)) {}"),
+        ".x[data-lunas-x]:not(:is(.a, .b)) {}"
+    );
+}
+
+#[test]
+fn double_colon_pseudo_element() {
+    assert_eq!(scope("a::before {}"), "a[data-lunas-x]::before {}");
+}
+
+#[test]
+fn selection_pseudo_element() {
+    assert_eq!(scope(".a::selection {}"), ".a[data-lunas-x]::selection {}");
+}
+
+#[test]
+fn bare_double_colon_pseudo_element() {
+    assert_eq!(scope("::selection {}"), "[data-lunas-x]::selection {}");
+}
+
+#[test]
+fn pseudo_class_then_pseudo_element() {
+    assert_eq!(
+        scope("a:hover::before {}"),
+        "a[data-lunas-x]:hover::before {}"
+    );
+}
+
+#[test]
+fn compound_with_attr_and_pseudo() {
+    assert_eq!(
+        scope("input[type=checkbox]:checked {}"),
+        "input[type=checkbox][data-lunas-x]:checked {}"
+    );
+}
+
+#[test]
+fn compound_type_class_id_attr_pseudo() {
+    assert_eq!(
+        scope("a.b#c[d]:hover {}"),
+        "a.b#c[d][data-lunas-x]:hover {}"
+    );
+}
+
+// --- pseudo-class formulas / functional args with combinators ---------------
+
+#[test]
+fn not_with_combinator_inside() {
+    assert_eq!(scope(".x:not(> .a) {}"), ".x[data-lunas-x]:not(> .a) {}");
+}
+
+#[test]
+fn language_pseudo_class() {
+    assert_eq!(scope(":lang(en) {}"), "[data-lunas-x]:lang(en) {}");
+}
+
+#[test]
+fn dir_pseudo_class() {
+    assert_eq!(scope(":dir(rtl) {}"), "[data-lunas-x]:dir(rtl) {}");
+}
+
+// --- selector lists with mixed complexity ------------------------------------
+
+#[test]
+fn selector_list_with_pseudo_and_combinator() {
+    assert_eq!(
+        scope("a:hover, b > c {}"),
+        "a[data-lunas-x]:hover, b[data-lunas-x] > c[data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn selector_list_trailing_comma_whitespace() {
+    let out = scope("a, b, {}");
+    assert_eq!(out, "a[data-lunas-x], b[data-lunas-x], {}");
+}
+
+#[test]
+fn selector_list_leading_comma() {
+    let out = scope(", a {}");
+    assert_eq!(out, ", a[data-lunas-x] {}");
+}
+
+#[test]
+fn selector_list_many_entries() {
+    assert_eq!(
+        scope("a, b, c, d, e {}"),
+        "a[data-lunas-x], b[data-lunas-x], c[data-lunas-x], d[data-lunas-x], e[data-lunas-x] {}"
+    );
+}
+
+#[test]
+fn comma_inside_attribute_value_not_split() {
+    let out = scope(r#"a[title="x, y, z"], b {}"#);
+    assert_eq!(
+        out,
+        r#"a[title="x, y, z"][data-lunas-x], b[data-lunas-x] {}"#
+    );
+}
+
+// --- escapes -----------------------------------------------------------------
+
+#[test]
+fn escaped_colon_in_class_name() {
+    // `a\:hover` is a literal class-ish identifier with an escaped colon, not
+    // a pseudo-class; the scanner treats the escape as opaque, so `attach_scope`
+    // still finds no top-level `:` after the escape sequence itself.
+    let out = scope(r"a\:hover {}");
+    assert_eq!(out, r"a\:hover[data-lunas-x] {}");
+}
+
+#[test]
+fn escaped_dot_in_id() {
+    let out = scope(r"#a\.b {}");
+    assert_eq!(out, r"#a\.b[data-lunas-x] {}");
+}
+
+#[test]
+fn escaped_space_in_class() {
+    let out = scope(r".foo\ bar {}");
+    assert_eq!(out, r".foo\ bar[data-lunas-x] {}");
+}
+
+#[test]
+fn escaped_bracket_in_class_name() {
+    let out = scope(r".a\[1\] {}");
+    assert_eq!(out, r".a\[1\][data-lunas-x] {}");
+}
+
+// --- unicode identifiers ------------------------------------------------------
+
+#[test]
+fn unicode_class_japanese() {
+    assert_eq!(scope(".日本語 {}"), ".日本語[data-lunas-x] {}");
+}
+
+#[test]
+fn unicode_id_cyrillic() {
+    assert_eq!(scope("#привет {}"), "#привет[data-lunas-x] {}");
+}
+
+#[test]
+fn unicode_type_selector_combinator() {
+    assert_eq!(
+        scope("café > 日本語 {}"),
+        "café[data-lunas-x] > 日本語[data-lunas-x] {}"
+    );
+}
+
+// --- :is()/:where() combined with combinators inside -------------------------
+
+#[test]
+fn is_with_descendant_inside_arg() {
+    assert_eq!(scope(".x:is(.a .b) {}"), ".x[data-lunas-x]:is(.a .b) {}");
+}
+
+#[test]
+fn where_nested_in_not() {
+    assert_eq!(
+        scope(":not(:where(.a, .b)) {}"),
+        "[data-lunas-x]:not(:where(.a, .b)) {}"
+    );
+}


### PR DESCRIPTION
## Summary

Mass-expands the `lunas_css` (scoped-CSS transform) Rust test suite with **168 new edge-focused tests** across 7 new files, none of which touch existing test files, source, `roadmap.yml`, or any other crate.

- `crates/lunas_css/tests/selectors_edge.rs` (58 tests) — combinators (all four kinds, no/mixed whitespace), attribute-selector operators (`~=`, `|=`, `^=`, `$=`, `*=`, case-sensitivity flags `i`/`s`), `:not()`/`:is()`/`:where()`/`:has()` comma-inside-functional-pseudo handling (including nested), pseudo-elements (`::before`, `::selection`, bare forms), compound-selector scope insertion point, escaped characters, unicode identifiers, namespaced type/universal selectors.
- `crates/lunas_css/tests/deep_global.rs` (23 tests) — `:deep()`/`:global()` edge cases: empty arguments, selector-list interaction (only the matching entry is affected), chained/nested wrappers, combinators inside the argument, and documents two real implementation behaviors (only the *first* `:deep()` boundary is honored; `:global` anywhere makes the *whole* selector global, including any `:deep()` present).
- `crates/lunas_css/tests/at_rules.rs` (28 tests) — `@media`/`@supports`/`@layer`/`@container`/`@scope` recursion (including `@scope (...) to (...)`), vendor-prefixed conditional groups, triple nesting, and pass-through at-rules (`@font-face`/`@page`/`@import`/`@charset`/unknown at-rules) including the case where an unknown at-rule's block looks like a qualified rule but is correctly *not* scoped.
- `crates/lunas_css/tests/keyframes.rs` (21 tests) — `@keyframes` renaming and `animation`/`animation-name` rewriting: forward/backward references, comma-separated shorthand values, case sensitivity/insensitivity, duplicate `@keyframes` declarations, vendor prefixes, and the known limitation that `@keyframes` nested inside `@media` isn't collected by the name-collection pass (so neither the rule nor references to it are renamed).
- `crates/lunas_css/tests/malformed.rs` (21 tests) — unterminated blocks/strings/comments/at-rules/keyframes, stray braces, diagnostic `TextRange` correctness (validated to be in-bounds and non-inverted), verbatim passthrough of unparseable regions.
- `crates/lunas_css/tests/scope_id_stability.rs` (12 tests) — determinism across repeated calls, distinctness across inputs (including single-byte-flip avalanche check), fixed-length lowercase-hex format invariant, and the `scope_id` → `scope_css` integration round-trip contract from the crate README.
- `crates/lunas_css/tests/fuzz_more.rs` (5 tests, 25k+ fuzz iterations) — a second, independently-seeded never-panic fuzz corpus (xorshift RNG vs. the existing LCG in `robustness.rs`) using three distinct strategies: pure random byte soup, grammar-guided CSS fragment assembly, and mutation-fuzzing of valid stylesheets (byte insert/delete/overwrite/truncate). Also fuzzes adversarial `scope_attr` values.

Every new assertion was verified against `scope_css`/`scope_id`'s actual output (via scratch probe tests, removed before commit) rather than assumed, so the suite documents real behavior — including a few non-obvious corners (e.g. `:deep(.a)` alone yields `.a {}` with no leading space; `@keyframes` inside `@media` isn't renamed).

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all green (168 new + all existing tests pass)
- [x] `cargo build -p lunas_css --target wasm32-unknown-unknown` — clean (crate has no host-only deps)
- [x] Confirmed only new test files added: no source, `roadmap.yml`, or existing test file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)