### PR TITLE
test(script): expand lunas_script analysis/scoping/mutation suites

### DIFF
--- a/crates/lunas_script/tests/deps.rs
+++ b/crates/lunas_script/tests/deps.rs
@@ -1,0 +1,280 @@
+//! Coverage of `function_dependencies` (per top-level function, the free names
+//! its body reads — including the names of functions it calls, for transitive
+//! expansion) plus `declared_bindings` and `referenced_identifiers` edge cases.
+
+use lunas_script::{declared_bindings, function_dependencies, referenced_identifiers};
+
+fn deps(code: &str) -> Vec<(String, Vec<String>)> {
+    function_dependencies(code).expect("parse ok")
+}
+
+fn bindings(code: &str) -> Vec<String> {
+    declared_bindings(code).expect("parse ok")
+}
+
+fn refs(code: &str) -> Vec<String> {
+    referenced_identifiers(code).expect("parse ok")
+}
+
+// --- function_dependencies: read sets ---
+
+#[test]
+fn deps_reads_outer_names() {
+    assert_eq!(
+        deps("function total(){ return price * qty }"),
+        vec![(
+            "total".to_string(),
+            vec!["price".to_string(), "qty".to_string()]
+        )]
+    );
+}
+
+#[test]
+fn deps_excludes_params_and_locals() {
+    assert_eq!(
+        deps("function f(a){ const b = a + outer; return b }"),
+        vec![("f".to_string(), vec!["outer".to_string()])]
+    );
+}
+
+#[test]
+fn deps_includes_called_function_names() {
+    // A called function's name is a free read, listed so callers expand deps.
+    assert_eq!(
+        deps("const f = () => total() + tax"),
+        vec![(
+            "f".to_string(),
+            vec!["total".to_string(), "tax".to_string()]
+        )]
+    );
+}
+
+#[test]
+fn deps_dedups_repeated_reads() {
+    assert_eq!(
+        deps("function f(){ return a + a + b + a }"),
+        vec![("f".to_string(), vec!["a".to_string(), "b".to_string()])]
+    );
+}
+
+#[test]
+fn deps_recursive_self_call_lists_own_name() {
+    // `function_dependencies` visits the function body directly (not through a
+    // block that would bind the decl name), so a recursive self-call IS a free
+    // read — `fib` lists itself. A caller expanding to a fixpoint must guard
+    // this cycle; the analysis records the name only once (deduped).
+    assert_eq!(
+        deps("function fib(n){ return n < 2 ? n : fib(n - 1) + fib(n - 2) }"),
+        vec![("fib".to_string(), vec!["fib".to_string()])]
+    );
+}
+
+#[test]
+fn deps_transitive_pair_each_lists_callee() {
+    // total() reads price/qty; grand() calls total and reads shipping. The two
+    // dep sets let a caller expand grand -> total -> {price, qty, shipping}.
+    let got = deps(
+        "function total(){ return price * qty }\nfunction grand(){ return total() + shipping }",
+    );
+    assert_eq!(
+        got,
+        vec![
+            (
+                "total".to_string(),
+                vec!["price".to_string(), "qty".to_string()]
+            ),
+            (
+                "grand".to_string(),
+                vec!["total".to_string(), "shipping".to_string()]
+            ),
+        ]
+    );
+}
+
+#[test]
+fn deps_mutual_recursion_cycle_safe() {
+    // isEven/isOdd call each other; each lists the other's name once. A caller
+    // expanding to a fixpoint must guard the cycle — the analysis itself never
+    // loops (it only records names).
+    let got = deps(
+        "function isEven(n){ return n === 0 ? true : isOdd(n - 1) }\n\
+         function isOdd(n){ return n === 0 ? false : isEven(n - 1) }",
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("isEven".to_string(), vec!["isOdd".to_string()]),
+            ("isOdd".to_string(), vec!["isEven".to_string()]),
+        ]
+    );
+}
+
+#[test]
+fn deps_arrow_with_block_body_locals_excluded() {
+    assert_eq!(
+        deps("const calc = () => { const t = base * rate; return t + fee }"),
+        vec![(
+            "calc".to_string(),
+            vec!["base".to_string(), "rate".to_string(), "fee".to_string()]
+        )]
+    );
+}
+
+#[test]
+fn deps_non_callable_const_skipped() {
+    // `const x = a + b` is not a function; only `g` gets a dep entry.
+    assert_eq!(
+        deps("const x = a + b\nfunction g(){ return x + c }"),
+        vec![("g".to_string(), vec!["x".to_string(), "c".to_string()])]
+    );
+}
+
+#[test]
+fn deps_exported_function_included() {
+    assert_eq!(
+        deps("export function label(){ return prefix + name }"),
+        vec![(
+            "label".to_string(),
+            vec!["prefix".to_string(), "name".to_string()]
+        )]
+    );
+}
+
+#[test]
+fn deps_nested_arrow_scoping() {
+    // The inner arrow's param `x` is bound; `factor` and `xs` are free reads.
+    assert_eq!(
+        deps("function scale(){ return xs.map(x => x * factor) }"),
+        vec![(
+            "scale".to_string(),
+            vec!["xs".to_string(), "factor".to_string()]
+        )]
+    );
+}
+
+// --- declared_bindings edge cases ---
+
+#[test]
+fn bindings_var_let_const_mixed() {
+    assert_eq!(bindings("var a\nlet b\nconst c = 1"), ["a", "b", "c"]);
+}
+
+#[test]
+fn bindings_array_with_holes_and_rest() {
+    assert_eq!(bindings("const [a, , b, ...rest] = xs"), ["a", "b", "rest"]);
+}
+
+#[test]
+fn bindings_object_rename_default_rest() {
+    assert_eq!(
+        bindings("const { a: x, b = 1, ...others } = obj"),
+        ["x", "b", "others"]
+    );
+}
+
+#[test]
+fn bindings_deeply_nested_destructure() {
+    assert_eq!(bindings("const { a: { b: [c, { d }] } } = src"), ["c", "d"]);
+}
+
+#[test]
+fn bindings_array_default_element() {
+    assert_eq!(bindings("const [a = 1, b = 2] = xs"), ["a", "b"]);
+}
+
+#[test]
+fn bindings_default_import_and_namespace() {
+    assert_eq!(
+        bindings("import def from 'm'\nimport * as ns from 'n'"),
+        ["def", "ns"]
+    );
+}
+
+#[test]
+fn bindings_named_imports_with_alias() {
+    assert_eq!(
+        bindings("import { a, b as c, d } from 'm'"),
+        ["a", "c", "d"]
+    );
+}
+
+#[test]
+fn bindings_mixed_default_and_named_import() {
+    assert_eq!(bindings("import def, { named } from 'm'"), ["def", "named"]);
+}
+
+#[test]
+fn bindings_class_and_function_and_export() {
+    assert_eq!(
+        bindings("export class C {}\nexport function f(){}\nexport const k = 1"),
+        ["C", "f", "k"]
+    );
+}
+
+#[test]
+fn bindings_typescript_type_only_declares_nothing() {
+    // `collect_decl` only handles var/fn/class, so a TS `enum` (though it is a
+    // runtime value) is NOT reported, and type/interface declare nothing. Only
+    // the plain `let` binding surfaces.
+    assert_eq!(
+        bindings("type T = number\ninterface I {}\nenum E { A }\nlet v = 1"),
+        ["v"]
+    );
+}
+
+#[test]
+fn bindings_nested_are_not_top_level() {
+    assert_eq!(
+        bindings("let top = 1\n{ let inner = 2 }\nif (x) { const c = 3 }"),
+        ["top"]
+    );
+}
+
+// --- referenced_identifiers edge cases (flat, no scoping) ---
+
+#[test]
+fn refs_optional_chaining_root_only() {
+    assert_eq!(refs("a?.b?.c"), ["a"]);
+}
+
+#[test]
+fn refs_optional_call_and_computed() {
+    assert_eq!(refs("a?.[k]?.(x)"), ["a", "k", "x"]);
+}
+
+#[test]
+fn refs_template_literal_interpolations() {
+    assert_eq!(refs("`${a} and ${b.c}`"), ["a", "b"]);
+}
+
+#[test]
+fn refs_spread_in_call_and_array() {
+    assert_eq!(refs("f(...args, [...more])"), ["f", "args", "more"]);
+}
+
+#[test]
+fn refs_new_expression() {
+    assert_eq!(refs("new Ctor(arg)"), ["Ctor", "arg"]);
+}
+
+#[test]
+fn refs_logical_and_nullish() {
+    assert_eq!(refs("a && b || c ?? d"), ["a", "b", "c", "d"]);
+}
+
+#[test]
+fn refs_arrow_body_flat_includes_param() {
+    // referenced_identifiers does NOT scope: the arrow param binding `x` and
+    // every body occurrence of `x` are all reported (flat identifier walk).
+    assert_eq!(refs("xs.map(x => x + y)"), ["xs", "x", "x", "y"]);
+}
+
+#[test]
+fn refs_sequence_expression() {
+    assert_eq!(refs("(a, b, c)"), ["a", "b", "c"]);
+}
+
+#[test]
+fn refs_tagged_template() {
+    assert_eq!(refs("tag`${x}`"), ["tag", "x"]);
+}

--- a/crates/lunas_script/tests/for_header_ext.rs
+++ b/crates/lunas_script/tests/for_header_ext.rs
@@ -1,0 +1,231 @@
+//! Extended `parse_for` coverage: `of`/`in` variants, destructuring bindings,
+//! index patterns, complex iterables, and the special `.entries()` unwrapping.
+
+use lunas_script::{parse_for, ForKind};
+
+fn ok(input: &str) -> (ForKind, String, String) {
+    let p = parse_for(input).unwrap_or_else(|| panic!("expected Some for {input:?}"));
+    (p.kind, p.binding, p.iterable)
+}
+
+// --- of / in kinds ---
+
+#[test]
+fn fe_plain_of() {
+    assert_eq!(
+        ok("item of items"),
+        (ForKind::Of, "item".into(), "items".into())
+    );
+}
+
+#[test]
+fn fe_plain_in() {
+    assert_eq!(ok("key in obj"), (ForKind::In, "key".into(), "obj".into()));
+}
+
+#[test]
+fn fe_of_with_let_keyword() {
+    assert_eq!(ok("let v of xs"), (ForKind::Of, "v".into(), "xs".into()));
+}
+
+#[test]
+fn fe_of_with_const_keyword() {
+    assert_eq!(ok("const v of xs"), (ForKind::Of, "v".into(), "xs".into()));
+}
+
+#[test]
+fn fe_of_with_var_keyword() {
+    assert_eq!(ok("var v of xs"), (ForKind::Of, "v".into(), "xs".into()));
+}
+
+// --- destructuring bindings ---
+
+#[test]
+fn fe_array_destructure_binding() {
+    assert_eq!(
+        ok("[i, v] of pairs"),
+        (ForKind::Of, "[i, v]".into(), "pairs".into())
+    );
+}
+
+#[test]
+fn fe_object_destructure_binding() {
+    assert_eq!(
+        ok("{ id, name } of rows"),
+        (ForKind::Of, "{ id, name }".into(), "rows".into())
+    );
+}
+
+#[test]
+fn fe_nested_destructure_binding() {
+    assert_eq!(
+        ok("[i, { done }] of tasks"),
+        (ForKind::Of, "[i, { done }]".into(), "tasks".into())
+    );
+}
+
+#[test]
+fn fe_destructure_with_default() {
+    assert_eq!(
+        ok("[a = 0, b] of xs"),
+        (ForKind::Of, "[a = 0, b]".into(), "xs".into())
+    );
+}
+
+// --- complex iterables ---
+
+#[test]
+fn fe_iterable_call_expression() {
+    assert_eq!(
+        ok("item of getItems()"),
+        (ForKind::Of, "item".into(), "getItems()".into())
+    );
+}
+
+#[test]
+fn fe_iterable_member_access() {
+    assert_eq!(
+        ok("v of store.items"),
+        (ForKind::Of, "v".into(), "store.items".into())
+    );
+}
+
+#[test]
+fn fe_iterable_spread_array() {
+    assert_eq!(
+        ok("i of [...Array(n).keys()]"),
+        (ForKind::Of, "i".into(), "[...Array(n).keys()]".into())
+    );
+}
+
+#[test]
+fn fe_iterable_await_chain() {
+    assert_eq!(
+        ok("[i, v] of Object.entries(await load().then(r => r.json()))"),
+        (
+            ForKind::Of,
+            "[i, v]".into(),
+            "await load().then(r => r.json())".into()
+        )
+    );
+}
+
+// --- .entries() unwrapping behavior ---
+
+#[test]
+fn fe_object_entries_non_ident_arg_unwraps() {
+    // Object.entries(<non-ident>) unwraps to the argument.
+    assert_eq!(
+        ok("[k, v] of Object.entries(data.map)"),
+        (ForKind::Of, "[k, v]".into(), "data.map".into())
+    );
+}
+
+#[test]
+fn fe_object_entries_ident_arg_kept() {
+    // A bare identifier arg is NOT unwrapped — the whole call is kept.
+    assert_eq!(
+        ok("[k, v] of Object.entries(data)"),
+        (ForKind::Of, "[k, v]".into(), "Object.entries(data)".into())
+    );
+}
+
+#[test]
+fn fe_ident_entries_receiver_kept() {
+    // `arr.entries()` where the receiver is a bare identifier is NOT unwrapped
+    // (only member/paren-member receivers or Object.entries(non-ident) unwrap).
+    assert_eq!(
+        ok("[i, v] of arr.entries()"),
+        (ForKind::Of, "[i, v]".into(), "arr.entries()".into())
+    );
+}
+
+#[test]
+fn fe_chained_member_entries_unwraps() {
+    assert_eq!(
+        ok("[i, v] of obj.get().items.entries()"),
+        (ForKind::Of, "[i, v]".into(), "obj.get().items".into())
+    );
+}
+
+#[test]
+fn fe_paren_member_entries_unwraps() {
+    assert_eq!(
+        ok("[k, v] of (getObj()).items.entries()"),
+        (ForKind::Of, "[k, v]".into(), "(getObj()).items".into())
+    );
+}
+
+#[test]
+fn fe_for_in_entries_not_unwrapped() {
+    // The `.entries()` unwrap only applies to for-of, not for-in.
+    assert_eq!(
+        ok("[i, v] in data.entries()"),
+        (ForKind::In, "[i, v]".into(), "data.entries()".into())
+    );
+}
+
+// --- whitespace tolerance ---
+
+#[test]
+fn fe_leading_trailing_whitespace() {
+    assert_eq!(
+        ok("  item \t of \n items  "),
+        (ForKind::Of, "item".into(), "items".into())
+    );
+}
+
+#[test]
+fn fe_whitespace_around_destructure() {
+    assert_eq!(
+        ok(" [ i , v ] of  arr "),
+        (ForKind::Of, "[ i , v ]".into(), "arr".into())
+    );
+}
+
+// --- literal iterables ---
+
+#[test]
+fn fe_array_literal_iterable() {
+    assert_eq!(
+        ok("x of [1, 2, 3]"),
+        (ForKind::Of, "x".into(), "[1, 2, 3]".into())
+    );
+}
+
+// --- rejection cases ---
+
+#[test]
+fn fe_rejects_plain_c_style_for() {
+    assert!(parse_for("let i = 0; i < 10; i++").is_none());
+}
+
+#[test]
+fn fe_rejects_missing_iterable() {
+    assert!(parse_for("item of").is_none());
+}
+
+#[test]
+fn fe_rejects_missing_binding() {
+    assert!(parse_for("of items").is_none());
+}
+
+#[test]
+fn fe_rejects_trailing_tokens() {
+    assert!(parse_for("a of b c").is_none());
+}
+
+#[test]
+fn fe_rejects_empty() {
+    assert!(parse_for("").is_none());
+}
+
+#[test]
+fn fe_rejects_incomplete_member() {
+    assert!(parse_for("v of obj.").is_none());
+}
+
+#[test]
+fn fe_rejects_garbage() {
+    assert!(parse_for("not a loop header at all").is_none());
+}

--- a/crates/lunas_script/tests/fuzz.rs
+++ b/crates/lunas_script/tests/fuzz.rs
@@ -1,0 +1,299 @@
+//! Never-panic fuzzing across *every* public `lunas_script` entry point,
+//! including the scope-aware and span-returning analyses and the two functions
+//! (`function_dependencies`, `analyze_script`, `module_binding_references`,
+//! `top_level_declarations`) not exercised by the crate's `robustness.rs`.
+//! Public entry points return `Result`/`Option` and must never panic.
+
+use lunas_script::{
+    analyze_script, assigned_identifiers, declared_bindings, declared_bindings_with_spans,
+    free_identifiers, free_identifiers_with_spans, function_dependencies, function_mutations,
+    module_binding_references, parse_for, parse_to_ast_json, referenced_identifiers,
+    referenced_identifiers_with_spans, top_level_declarations, transform_ts_to_js,
+};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+fn no_panic(label: &str, input: &str, f: impl Fn(&str)) {
+    let result = catch_unwind(AssertUnwindSafe(|| f(input)));
+    assert!(result.is_ok(), "{label} panicked on input: {input:?}");
+}
+
+/// Exercise every public entry with `input`.
+fn exercise(input: &str) {
+    no_panic("parse_for", input, |s| {
+        let _ = parse_for(s);
+    });
+    no_panic("transform_ts_to_js", input, |s| {
+        let _ = transform_ts_to_js(s);
+    });
+    no_panic("parse_to_ast_json", input, |s| {
+        let _ = parse_to_ast_json(s);
+    });
+    no_panic("declared_bindings", input, |s| {
+        let _ = declared_bindings(s);
+    });
+    no_panic("declared_bindings_with_spans", input, |s| {
+        let _ = declared_bindings_with_spans(s);
+    });
+    no_panic("referenced_identifiers", input, |s| {
+        let _ = referenced_identifiers(s);
+    });
+    no_panic("referenced_identifiers_with_spans", input, |s| {
+        let _ = referenced_identifiers_with_spans(s);
+    });
+    no_panic("free_identifiers", input, |s| {
+        let _ = free_identifiers(s);
+    });
+    no_panic("free_identifiers_with_spans", input, |s| {
+        let _ = free_identifiers_with_spans(s);
+    });
+    no_panic("assigned_identifiers", input, |s| {
+        let _ = assigned_identifiers(s);
+    });
+    no_panic("function_mutations", input, |s| {
+        let _ = function_mutations(s);
+    });
+    no_panic("function_dependencies", input, |s| {
+        let _ = function_dependencies(s);
+    });
+    no_panic("analyze_script", input, |s| {
+        let _ = analyze_script(s);
+    });
+    no_panic("module_binding_references", input, |s| {
+        let _ = module_binding_references(s);
+    });
+    no_panic("top_level_declarations", input, |s| {
+        let _ = top_level_declarations(s);
+    });
+}
+
+/// If a call *succeeds*, every returned byte range must be in-bounds and slice
+/// back to its identifier text. This guards the span arithmetic against off-by-
+/// one / unicode-boundary bugs across arbitrary input.
+fn assert_span_consistency(input: &str) {
+    if let Ok(ids) = referenced_identifiers_with_spans(input) {
+        for (name, range) in &ids {
+            assert_eq!(
+                range.slice(input),
+                Some(name.as_str()),
+                "ref span {input:?}"
+            );
+        }
+    }
+    if let Ok(ids) = free_identifiers_with_spans(input) {
+        for (name, range) in &ids {
+            assert_eq!(
+                range.slice(input),
+                Some(name.as_str()),
+                "free span {input:?}"
+            );
+        }
+    }
+    if let Ok(decls) = declared_bindings_with_spans(input) {
+        for (name, range) in &decls {
+            assert_eq!(
+                range.slice(input),
+                Some(name.as_str()),
+                "decl span {input:?}"
+            );
+        }
+    }
+    if let Ok(refs) = module_binding_references(input) {
+        for r in &refs {
+            assert_eq!(
+                r.range.slice(input),
+                Some(r.name.as_str()),
+                "mref span {input:?}"
+            );
+        }
+    }
+    if let Ok(ds) = top_level_declarations(input) {
+        for d in &ds {
+            assert_eq!(
+                d.name_range.slice(input),
+                Some(d.name.as_str()),
+                "tld name span {input:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn adversarial_inputs_never_panic() {
+    let cases = [
+        "",
+        " ",
+        "\n\n\n",
+        "\t",
+        "let",
+        "let x",
+        "let x:",
+        "let x: =",
+        "const",
+        "= = =",
+        "=> =>",
+        "for",
+        "for(",
+        "for(;;)",
+        "for(let x of)",
+        "item of",
+        "of items",
+        "[a,b] of",
+        "{a} of",
+        "const {a} of x.entries()",
+        "function",
+        "function(){",
+        "class",
+        "class {}",
+        "class C extends",
+        "`unterminated",
+        "'unterminated",
+        "\"unterminated",
+        "/* unterminated",
+        "// only a comment",
+        "({[",
+        ")}]",
+        "...",
+        "?.",
+        "a?.b!.c",
+        "a ?? b ?? c",
+        "interface A { x: number }",
+        "type T =",
+        "enum",
+        "enum E {",
+        "namespace N {",
+        "import",
+        "import from",
+        "import type",
+        "export",
+        "export default",
+        "export const",
+        "@decorator class C {}",
+        "あ of \u{1F600}",
+        "λ => λ",
+        "\0\0\0",
+        "let \u{202e}rtl = 1",
+        "0xZZ",
+        "1_000_000n",
+        "#private",
+        "class C { #x = 1 }",
+        "yield await",
+        "a = b = c = d = e",
+        "((((((((((",
+        "{{{{{{{{{{",
+    ];
+    for c in cases {
+        exercise(c);
+        assert_span_consistency(c);
+    }
+    // Long inputs of various shapes, kept alive across the calls. Nesting depth
+    // is kept modest: SWC's recursive-descent parser (like any) can exhaust the
+    // stack on pathological nesting, which aborts rather than unwinds and is
+    // outside the never-panic (Result-returning) contract. These depths stay
+    // comfortably below that to fuzz breadth, not parser recursion limits.
+    let long_ident = "x".repeat(2000);
+    exercise(&long_ident);
+    let deep_nest = format!("{}1{}", "(".repeat(40), ")".repeat(40));
+    exercise(&deep_nest);
+    let long_chain = format!("{}b", "a.".repeat(200));
+    exercise(&long_chain);
+    let wide_add = (0..400).map(|i| format!("v{i} + ")).collect::<String>() + "z";
+    exercise(&wide_add);
+    let many_decls = (0..300)
+        .map(|i| format!("let v{i} = {i}\n"))
+        .collect::<String>();
+    exercise(&many_decls);
+    assert_span_consistency(&many_decls);
+}
+
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+}
+
+#[test]
+fn pseudo_random_fuzz_never_panics() {
+    // A richer fragment set than robustness.rs: adds functions, members,
+    // destructuring, TS type syntax, and mutating-method fragments so the
+    // scope/mutation/dependency analyses get adversarial trees too.
+    let frags: &[&str] = &[
+        "let ",
+        "const ",
+        "var ",
+        "function ",
+        "class ",
+        "return ",
+        "for",
+        "while",
+        "if",
+        "(",
+        ")",
+        "{",
+        "}",
+        "[",
+        "]",
+        " of ",
+        " in ",
+        ";",
+        ",",
+        "=",
+        "=>",
+        "+",
+        "-",
+        "*",
+        ".",
+        "?.",
+        "??",
+        "!",
+        ":",
+        "...",
+        "a",
+        "b",
+        "c",
+        "f",
+        "x",
+        "obj",
+        "items",
+        ".push(",
+        ".map(",
+        ".entries()",
+        "1",
+        "0",
+        "\"s\"",
+        "'c'",
+        "`t`",
+        "${",
+        "number",
+        "string",
+        "as ",
+        "satisfies ",
+        "type ",
+        "interface ",
+        "enum ",
+        "import ",
+        "export ",
+        "from ",
+        "\n",
+        " ",
+        "あ",
+        "λ",
+        "\0",
+        "@",
+        "#",
+    ];
+    let mut rng = Lcg(0xfeed_face_dead_beef);
+    for _ in 0..2500 {
+        let parts = (rng.next() % 14) as usize;
+        let mut s = String::new();
+        for _ in 0..parts {
+            s.push_str(frags[(rng.next() as usize) % frags.len()]);
+        }
+        exercise(&s);
+        assert_span_consistency(&s);
+    }
+}

--- a/crates/lunas_script/tests/mutations.rs
+++ b/crates/lunas_script/tests/mutations.rs
@@ -1,0 +1,266 @@
+//! Coverage of the mutation-tracking analyses: `assigned_identifiers` (all
+//! assignment / update / in-place-mutator targets in a snippet) and
+//! `function_mutations` (per top-level function, the roots it mutates). These
+//! drive which component state a handler changes for reactive updates.
+
+use lunas_script::{assigned_identifiers, function_mutations};
+
+fn assigns(code: &str) -> Vec<String> {
+    assigned_identifiers(code).expect("parse ok")
+}
+
+fn none() -> Vec<String> {
+    Vec::<String>::new()
+}
+
+// --- plain and compound assignment ---
+
+#[test]
+fn assign_all_compound_operators() {
+    assert_eq!(
+        assigns("a += 1; b -= 1; c *= 2; d /= 2; e %= 2; f **= 2"),
+        ["a", "b", "c", "d", "e", "f"]
+    );
+}
+
+#[test]
+fn assign_bitwise_and_shift_compound() {
+    assert_eq!(
+        assigns("a &= 1; b |= 1; c ^= 1; d <<= 1; e >>= 1; f >>>= 1"),
+        ["a", "b", "c", "d", "e", "f"]
+    );
+}
+
+#[test]
+fn assign_logical_compound() {
+    assert_eq!(assigns("a ||= 1; b &&= 1; c ??= 1"), ["a", "b", "c"]);
+}
+
+// --- update expressions ---
+
+#[test]
+fn assign_prefix_and_postfix_update() {
+    assert_eq!(assigns("++a; a++; --b; b--"), ["a", "a", "b", "b"]);
+}
+
+#[test]
+fn assign_update_on_member_reports_root() {
+    assert_eq!(assigns("obj.count++; ++state.n"), ["obj", "state"]);
+}
+
+// --- member / index targets report the root binding ---
+
+#[test]
+fn assign_deep_member_root() {
+    assert_eq!(assigns("a.b.c.d = 1"), ["a"]);
+}
+
+#[test]
+fn assign_computed_index_root() {
+    assert_eq!(assigns("arr[i] = 1; grid[x][y] = 2"), ["arr", "grid"]);
+}
+
+#[test]
+fn assign_mixed_member_and_index_root() {
+    assert_eq!(assigns("state.items[k].done = true"), ["state"]);
+}
+
+#[test]
+fn assign_parenthesized_target_root() {
+    assert_eq!(assigns("(obj).x = 1"), ["obj"]);
+}
+
+// --- in-place mutating methods report the receiver root ---
+
+#[test]
+fn assign_array_mutators() {
+    assert_eq!(
+        assigns("xs.push(1); ys.pop(); zs.shift(); ws.unshift(0)"),
+        ["xs", "ys", "zs", "ws"]
+    );
+}
+
+#[test]
+fn assign_more_array_mutators() {
+    assert_eq!(
+        assigns("a.splice(0,1); b.sort(); c.reverse(); d.fill(0); e.copyWithin(0,1)"),
+        ["a", "b", "c", "d", "e"]
+    );
+}
+
+#[test]
+fn assign_collection_mutators() {
+    assert_eq!(
+        assigns("s.add(1); s2.delete(2); m.set('k', 1); m2.clear()"),
+        ["s", "s2", "m", "m2"]
+    );
+}
+
+#[test]
+fn assign_mutator_on_nested_member_reports_root() {
+    assert_eq!(assigns("state.list.push(1)"), ["state"]);
+}
+
+#[test]
+fn assign_non_mutating_methods_ignored() {
+    // filter/map/slice/concat return new values; the receiver is not mutated.
+    assert_eq!(
+        assigns("const a = xs.filter(f).map(g).slice(0).concat(ys)"),
+        none()
+    );
+}
+
+#[test]
+fn assign_mutator_name_as_plain_call_not_counted() {
+    // A bare `push(x)` (not a method call) is not a receiver mutation.
+    assert_eq!(assigns("push(x)"), none());
+}
+
+// --- assignment chains and RHS recursion ---
+
+#[test]
+fn assign_chain_reports_all_targets() {
+    assert_eq!(assigns("a = b = c = 1"), ["a", "b", "c"]);
+}
+
+#[test]
+fn assign_rhs_nested_assignment_and_mutator() {
+    // The RHS is recursed: inner assignment and a mutator both count.
+    assert_eq!(assigns("outer = (inner = 1)"), ["outer", "inner"]);
+    assert_eq!(assigns("x = xs.push(1)"), ["x", "xs"]);
+}
+
+// --- destructuring assignment targets ---
+
+#[test]
+fn assign_array_destructure_targets() {
+    assert_eq!(assigns("[a, , b] = pair"), ["a", "b"]);
+}
+
+#[test]
+fn assign_object_destructure_targets() {
+    assert_eq!(assigns("({ x, y: z, ...rest } = obj)"), ["x", "z", "rest"]);
+}
+
+#[test]
+fn assign_nested_destructure_targets() {
+    assert_eq!(assigns("({ a: { b }, c: [d] } = src)"), ["b", "d"]);
+}
+
+// --- comparisons are not assignments ---
+
+#[test]
+fn assign_equality_not_counted() {
+    assert_eq!(assigns("a == b; c === d; e != f; g !== h"), none());
+}
+
+// --- mutations occurring inside nested functions still count (flat visitor) ---
+
+#[test]
+fn assign_inside_nested_function() {
+    assert_eq!(
+        assigns("function outer(){ function inner(){ state = 1 } inner() }"),
+        ["state"]
+    );
+}
+
+#[test]
+fn assign_inside_arrow_callback() {
+    assert_eq!(
+        assigns("items.forEach(() => { touched = true })"),
+        ["touched"]
+    );
+}
+
+#[test]
+fn assign_via_aliased_member() {
+    // Mutating through an aliased reference still roots at the alias binding.
+    assert_eq!(assigns("const ref = obj; ref.x = 1"), ["ref"]);
+}
+
+// --- function_mutations: per-function grouping ---
+
+#[test]
+fn fmut_multiple_functions_grouped() {
+    let muts = function_mutations(
+        "function a(){ x = 1 }\nfunction b(){ y++ }\nconst c = () => { z.push(1) }",
+    )
+    .unwrap();
+    assert_eq!(
+        muts,
+        vec![
+            ("a".to_string(), vec!["x".to_string()]),
+            ("b".to_string(), vec!["y".to_string()]),
+            ("c".to_string(), vec!["z".to_string()]),
+        ]
+    );
+}
+
+#[test]
+fn fmut_function_expression_const() {
+    let muts = function_mutations("const f = function(){ n = 1 }").unwrap();
+    assert_eq!(muts, vec![("f".to_string(), vec!["n".to_string()])]);
+}
+
+#[test]
+fn fmut_dedups_repeated_targets() {
+    let muts = function_mutations("function f(){ a = 1; a += 2; a++; a.push(1) }").unwrap();
+    assert_eq!(muts, vec![("f".to_string(), vec!["a".to_string()])]);
+}
+
+#[test]
+fn fmut_empty_for_pure_function() {
+    let muts = function_mutations("function pure(x){ return x * 2 }").unwrap();
+    assert_eq!(muts, vec![("pure".to_string(), vec![])]);
+}
+
+#[test]
+fn fmut_mutation_in_nested_closure_attributed_to_outer() {
+    // The nested arrow's mutation is attributed to the top-level function.
+    let muts = function_mutations("function reg(){ on('x', () => { fired = true }) }").unwrap();
+    assert_eq!(muts, vec![("reg".to_string(), vec!["fired".to_string()])]);
+}
+
+#[test]
+fn fmut_exported_function_included() {
+    let muts = function_mutations("export function inc(){ count++ }").unwrap();
+    assert_eq!(muts, vec![("inc".to_string(), vec!["count".to_string()])]);
+}
+
+#[test]
+fn fmut_non_callable_const_skipped() {
+    // A plain `const` (not arrow/function) is not a function; only `f` appears.
+    let muts = function_mutations("const total = 0\nconst f = () => { total2 = 1 }").unwrap();
+    assert_eq!(muts, vec![("f".to_string(), vec!["total2".to_string()])]);
+}
+
+#[test]
+fn fmut_member_mutator_receiver_root() {
+    let muts = function_mutations("function f(){ store.items.splice(0, 1) }").unwrap();
+    assert_eq!(muts, vec![("f".to_string(), vec!["store".to_string()])]);
+}
+
+#[test]
+fn fmut_multi_declarator_const_functions() {
+    // `const a = ..., b = ...` with two arrows yields two entries.
+    let muts = function_mutations("const a = () => { p = 1 }, b = () => { q = 2 }").unwrap();
+    assert_eq!(
+        muts,
+        vec![
+            ("a".to_string(), vec!["p".to_string()]),
+            ("b".to_string(), vec!["q".to_string()]),
+        ]
+    );
+}
+
+#[test]
+fn fmut_order_preserved_within_function() {
+    let muts = function_mutations("function f(){ b = 1; a = 2; c.push(1) }").unwrap();
+    assert_eq!(
+        muts,
+        vec![(
+            "f".to_string(),
+            vec!["b".to_string(), "a".to_string(), "c".to_string()]
+        )]
+    );
+}

--- a/crates/lunas_script/tests/scoping.rs
+++ b/crates/lunas_script/tests/scoping.rs
@@ -1,0 +1,324 @@
+//! Deep coverage of `free_identifiers` lexical scoping — the reactivity input
+//! that must report only the *free* variables an expression/function reads,
+//! excluding names bound by params, locals, block scopes, catch clauses, named
+//! fn/class expressions, and honoring shadowing at every nesting level.
+
+use lunas_script::{free_identifiers, free_identifiers_with_spans};
+
+fn free(code: &str) -> Vec<String> {
+    free_identifiers(code).expect("parse ok")
+}
+
+fn none() -> Vec<String> {
+    Vec::<String>::new()
+}
+
+// --- arrow / function params ---
+
+#[test]
+fn free_single_arrow_param_bound() {
+    assert_eq!(free("x => x"), none());
+}
+
+#[test]
+fn free_arrow_param_outer_still_free() {
+    assert_eq!(free("x => x + outer"), ["outer"]);
+}
+
+#[test]
+fn free_multiple_params_all_bound() {
+    assert_eq!(free("(a, b, c) => a + b + c"), none());
+}
+
+#[test]
+fn free_rest_param_bound() {
+    assert_eq!(free("(...xs) => xs.length + n"), ["n"]);
+}
+
+#[test]
+fn free_function_expr_params_bound() {
+    assert_eq!(free("(function(a, b){ return a + b + z })"), ["z"]);
+}
+
+// --- shadowing across nesting ---
+
+#[test]
+fn free_inner_param_shadows_outer_free_name_reported_once() {
+    // Outer `a` is free; the inner arrow's `a` param shadows only inside.
+    assert_eq!(free("a + (a => a)"), ["a"]);
+}
+
+#[test]
+fn free_double_nested_shadow_collapses() {
+    // Both levels bind `a`; no free `a` escapes.
+    assert_eq!(free("a => (a => a)"), none());
+}
+
+#[test]
+fn free_outer_visible_through_two_arrows() {
+    assert_eq!(
+        free("outer + (a => (b => a + b + outer))"),
+        ["outer", "outer"]
+    );
+}
+
+#[test]
+fn free_block_let_shadows_outer() {
+    // A block-scoped `n` shadows the outer read; only `dep` is free.
+    assert_eq!(free("(function(){ let n = dep; return n })"), ["dep"]);
+}
+
+#[test]
+fn free_inner_const_shadows_param_name() {
+    // Param `v` then a block `const v`; nothing leaks, `seed` is free.
+    assert_eq!(
+        free("(function(v){ { const v = seed; return v } })"),
+        ["seed"]
+    );
+}
+
+#[test]
+fn free_function_decl_in_block_shadows() {
+    // A nested `function helper` binding is not free; `dep` inside it is.
+    assert_eq!(
+        free("(function(){ function helper(){ return dep } return helper() })"),
+        ["dep"]
+    );
+}
+
+#[test]
+fn free_class_decl_in_block_bound() {
+    assert_eq!(
+        free("(function(){ class Local { m(){ return base } } return new Local() })"),
+        ["base"]
+    );
+}
+
+// --- for headers ---
+//
+// KNOWN LIMITATION: `ScopedFreeCollector` does not open a scope for a `for` /
+// `for-of` / `for-in` header, so the loop binding leaks and is reported as a
+// free read. These tests pin that current contract; if for-header scoping is
+// added, update them (the loop variable should then disappear from the set).
+
+#[test]
+fn free_for_of_binding_leaks_current_behavior() {
+    // `x` (loop binding) leaks in source order alongside the genuine frees.
+    assert_eq!(
+        free("(function(){ for (const x of items) { total += x } return total })"),
+        ["x", "items", "total", "x", "total"]
+    );
+}
+
+#[test]
+fn free_for_in_binding_leaks_current_behavior() {
+    assert_eq!(
+        free("(function(){ for (const k in obj) { use(k) } })"),
+        ["k", "obj", "use", "k"]
+    );
+}
+
+#[test]
+fn free_c_style_for_header_binding_leaks_current_behavior() {
+    // `i` from the header is not scoped and leaks at every occurrence.
+    assert_eq!(
+        free("(function(){ for (let i = 0; i < limit; i++) { sum += i } })"),
+        ["i", "i", "limit", "i", "sum", "i"]
+    );
+}
+
+// --- catch bindings ---
+//
+// KNOWN LIMITATION: `ScopedFreeCollector` has no `visit_catch_clause`, so a
+// catch parameter is NOT bound and leaks as a free read (unlike
+// `module_binding_references`, which does scope catch params). Pin the current
+// behavior.
+
+#[test]
+fn free_catch_param_leaks_current_behavior() {
+    assert_eq!(
+        free("(function(){ try { risky() } catch (e) { report(e) } })"),
+        ["risky", "e", "report", "e"]
+    );
+}
+
+#[test]
+fn free_catch_outer_same_name_all_leak() {
+    // Every `e` occurrence is reported (catch param not scoped).
+    assert_eq!(
+        free("(function(){ try { f() } catch (e) { e } return e })"),
+        ["f", "e", "e", "e"]
+    );
+}
+
+#[test]
+fn free_catch_destructured_param_leaks_current_behavior() {
+    assert_eq!(
+        free("(function(){ try { f() } catch ({ message }) { log(message) } })"),
+        ["f", "message", "log", "message"]
+    );
+}
+
+// --- destructuring params ---
+
+#[test]
+fn free_object_destructure_param_bound() {
+    assert_eq!(
+        free("data.map(({ id }) => id + suffix)"),
+        ["data", "suffix"]
+    );
+}
+
+#[test]
+fn free_array_destructure_param_bound() {
+    assert_eq!(free("pairs.map(([a, b]) => a + b + c)"), ["pairs", "c"]);
+}
+
+#[test]
+fn free_nested_destructure_param_bound() {
+    assert_eq!(
+        free("rows.map(({ user: { name } }) => name + tag)"),
+        ["rows", "tag"]
+    );
+}
+
+#[test]
+fn free_rest_in_destructure_param_bound() {
+    assert_eq!(
+        free("xs.map(({ a, ...rest }) => a + rest.length + k)"),
+        ["xs", "k"]
+    );
+}
+
+// --- default params referencing earlier params / outer names ---
+
+#[test]
+fn free_default_param_reads_outer() {
+    // The default value expression reads `fallback` (free); `b` param is bound.
+    assert_eq!(free("xs.map((b = fallback) => b)"), ["xs", "fallback"]);
+}
+
+#[test]
+fn free_default_reads_earlier_param() {
+    // `a` in `b = a` is an earlier param; it is bound, so only `xs` is free.
+    assert_eq!(free("xs.map((a, b = a) => a + b)"), ["xs"]);
+}
+
+// --- IIFE ---
+
+#[test]
+fn free_iife_locals_bound() {
+    // The callee (arrow body) is visited before the argument, so `external`
+    // (read in the body) precedes `seed` (the call argument).
+    assert_eq!(
+        free("((n) => { const twice = n * 2; return twice + external })(seed)"),
+        ["external", "seed"]
+    );
+}
+
+// --- named function / class expression self-reference ---
+
+#[test]
+fn free_named_fn_expr_self_ref_bound() {
+    // `fact` refers to the fn-expr's own name — bound, not free.
+    assert_eq!(
+        free("(function fact(n){ return n <= 1 ? 1 : n * fact(n - 1) })"),
+        none()
+    );
+}
+
+#[test]
+fn free_named_class_expr_self_ref_bound() {
+    assert_eq!(
+        free("(class Node { clone(){ return new Node() } })"),
+        none()
+    );
+}
+
+// --- class methods / fields ---
+
+#[test]
+fn free_class_method_reads_outer() {
+    assert_eq!(
+        free("(class C { greet(){ return prefix + name } })"),
+        ["prefix", "name"]
+    );
+}
+
+#[test]
+fn free_class_method_param_bound() {
+    assert_eq!(free("(class C { add(x){ return x + base } })"), ["base"]);
+}
+
+// --- hoisting: a name declared later in a block is still bound throughout ---
+
+#[test]
+fn free_hoisted_block_decl_bound_before_use() {
+    // `helper` is used before its declaration in source order but is block-
+    // scoped-visible, so it must not be reported free.
+    assert_eq!(
+        free("(function(){ const r = helper(); function helper(){ return dep } return r })"),
+        ["dep"]
+    );
+}
+
+// --- multiple free occurrences preserved in order ---
+
+#[test]
+fn free_preserves_order_and_repeats() {
+    assert_eq!(free("a + b + a"), ["a", "b", "a"]);
+}
+
+// --- with-spans variant: shadowed occurrences excluded, ranges slice back ---
+
+#[test]
+fn free_spans_exclude_shadowed_and_slice_back() {
+    let code = "total + rows.map(total => total * 2)";
+    let ids = free_identifiers_with_spans(code).unwrap();
+    let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+    // Only the outer `total` and `rows` are free.
+    assert_eq!(names, ["total", "rows"]);
+    // The reported `total` is the outer occurrence at offset 0.
+    assert_eq!(ids[0].1.start().raw(), 0);
+    for (name, range) in &ids {
+        assert_eq!(
+            range.slice(code),
+            Some(name.as_str()),
+            "bad span for {name}"
+        );
+    }
+}
+
+#[test]
+fn free_spans_nested_free_uses_distinct_ranges() {
+    let code = "count + f(count)";
+    let ids = free_identifiers_with_spans(code).unwrap();
+    let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["count", "f", "count"]);
+    assert_ne!(ids[0].1, ids[2].1);
+    for (name, range) in &ids {
+        assert_eq!(range.slice(code), Some(name.as_str()));
+    }
+}
+
+#[test]
+fn free_spans_unicode_offsets() {
+    let code = "αβ + f(γ)";
+    let ids = free_identifiers_with_spans(code).unwrap();
+    for (name, range) in &ids {
+        assert_eq!(range.slice(code), Some(name.as_str()));
+    }
+}
+
+// --- deeply nested closures resolve outer frees ---
+
+#[test]
+fn free_deep_closure_resolves_outermost() {
+    assert_eq!(free("a => b => c => d => a + b + c + d + e"), ["e"]);
+}
+
+#[test]
+fn free_sibling_scopes_do_not_leak() {
+    // `x` bound in the first arrow must not bind the second arrow's read.
+    assert_eq!(free("(x => x) + (() => x)"), ["x"]);
+}

--- a/crates/lunas_script/tests/spans.rs
+++ b/crates/lunas_script/tests/spans.rs
@@ -1,0 +1,291 @@
+//! Byte-range correctness for the span-returning analyses — the input to
+//! LSP go-to-definition, find-references, rename, and in-place reactive
+//! rewrites. Every reported range must slice back to the exact identifier /
+//! initializer / statement text, and distinct occurrences must have distinct
+//! ranges.
+
+use lunas_script::{
+    declared_bindings_with_spans, free_identifiers_with_spans, module_binding_references,
+    referenced_identifiers_with_spans, top_level_declarations, BindingRef, DeclKind,
+};
+use lunas_span::TextRange;
+
+// Helper: assert every (name, range) slices back to `name` in `code`.
+fn assert_slices_back(code: &str, ids: &[(String, TextRange)]) {
+    for (name, range) in ids {
+        assert_eq!(
+            range.slice(code),
+            Some(name.as_str()),
+            "bad span for {name}"
+        );
+    }
+}
+
+// --- referenced_identifiers_with_spans ---
+
+#[test]
+fn ref_spans_multiline_offsets() {
+    let code = "a +\n  bbb *\n    cc";
+    let ids = referenced_identifiers_with_spans(code).unwrap();
+    let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["a", "bbb", "cc"]);
+    assert_slices_back(code, &ids);
+}
+
+#[test]
+fn ref_spans_repeated_name_distinct_ranges() {
+    let code = "x + x + x";
+    let ids = referenced_identifiers_with_spans(code).unwrap();
+    assert_eq!(ids.len(), 3);
+    assert_ne!(ids[0].1, ids[1].1);
+    assert_ne!(ids[1].1, ids[2].1);
+    assert_eq!(ids[0].1.start().raw(), 0);
+    assert_eq!(ids[2].1.start().raw(), 8);
+}
+
+#[test]
+fn ref_spans_unicode_multibyte() {
+    let code = "café + naïve + 日本語";
+    let ids = referenced_identifiers_with_spans(code).unwrap();
+    assert_slices_back(code, &ids);
+    let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["café", "naïve", "日本語"]);
+}
+
+#[test]
+fn ref_spans_member_root_only() {
+    let code = "obj.deep.prop";
+    let ids = referenced_identifiers_with_spans(code).unwrap();
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].1.slice(code), Some("obj"));
+}
+
+// --- declared_bindings_with_spans ---
+
+#[test]
+fn decl_spans_point_at_names_not_values() {
+    let code = "let count = 100\nconst label = \"hi\"";
+    let decls = declared_bindings_with_spans(code).unwrap();
+    let names: Vec<_> = decls.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["count", "label"]);
+    assert_slices_back(code, &decls);
+    // The span is the name, not the initializer.
+    assert_eq!(decls[0].1.start().raw(), 4);
+}
+
+#[test]
+fn decl_spans_destructuring_each_name() {
+    let code = "const { a, b: c } = obj\nconst [d, e] = xs";
+    let decls = declared_bindings_with_spans(code).unwrap();
+    let names: Vec<_> = decls.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["a", "c", "d", "e"]);
+    assert_slices_back(code, &decls);
+}
+
+#[test]
+fn decl_spans_imports() {
+    let code = "import def, { named as alias } from 'm'";
+    let decls = declared_bindings_with_spans(code).unwrap();
+    let names: Vec<_> = decls.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["def", "alias"]);
+    assert_slices_back(code, &decls);
+}
+
+#[test]
+fn decl_spans_function_and_class_names() {
+    let code = "function compute(){}\nclass Widget {}";
+    let decls = declared_bindings_with_spans(code).unwrap();
+    assert_eq!(decls[0].1.slice(code), Some("compute"));
+    assert_eq!(decls[1].1.slice(code), Some("Widget"));
+}
+
+#[test]
+fn decl_spans_object_assign_default_uses_key() {
+    // `{ x = 5 }` — the span is the key `x`, not the default.
+    let code = "const { x = 5 } = obj";
+    let decls = declared_bindings_with_spans(code).unwrap();
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].0, "x");
+    assert_eq!(decls[0].1.slice(code), Some("x"));
+}
+
+// --- free_identifiers_with_spans ---
+
+#[test]
+fn free_spans_report_outer_not_shadow() {
+    let code = "value + list.map(value => value)";
+    let ids = free_identifiers_with_spans(code).unwrap();
+    let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, ["value", "list"]);
+    // The kept `value` is the leading (outer) occurrence.
+    assert_eq!(ids[0].1.start().raw(), 0);
+    assert_slices_back(code, &ids);
+}
+
+// --- module_binding_references ---
+
+fn mrefs(code: &str) -> Vec<BindingRef> {
+    module_binding_references(code).expect("parse ok")
+}
+
+#[test]
+fn mref_spans_slice_back_to_identifier() {
+    let code = "let count = 0\nfunction inc(){ count = count + 1 }";
+    let refs = mrefs(code);
+    assert_eq!(refs.len(), 2);
+    for r in &refs {
+        assert_eq!(r.range.slice(code), Some("count"));
+        assert_eq!(r.name, "count");
+        assert!(!r.shorthand);
+    }
+    // Two distinct occurrences.
+    assert_ne!(refs[0].range, refs[1].range);
+}
+
+#[test]
+fn mref_declaration_and_shadow_excluded() {
+    let code = "let n = 1\nconst f = (n) => n + 1\nfunction g(){ return n }";
+    let refs = mrefs(code);
+    // Only `return n` in g refers to the top-level binding.
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].name, "n");
+    assert_eq!(refs[0].range.slice(code), Some("n"));
+}
+
+#[test]
+fn mref_block_shadow_only_outer_counts() {
+    let code = "let n = 1\nfunction g(){ { let n = 2; n } return n }";
+    let refs = mrefs(code);
+    assert_eq!(refs.len(), 1);
+    // The surviving ref is the later `return n`, past the shadowing block.
+    assert!(refs[0].range.start().raw() > code.find("return").unwrap() as u32 - 1);
+}
+
+#[test]
+fn mref_shorthand_flag_and_expansion_range() {
+    let code = "let count = 0\nfunction f(){ return { count } }";
+    let refs = mrefs(code);
+    assert_eq!(refs.len(), 1);
+    assert!(refs[0].shorthand);
+    assert_eq!(refs[0].range.slice(code), Some("count"));
+}
+
+#[test]
+fn mref_catch_param_shadows_top_level() {
+    let code = "let e = 1\nfunction f(){ try { g() } catch (e) { return e } return e }";
+    let refs = mrefs(code);
+    // Only the outer `return e` (outside catch) is a top-level ref.
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].name, "e");
+}
+
+#[test]
+fn mref_param_default_expression_is_reference() {
+    let code = "let base = 1\nconst f = (x = base) => x";
+    let refs = mrefs(code);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].name, "base");
+    assert_eq!(refs[0].range.slice(code), Some("base"));
+}
+
+#[test]
+fn mref_computed_member_key_is_reference_static_prop_not() {
+    let code = "let k = 'a'\nlet obj = {}\nfunction f(){ return obj[k].k }";
+    let refs = mrefs(code);
+    // obj (once) and computed k (once); the static `.k` prop is not a ref.
+    let ks = refs.iter().filter(|r| r.name == "k").count();
+    let objs = refs.iter().filter(|r| r.name == "obj").count();
+    assert_eq!(ks, 1);
+    assert_eq!(objs, 1);
+}
+
+#[test]
+fn mref_named_fn_expr_self_name_not_top_level() {
+    // The named fn-expr `count` self-name shadows the top-level binding inside.
+    let code = "let count = 0\nconst f = function count(){ return count }";
+    let refs = mrefs(code);
+    // The inner `return count` is the fn-expr's own name, not the top-level one.
+    assert!(refs.is_empty(), "got {refs:?}");
+}
+
+// --- top_level_declarations ---
+
+#[test]
+fn tld_init_and_stmt_ranges() {
+    let code = "let count = 1 + 2";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    assert_eq!(ds[0].name, "count");
+    assert_eq!(ds[0].kind, DeclKind::Let);
+    assert_eq!(ds[0].name_range.slice(code), Some("count"));
+    assert_eq!(ds[0].init_range.unwrap().slice(code), Some("1 + 2"));
+    assert_eq!(ds[0].stmt_range.slice(code), Some("let count = 1 + 2"));
+    assert_eq!(ds[0].declarators_in_stmt, 1);
+}
+
+#[test]
+fn tld_no_init_var() {
+    let code = "var loose";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    assert_eq!(ds[0].kind, DeclKind::Var);
+    assert!(ds[0].init_range.is_none());
+    assert_eq!(ds[0].name_range.slice(code), Some("loose"));
+}
+
+#[test]
+fn tld_multi_declarator_shares_stmt_range() {
+    let code = "const a = 1, b = 2, c = 3";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 3);
+    for d in &ds {
+        assert_eq!(d.declarators_in_stmt, 3);
+        assert_eq!(d.stmt_range.slice(code), Some(code));
+    }
+    assert_eq!(ds[0].init_range.unwrap().slice(code), Some("1"));
+    assert_eq!(ds[2].name_range.slice(code), Some("c"));
+}
+
+#[test]
+fn tld_destructured_declarators_skipped() {
+    let code = "const { a } = o\nconst [b] = xs\nlet plain = 1";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    assert_eq!(ds[0].name, "plain");
+}
+
+#[test]
+fn tld_exported_included_stmt_excludes_export_keyword() {
+    let code = "export let shown = true";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    // stmt_range covers the VarDecl, not the `export` keyword.
+    assert_eq!(ds[0].stmt_range.slice(code), Some("let shown = true"));
+}
+
+#[test]
+fn tld_typescript_annotation_init_range() {
+    let code = "let n: number = 42";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    // The init range is the value, not the annotation.
+    assert_eq!(ds[0].init_range.unwrap().slice(code), Some("42"));
+}
+
+#[test]
+fn tld_multiline_offsets() {
+    let code = "let a = 1\nlet b = 2\nlet c = 3";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 3);
+    assert_eq!(ds[1].name_range.slice(code), Some("b"));
+    assert_eq!(ds[1].init_range.unwrap().slice(code), Some("2"));
+    assert_eq!(ds[2].stmt_range.slice(code), Some("let c = 3"));
+}
+
+#[test]
+fn tld_function_and_class_not_variable_decls() {
+    let code = "function f(){}\nclass C {}\nlet only = 1";
+    let ds = top_level_declarations(code).unwrap();
+    assert_eq!(ds.len(), 1);
+    assert_eq!(ds[0].name, "only");
+}

--- a/crates/lunas_script/tests/ts_transform.rs
+++ b/crates/lunas_script/tests/ts_transform.rs
@@ -1,0 +1,278 @@
+//! Coverage of `transform_ts_to_js` (TypeScript type-stripping → JS) and
+//! `parse_to_ast_json` (shallow span-annotated AST projection). The transform
+//! must produce valid JS with all type-only syntax removed; the AST projection
+//! must classify top-level statement kinds and expose byte spans.
+
+use lunas_script::{parse_to_ast_json, transform_ts_to_js};
+
+fn js(ts: &str) -> String {
+    transform_ts_to_js(ts).expect("transform ok")
+}
+
+// --- type-only syntax stripped ---
+
+#[test]
+fn ts_strips_interface_and_type_alias() {
+    let out = js("interface I { x: number }\ntype T = I | null\nconst v = 1");
+    assert!(!out.contains("interface"));
+    assert!(!out.contains("type T"));
+    assert!(out.contains("v"));
+}
+
+#[test]
+fn ts_strips_param_and_return_annotations() {
+    let out = js("function add(a: number, b: number): number { return a + b }");
+    assert!(out.contains("function add("));
+    assert!(!out.contains("number"));
+}
+
+#[test]
+fn ts_strips_generics() {
+    let out = js("function id<T>(x: T): T { return x }");
+    assert!(out.contains("function id("));
+    assert!(!out.contains("<T>"));
+}
+
+#[test]
+fn ts_strips_as_cast() {
+    let out = js("const n = value as number");
+    assert!(!out.contains("as number"));
+    assert!(out.contains("value"));
+}
+
+#[test]
+fn ts_strips_satisfies() {
+    let out = js("const cfg = { a: 1 } satisfies Record<string, number>");
+    assert!(!out.contains("satisfies"));
+    assert!(out.contains("a: 1") || out.contains("a:1"));
+}
+
+#[test]
+fn ts_strips_as_const() {
+    let out = js("const x = [1, 2] as const");
+    assert!(!out.contains("as const"));
+    assert!(out.contains("1"));
+}
+
+#[test]
+fn ts_strips_non_null_assertion() {
+    let out = js("const y = a!.b");
+    assert!(!out.contains("!."));
+    assert!(out.contains("a.b") || out.contains("a .b"));
+}
+
+#[test]
+fn ts_strips_definite_assignment() {
+    let out = js("let x!: number");
+    assert!(!out.contains("number"));
+    assert!(!out.contains("!"));
+    assert!(out.contains("x"));
+}
+
+#[test]
+fn ts_strips_optional_param_marker() {
+    let out = js("function f(a?: number){ return a }");
+    assert!(!out.contains("?"));
+    assert!(!out.contains("number"));
+}
+
+#[test]
+fn ts_strips_readonly_and_index_signature() {
+    let out = js("interface I { readonly x: number; [k: string]: unknown }\nconst v = 1");
+    assert!(!out.contains("readonly"));
+    assert!(!out.contains("interface"));
+    assert!(out.contains("v"));
+}
+
+#[test]
+fn ts_strips_declare() {
+    let out = js("declare const g: number\nconst u = 1");
+    assert!(!out.contains("declare"));
+    assert!(out.contains("u"));
+}
+
+// --- type-only imports / exports ---
+
+#[test]
+fn ts_strips_type_only_import() {
+    let out = js("import type { Foo } from 'm'\nimport { bar } from 'n'\nconst x: Foo = bar");
+    assert!(!out.contains("import type"));
+    assert!(out.contains("bar"));
+    assert!(!out.contains(": Foo"));
+}
+
+#[test]
+fn ts_strips_type_only_export() {
+    let out = js("export type { Foo } from 'm'\nexport { bar } from 'n'");
+    assert!(!out.contains("export type"));
+    assert!(out.contains("bar"));
+}
+
+#[test]
+fn ts_strips_inline_type_import_specifier() {
+    let out = js("import { type A, b } from 'm'\nconst x = b");
+    assert!(!out.contains("type A"));
+    assert!(out.contains("b"));
+}
+
+// --- constructs that lower to runtime code ---
+
+#[test]
+fn ts_enum_lowers_to_runtime_object() {
+    let out = js("enum Color { Red, Green }\nconst c = Color.Red");
+    assert!(!out.contains("enum"));
+    // The enum becomes an IIFE-style runtime object referencing `Color`.
+    assert!(out.contains("Color"));
+}
+
+#[test]
+fn ts_namespace_lowers_to_runtime() {
+    let out = js("namespace NS { export const x = 1 }\nconst y = NS.x");
+    assert!(!out.contains("namespace"));
+    assert!(out.contains("NS"));
+}
+
+#[test]
+fn ts_constructor_param_properties_expanded() {
+    // `private x: number` param property becomes a field + `this.x = x`.
+    let out = js("class C { constructor(private x: number){} }");
+    assert!(!out.contains("private"));
+    assert!(out.contains("this.x = x"));
+}
+
+#[test]
+fn ts_abstract_class_keyword_stripped() {
+    let out = js("abstract class A { abstract m(): void {} }");
+    assert!(!out.contains("abstract"));
+    assert!(out.contains("class A"));
+}
+
+#[test]
+fn ts_import_equals_lowers_to_require() {
+    let out = js("import M = require('m')\nconst v = M");
+    assert!(!out.contains("import M ="));
+    assert!(out.contains("require('m')"));
+}
+
+// --- preserved runtime syntax ---
+
+#[test]
+fn ts_preserves_optional_chaining_and_nullish() {
+    let out = js("const y = a?.b ?? c");
+    assert!(out.contains("?."));
+    assert!(out.contains("??"));
+}
+
+#[test]
+fn ts_preserves_value_imports() {
+    let out = js("import axios from 'axios'\nconst r = axios");
+    assert!(out.contains("import axios from 'axios'"));
+}
+
+#[test]
+fn ts_preserves_template_literals() {
+    let out = js("const s: string = `hi ${name}`");
+    assert!(out.contains("`hi ${name}`"));
+    assert!(!out.contains(": string"));
+}
+
+// --- transform edge cases ---
+
+#[test]
+fn ts_empty_input_is_empty() {
+    assert_eq!(transform_ts_to_js("").expect("ok").trim(), "");
+}
+
+#[test]
+fn ts_plain_js_passthrough() {
+    let out = js("const a = 1\nfunction f(){ return a }");
+    assert!(out.contains("const a = 1"));
+    assert!(out.contains("function f("));
+}
+
+#[test]
+fn ts_invalid_is_error_not_panic() {
+    assert!(transform_ts_to_js("let x: = =").is_err());
+}
+
+#[test]
+fn ts_decorators_unsupported_are_error() {
+    // The parser's default TS syntax disables decorators; a decorated member is
+    // a parse error rather than a panic (never-panic contract).
+    assert!(transform_ts_to_js("class C { @dec method(){} }").is_err());
+}
+
+// --- parse_to_ast_json ---
+
+#[test]
+fn ast_json_top_level_kinds() {
+    let ast = parse_to_ast_json(
+        "import a from 'm'\nlet x = 1\nfunction f(){}\nclass C {}\nexport const y = 2",
+    )
+    .unwrap();
+    let body = ast["body"].as_array().unwrap();
+    let kinds: Vec<&str> = body.iter().map(|n| n["type"].as_str().unwrap()).collect();
+    assert_eq!(
+        kinds,
+        [
+            "ImportDeclaration",
+            "VariableDeclaration",
+            "FunctionDeclaration",
+            "ClassDeclaration",
+            "ExportDeclaration",
+        ]
+    );
+    assert_eq!(ast["type"], "Module");
+}
+
+#[test]
+fn ast_json_control_flow_kinds() {
+    let ast = parse_to_ast_json(
+        "if (a) {}\nfor (const i of xs) {}\nfor (const k in o) {}\nwhile (b) {}\nreturn 1",
+    )
+    .unwrap();
+    let body = ast["body"].as_array().unwrap();
+    let kinds: Vec<&str> = body.iter().map(|n| n["type"].as_str().unwrap()).collect();
+    assert_eq!(
+        kinds,
+        [
+            "IfStatement",
+            "ForOfStatement",
+            "ForInStatement",
+            "WhileStatement",
+            "ReturnStatement",
+        ]
+    );
+}
+
+#[test]
+fn ast_json_spans_are_ordered_and_present() {
+    let ast = parse_to_ast_json("let a = 1\nlet b = 2").unwrap();
+    let body = ast["body"].as_array().unwrap();
+    assert_eq!(body.len(), 2);
+    let lo0 = body[0]["span"]["lo"].as_u64().unwrap();
+    let hi0 = body[0]["span"]["hi"].as_u64().unwrap();
+    let lo1 = body[1]["span"]["lo"].as_u64().unwrap();
+    assert!(lo0 < hi0);
+    assert!(hi0 <= lo1, "spans should not overlap and be ordered");
+}
+
+#[test]
+fn ast_json_typescript_parsed_natively() {
+    // TS is parsed without stripping first; type-only items still project.
+    let ast = parse_to_ast_json("interface I {}\nlet x: number = 0").unwrap();
+    let body = ast["body"].as_array().unwrap();
+    // The `let` declaration is present regardless of the interface classification.
+    assert!(body.iter().any(|n| n["type"] == "VariableDeclaration"));
+}
+
+#[test]
+fn ast_json_empty_module() {
+    let ast = parse_to_ast_json("").unwrap();
+    assert_eq!(ast["body"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn ast_json_invalid_is_error() {
+    assert!(parse_to_ast_json("let = = =").is_err());
+}


### PR DESCRIPTION
## What

Mass expansion of the Rust test suite for `lunas_script` (the SWC-based JS/TS analysis crate). Adds **190 new test functions** across 7 new test files, all under `crates/lunas_script/tests/` — no source or existing-test changes.

## New files

- **`scoping.rs`** (36) — `free_identifiers` lexical scoping: arrow/function/rest/destructured/default params, multi-level shadowing, block/for/catch scopes, named fn/class expression self-reference, class methods, hoisting, deep-closure resolution, span variants.
- **`mutations.rs`** (34) — `assigned_identifiers` (every compound/update/bitwise/logical operator, member/index roots, in-place mutators vs non-mutating chains, destructuring targets, RHS recursion, nested-fn/arrow mutations) and `function_mutations` (per-function grouping, dedup, closures, exports, multi-declarator const).
- **`deps.rs`** (31) — `function_dependencies` (read sets, transitive/recursive/mutual-recursion cycle-safety, non-callable skipping) plus `declared_bindings` and `referenced_identifiers` edge cases.
- **`spans.rs`** (26) — byte-range correctness for the `*_with_spans` analyses, `module_binding_references`, and `top_level_declarations`; every reported range slices back to its exact source text (multiline/unicode offsets, distinct-occurrence ranges, shadowing, shorthand flag).
- **`ts_transform.rs`** (32) — `transform_ts_to_js` type-stripping (interfaces, aliases, generics, `as`/`satisfies`/`as const`, non-null, definite-assign, optional params, readonly, `declare`, type-only import/export) and runtime lowering (enum/namespace/param-properties/abstract/import-equals); preserved runtime syntax; decorators as a parse error. Plus `parse_to_ast_json` statement-kind classification and span ordering.
- **`for_header_ext.rs`** (29) — `parse_for` of/in, destructuring/nested/default bindings, complex iterables, and the `.entries()` unwrap rules.
- **`fuzz.rs`** (2 harness fns, ~5000 generated inputs) — never-panic + span-consistency fuzzing across all 15 public entry points, covering the four `robustness.rs` omits (`function_dependencies`, `analyze_script`, `module_binding_references`, `top_level_declarations`).

## Notable behaviors pinned

The tests assert *observed* behavior, documenting two current limitations of `ScopedFreeCollector` so a regression (or an intentional fix) is caught:

- `free_identifiers` does **not** open a scope for `for` / `for-of` / `for-in` headers, so the loop binding leaks as a free read.
- `free_identifiers` has no `visit_catch_clause`, so a catch parameter leaks (unlike `module_binding_references`, which does scope catch params).

Also: a TS `enum` produces no entry in `declared_bindings` (only var/fn/class are collected); decorators are unsupported by the parser config and surface as a parse error rather than a panic.

## Quality gates (run in `crates/`)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green, 0 failures

roadmap.yml untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)