### PR TITLE
test(samples): class & style binding E2E cases

### DIFF
--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <div class="box" :class="{active: on}" :style="{color: hue}" @click="go()"></div>
+script:
+    let on = false
+    let hue = "gray"
+    function go(){ on = true; hue = "red" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="box active" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="box" style="color: gray;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_reactive_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".box").attr("class", "box");
+  expect(".box").attr("style", "color: gray;");
+  await click(".box");
+  expect(".box").attr("class", "box active");
+  expect(".box").attr("style", "color: red;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_static_and_dynamic/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_static_and_dynamic/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="base" style="color: black;" :class="{active: true}" :style="{fontWeight: 'bold'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_static_and_dynamic/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_and_style_both_static_and_dynamic/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base active" style="color: black; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="[true, false, 'a']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "bare boolean literal true in an array -- non-string/array/object goes through String(value) so `true` leaks as literal text; false is dropped"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_boolean_literal_items/expected.html
@@ -1,0 +1,1 @@
+<div><div class="true a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_dashed_names/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_dashed_names/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['is-active', 'has-error']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_dashed_names/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_dashed_names/expected.html
@@ -1,0 +1,1 @@
+<div><div class="is-active has-error"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_deeply_nested/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_deeply_nested/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', ['b', ['c', ['d', 'e']]]]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_deeply_nested/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_deeply_nested/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c d e"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_duplicate_classes/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_duplicate_classes/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['dup', 'dup', 'other']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_duplicate_classes/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_duplicate_classes/expected.html
@@ -1,0 +1,1 @@
+<div><div class="dup dup other"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_empty/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="base" :class="[]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_filtering/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_filtering/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', false, null, undefined, '', 'b']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_filtering/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_filtering/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['a', 0, zero, 'b']"></div>
+script:
+    let zero = 0

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "known quirk: falsy number 0 leaks as literal \"0\" text in :class arrays (normClass only filters null/false, not 0)"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_falsy_number_zero_quirk/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a 0 0 b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <div class="tgt" :class="tags"></div>
+        <button class="add" @click="addTag()">add</button>
+        <button class="rm" @click="removeTag()">rm</button>
+    </div>
+script:
+    let tags = ["a", "b"]
+    function addTag(){ tags = [...tags, "c"] }
+    function removeTag(){ tags = tags.slice(0, -1) }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div class="tgt a c"></div><button class="add">add</button><button class="rm">rm</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/expected.html
@@ -1,0 +1,1 @@
+<div><div><div class="tgt a b"></div><button class="add">add</button><button class="rm">rm</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_add_remove_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("class", "tgt a b");
+  await click(".rm");
+  expect(".tgt").attr("class", "tgt a");
+  await click(".add");
+  expect(".tgt").attr("class", "tgt a c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :class="['base', show && 'visible']" @click="toggle()"></div>
+script:
+    let show = true
+    function toggle(){ show = !show }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="base visible"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base visible"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_item_toggle_between_string_and_false_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".base").attr("class", "base visible");
+  await click(".base");
+  expect(".base").attr("class", "base");
+  await click(".base");
+  expect(".base").attr("class", "base visible");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_merge_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_merge_static/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="base" :class="['a', 'b']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_merge_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_merge_static/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_mixed_all_forms/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_mixed_all_forms/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :class="['a', {b: true}, ['c', cond && 'd'], count > 0 && 'e']"></div>
+script:
+    let cond = true
+    let count = 1

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_mixed_all_forms/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_mixed_all_forms/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c d e"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_negation_operator/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_negation_operator/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['a', !hidden && 'visible']"></div>
+script:
+    let hidden = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_negation_operator/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_negation_operator/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a visible"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_nested_arrays/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_nested_arrays/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', ['b', 'c'], ['d', ['e']]]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_nested_arrays/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_nested_arrays/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c d e"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="[count]"></div>
+script:
+    let count = 42

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "non-string/array/object array items go through String(value) in normClass"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_number_coerced_string_value/expected.html
@@ -1,0 +1,1 @@
+<div><div class="42"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_of_objects_only/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_of_objects_only/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="[{a: true}, {b: false}, {c: true}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_of_objects_only/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_of_objects_only/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a c"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :class="expr" @click="swap()"></div>
+script:
+    let expr = ["a", "b"]
+    function swap(){ expr = {c: true, d: false} }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt c"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_toggle_whole_expr_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("class", "tgt a b");
+  await click(".tgt");
+  expect(".tgt").attr("class", "tgt c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :class="['base', extra]" @click="swap()"></div>
+script:
+    let extra = "one"
+    function swap(){ extra = "two" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="base two"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base one"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_reactive_var_swap/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".base").attr("class", "base one");
+  await click(".base");
+  expect(".base").attr("class", "base two");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_single_item/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_single_item/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['solo']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_single_item/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_single_item/expected.html
@@ -1,0 +1,1 @@
+<div><div class="solo"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_strings/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_strings/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', 'b', 'c']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_strings/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_strings/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_ternary_item/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_ternary_item/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['base', cond ? 'on' : 'off']"></div>
+script:
+    let cond = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_ternary_item/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_ternary_item/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base off"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['a', cond && 'b']"></div>
+script:
+    let cond = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['a', cond && 'b']"></div>
+script:
+    let cond = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_logical_and_false/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_object/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_object/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', {b: true, c: false}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_object/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_object/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_ternary_and_object/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_ternary_and_object/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :class="[mode === 'a' ? 'mode-a' : 'mode-b', {loading: busy}]"></div>
+script:
+    let mode = "a"
+    let busy = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_ternary_and_object/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_ternary_and_object/expected.html
@@ -1,0 +1,1 @@
+<div><div class="mode-a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="['a', cls]"></div>
+script:
+    let cls = "b"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_array_with_var/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="isOn"></div>
+script:
+    let isOn = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "false alone short-circuits normClass's null/false check and yields empty string"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="isOn"></div>
+script:
+    let isOn = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "a bare boolean bound directly (not wrapped in object/array) goes through the non-string/array/object String(value) branch"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_bool_var_direct_not_object/expected.html
@@ -1,0 +1,1 @@
+<div><div class="true"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_deeply_nested_object_in_array/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_deeply_nested_object_in_array/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="['a', [{b: true}, ['c', {d: false, e: true}]]]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_deeply_nested_object_in_array/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_deeply_nested_object_in_array/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c e"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_dynamic_only_no_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_dynamic_only_no_static/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="'solo'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_dynamic_only_no_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_dynamic_only_no_static/expected.html
@@ -1,0 +1,1 @@
+<div><div class="solo"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <div class="one" :class="{on: onA}" @click="toggleA()"></div>
+        <div class="two" :class="{on: onB}" @click="toggleB()"></div>
+    </div>
+script:
+    let onA = false
+    let onB = true
+    function toggleA(){ onA = !onA }
+    function toggleB(){ onB = !onB }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div class="one on"></div><div class="two"></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/expected.html
@@ -1,0 +1,1 @@
+<div><div><div class="one"></div><div class="two on"></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_multi_elements_independent_state_click/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ $, click, expect }) => {
+  expect(".one").attr("class", "one");
+  expect(".two").attr("class", "two on");
+  await click(".one");
+  expect(".one").attr("class", "one on");
+  expect(".two").attr("class", "two on");
+  await click(".two");
+  expect(".one").attr("class", "one on");
+  expect(".two").attr("class", "two");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_all_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_all_false/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="base" :class="{a: false, b: false}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_all_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_all_false/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_computed_key/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_computed_key/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{[keyName]: true}"></div>
+script:
+    let keyName = "dynamic"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_computed_key/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_computed_key/expected.html
@@ -1,0 +1,1 @@
+<div><div class="dynamic"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_dashed_key/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_dashed_key/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{'is-active': true, 'is-hidden': false}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_dashed_key/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_dashed_key/expected.html
@@ -1,0 +1,1 @@
+<div><div class="is-active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_empty/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="base" :class="{}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_expression_values/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_expression_values/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{big: count > 5, small: count <= 5}"></div>
+script:
+    let count = 10

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_expression_values/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_expression_values/expected.html
@@ -1,0 +1,1 @@
+<div><div class="big"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_falsy_values_null_undefined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_falsy_values_null_undefined/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{a: null, b: undefined, c: 0, d: '', e: true}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_falsy_values_null_undefined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_falsy_values_null_undefined/expected.html
@@ -1,0 +1,1 @@
+<div><div class="e"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{'has space key': true}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "class name with an embedded space -- documents raw passthrough behavior (may produce an odd but valid class token)"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_quoted_with_space/expected.html
@@ -1,0 +1,1 @@
+<div><div class="has space key"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_with_number_like_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_with_number_like_string/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{'2fast': true}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_with_number_like_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_key_with_number_like_string/expected.html
@@ -1,0 +1,1 @@
+<div><div class="2fast"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div class="base" :class="{active: on}"></div>
+script:
+    let on = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static_multi/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static_multi/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="base extra" :class="{active: on, hidden: off}"></div>
+script:
+    let on = true
+    let off = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static_multi/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_merge_static_multi/expected.html
@@ -1,0 +1,1 @@
+<div><div class="base extra active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_multi_mixed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_multi_mixed/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{active: true, disabled: false, hidden: true}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_multi_mixed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_multi_mixed/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active hidden"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_negated_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_negated_condition/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{hidden: !visible}"></div>
+script:
+    let visible = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_negated_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_negated_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_nested_prop_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_nested_prop_condition/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{ready: state.ready}"></div>
+script:
+    let state = {ready: true}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_nested_prop_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_nested_prop_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div class="ready"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_numeric_value_truthy/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_numeric_value_truthy/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{active: 1, disabled: 0}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_numeric_value_truthy/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_numeric_value_truthy/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <ul>
+        <li class="item" :class="{selected: sel === 1}" @click="pick(1)">one</li>
+        <li class="item" :class="{selected: sel === 2}" @click="pick(2)">two</li>
+    </ul>
+script:
+    let sel = 1
+    function pick(n){ sel = n }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><ul><li class="item">one</li><li class="item selected">two</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li class="item selected">one</li><li class="item">two</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_multi_flags_click/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $$, click, expect }) => {
+  const items = $$(".item");
+  expect(items[0]).attr("class", "item selected");
+  expect(items[1]).attr("class", "item");
+  await click(items[1]);
+  expect(items[0]).attr("class", "item");
+  expect(items[1]).attr("class", "item selected");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :class="{active: on}" @click="toggle()"></div>
+script:
+    let on = false
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_toggle_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("class", "tgt");
+  await click(".tgt");
+  expect(".tgt").hasClass("active");
+  await click(".tgt");
+  expect(".tgt").attr("class", "tgt");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{active: on}"></div>
+script:
+    let on = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_reactive_var/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_shorthand_like_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_shorthand_like_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="{active}"></div>
+script:
+    let active = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_shorthand_like_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_shorthand_like_var/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_false/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{active: false}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_true/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{active: true}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_single_true/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_string_value_truthy/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_string_value_truthy/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="{active: 'yes', disabled: ''}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_string_value_truthy/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_string_value_truthy/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <div class="box" :class="{active: activeFlag, error: errorFlag}" @click="toggleActive()"></div>
+        <button @click="toggleError()">err</button>
+    </div>
+script:
+    let activeFlag = false
+    let errorFlag = false
+    function toggleActive(){ activeFlag = !activeFlag }
+    function toggleError(){ errorFlag = !errorFlag }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div class="box active error"></div><button>err</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><div class="box"></div><button>err</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_two_keys_independent_toggle/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".box").attr("class", "box");
+  await click(".box");
+  expect(".box").attr("class", "box active");
+  await click("button");
+  expect(".box").attr("class", "box active error");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_via_function_call/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_via_function_call/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :class="classes()"></div>
+script:
+    let on = true
+    function classes(){ return {active: on, off: !on} }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_via_function_call/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_object_via_function_call/expected.html
@@ -1,0 +1,1 @@
+<div><div class="active"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="box" :class="items" @click="add()"></div>
+script:
+    let items = ["a"]
+    function add(){ items = [...items, "b"] }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="box a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="box a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_array_push_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".box").attr("class", "box a");
+  await click(".box");
+  expect(".box").attr("class", "box a b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :class="expr" @click="swap()"></div>
+script:
+    let expr = {a: true, b: false}
+    function swap(){ expr = "plain-string" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt plain-string"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_full_expr_replace_object_to_string_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("class", "tgt a");
+  await click(".tgt");
+  expect(".tgt").attr("class", "tgt plain-string");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="box" :class="flags" @click="addFlag()"></div>
+script:
+    let flags = {a: true}
+    function addFlag(){ flags = {...flags, b: true} }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="box a b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="box a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_reactive_object_add_key_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".box").attr("class", "box a");
+  await click(".box");
+  expect(".box").attr("class", "box a b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_static_only_no_dynamic_control/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_static_only_no_dynamic_control/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div class="plain static"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_static_only_no_dynamic_control/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_static_only_no_dynamic_control/expected.html
@@ -1,0 +1,1 @@
+<div><div class="plain static"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_concat_template/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_concat_template/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="`item-${kind}`"></div>
+script:
+    let kind = "primary"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_concat_template/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_concat_template/expected.html
@@ -1,0 +1,1 @@
+<div><div class="item-primary"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_empty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="cls"></div>
+script:
+    let cls = ""

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_interpolated_static_attr_merge/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_interpolated_static_attr_merge/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tag ${flavor}" :class="{hot: isHot}"></div>
+script:
+    let flavor = "sweet"
+    let isHot = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_interpolated_static_attr_merge/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_interpolated_static_attr_merge/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tag hot"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_only_whitespace/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_only_whitespace/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="'   '"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_only_whitespace/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_only_whitespace/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :class="cls" @click="swap()"></div>
+script:
+    let cls = "a"
+    function swap(){ cls = "b" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt b"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt a"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_toggle/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("class", "tgt a");
+  await click(".tgt");
+  expect(".tgt").attr("class", "tgt b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="cls"></div>
+script:
+    let cls = "alpha beta"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_reactive_var/expected.html
@@ -1,0 +1,1 @@
+<div><div class="alpha beta"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_static_literal/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_static_literal/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="'foo'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_static_literal/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_static_literal/expected.html
@@ -1,0 +1,1 @@
+<div><div class="foo"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="cond ? 'yes' : 'no'"></div>
+script:
+    let cond = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary/expected.html
@@ -1,0 +1,1 @@
+<div><div class="yes"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :class="cond ? 'yes' : 'no'"></div>
+script:
+    let cond = false

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_ternary_false/expected.html
@@ -1,0 +1,1 @@
+<div><div class="no"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_whitespace_collapse/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_whitespace_collapse/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :class="'  a   b  c '"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_whitespace_collapse/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_string_whitespace_collapse/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a b c"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <ul>
+        <li class="row" :for="item of items" :key="item.id" :class="{done: item.done}" @click="toggle(item.id)">${item.label}</li>
+    </ul>
+script:
+    let items = [{id:1,label:"a",done:false},{id:2,label:"b",done:true}]
+    function toggle(id){ items = items.map(it => it.id === id ? {...it, done: !it.done} : it) }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><ul><li class="row done">a</li><li class="row done">b</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li class="row">a</li><li class="row done">b</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/class_toggle_via_for_loop_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, click, expect }) => {
+  const rows = $$(".row");
+  expect(rows[0]).attr("class", "row");
+  expect(rows[1]).attr("class", "row done");
+  await click(rows[0]);
+  expect(rows[0]).attr("class", "row done");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="[0, false, 'color: red;']"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "raw non-object/array/string items in a style array: normStyle recurses and stringifies; documents actual leak behavior"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_boolean_and_number_items/expected.html
@@ -1,0 +1,1 @@
+<div><div style="0; color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_empty/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: blue;" :style="[]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_falsy_entries_dropped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_falsy_entries_dropped/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="[{color: 'red'}, false, null, {fontWeight: 'bold'}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_falsy_entries_dropped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_falsy_entries_dropped/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_nested_arrays/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_nested_arrays/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="[[{color: 'red'}], [{fontWeight: 'bold'}]]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_nested_arrays/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_nested_arrays/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="[{color: 'red'}, {fontWeight: 'bold'}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="[{color: 'red'}, {color: 'blue'}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "later array entries win for the same CSS property (left-to-right merge)"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_of_objects_override/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :style="[{color: hue}]" @click="swap()"></div>
+script:
+    let hue = "orange"
+    function swap(){ hue = "cyan" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: cyan;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: orange;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_reactive_swap_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: orange;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: cyan;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_string_and_object/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_string_and_object/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="['color: red;', {fontWeight: 'bold'}]"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_string_and_object/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_string_and_object/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_with_reactive_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_with_reactive_var/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :style="[base, {color: hue}]"></div>
+script:
+    let base = "font-weight: bold;"
+    let hue = "teal"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_with_reactive_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_array_with_reactive_var/expected.html
@@ -1,0 +1,1 @@
+<div><div style="font-weight: bold; color: teal;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_dynamic_only_no_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_dynamic_only_no_static/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'color: teal;'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_dynamic_only_no_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_dynamic_only_no_static/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: teal;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <div class="one" :style="{color: c1}" @click="cyc1()"></div>
+        <div class="two" :style="{color: c2}" @click="cyc2()"></div>
+    </div>
+script:
+    let c1 = "red"
+    let c2 = "blue"
+    function cyc1(){ c1 = "green" }
+    function cyc2(){ c2 = "yellow" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div class="one" style="color: green;"></div><div class="two" style="color: yellow;"></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/expected.html
@@ -1,0 +1,1 @@
+<div><div><div class="one" style="color: red;"></div><div class="two" style="color: blue;"></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multi_elements_independent_state_click/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ $, click, expect }) => {
+  expect(".one").attr("style", "color: red;");
+  expect(".two").attr("style", "color: blue;");
+  await click(".one");
+  expect(".one").attr("style", "color: green;");
+  expect(".two").attr("style", "color: blue;");
+  await click(".two");
+  expect(".two").attr("style", "color: yellow;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: red; font-weight: bold;" :style="{fontSize: '1em', color: 'blue'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "static wins position-wise (comes first in string) but same-name dynamic prop is simply appended after -- both end up in output since normStyle doesn't dedupe against the static string"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_multiple_static_merge_order/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold; font-size: 1em; color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :style="styleObj" @click="toggle()"></div>
+script:
+    let styleObj = {color: "red"}
+    function toggle(){ styleObj = styleObj.border ? {color: "red"} : {color: "red", border: "1px solid black"} }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_add_remove_property_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: red;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: red; border: 1px solid black;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: red;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_background_color/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_background_color/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{backgroundColor: 'yellow'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_background_color/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_background_color/expected.html
@@ -1,0 +1,1 @@
+<div><div style="background-color: yellow;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_font_size/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_font_size/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{fontSize: '12px'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_font_size/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_camel_case_font_size/expected.html
@@ -1,0 +1,1 @@
+<div><div style="font-size: 12px;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_conditional_value_ternary/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_conditional_value_ternary/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :style="{color: big ? 'red' : 'blue'}"></div>
+script:
+    let big = true

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_conditional_value_ternary/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_conditional_value_ternary/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{'--main-color': 'red', color: 'var(--main-color)'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property/expected.html
@@ -1,0 +1,1 @@
+<div><div style="--main-color: red; color: var(--main-color);"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{'--myCamelVar': '10px'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "custom properties preserve case; only plain camelCase CSS prop names get kebab-cased"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_custom_property_camel_untouched/expected.html
@@ -1,0 +1,1 @@
+<div><div style="--myCamelVar: 10px;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_empty/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: blue;" :style="{}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_falsy_values_dropped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_falsy_values_dropped/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{color: 'red', display: null, visibility: undefined, opacity: false}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_falsy_values_dropped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_falsy_values_dropped/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{'font-size': '10px', color: 'red'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "already-kebab keys pass through camelToKebab unchanged"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_hyphenated_key_passthrough/expected.html
@@ -1,0 +1,1 @@
+<div><div style="font-size: 10px; color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_important_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_important_value/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{color: 'red !important'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_important_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_important_value/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red !important;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: blue;" :style="{fontSize: '2em'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue; font-size: 2em;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static_no_semicolon/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static_no_semicolon/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: blue" :style="{fontSize: '2em'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static_no_semicolon/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_merge_static_no_semicolon/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue; font-size: 2em;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multi_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multi_props/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{color: 'red', fontSize: '12px', fontWeight: 'bold'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multi_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multi_props/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-size: 12px; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{a: '', b: 0, c: null, d: false, e: undefined, color: 'red'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "empty string is falsy for CSS values too since normStyle checks `v == null || v === false` only -- so empty string SURVIVES as `a: ;` -- verify actual behavior via UPDATE_EXPECTED"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_falsy_types_mixed/expected.html
@@ -1,0 +1,1 @@
+<div><div style="a: ; b: 0; color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <div class="tgt" :style="{color: hue, fontSize: size}" @click="grow()"></div>
+script:
+    let hue = "red"
+    let size = "10px"
+    function grow(){ size = "20px"; hue = "green" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: green; font-size: 20px;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red; font-size: 10px;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_multiple_reactive_props_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: red; font-size: 10px;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: green; font-size: 20px;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_nested_prop_source/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_nested_prop_source/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :style="{color: theme.color}"></div>
+script:
+    let theme = {color: "purple"}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_nested_prop_source/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_nested_prop_source/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: purple;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_number_zero_string_concat/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_number_zero_string_concat/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{margin: 0}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_number_zero_string_concat/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_number_zero_string_concat/expected.html
@@ -1,0 +1,1 @@
+<div><div style="margin: 0;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_numeric_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_numeric_value/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{width: 100, height: 50}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_numeric_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_numeric_value/expected.html
@@ -1,0 +1,1 @@
+<div><div style="width: 100; height: 50;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :style="{color: hue}" @click="go()"></div>
+script:
+    let hue = "red"
+    function go(){ hue = "blue" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_toggle_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: red;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: blue;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :style="{color: hue}"></div>
+script:
+    let hue = "green"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_reactive_var/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: green;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_single_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_single_prop/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{color: 'red'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_single_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_single_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{content: '\';\''}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "a CSS value that itself contains a semicolon/quote -- documents raw passthrough (no escaping in normStyle)"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_value_with_semicolon_embedded/expected.html
@@ -1,0 +1,1 @@
+<div><div style="content: ';';"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_vendor_prefixed_key/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_vendor_prefixed_key/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{WebkitTransform: 'rotate(5deg)'}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_vendor_prefixed_key/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_vendor_prefixed_key/expected.html
@@ -1,0 +1,1 @@
+<div><div style="-webkit-transform: rotate(5deg);"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_via_function_call/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_via_function_call/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :style="styles()"></div>
+script:
+    let hue = "navy"
+    function styles(){ return {color: hue} }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_via_function_call/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_via_function_call/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: navy;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="{opacity: 0, zIndex: 0}"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/_config.json
@@ -1,0 +1,3 @@
+{
+  "description": "0 is a legit CSS value (unlike class truthiness) and normStyle only drops null/false, so opacity:0/zIndex:0 should render"
+}

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_object_zero_value_kept/expected.html
@@ -1,0 +1,1 @@
+<div><div style="opacity: 0; z-index: 0;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :style="expr" @click="swap()"></div>
+script:
+    let expr = {color: "red"}
+    function swap(){ expr = "color: blue; font-weight: bold;" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: blue; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_reactive_full_expr_replace_object_to_string_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: red;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: blue; font-weight: bold;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_static_only_no_dynamic_control/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_static_only_no_dynamic_control/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div style="color: red; margin: 0;"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_static_only_no_dynamic_control/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_static_only_no_dynamic_control/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; margin: 0;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_empty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :style="s"></div>
+script:
+    let s = ""

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_important/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_important/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'color: red !important;'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_important/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_important/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red !important;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_multi_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_multi_props/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'color: red; font-weight: bold;'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_multi_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_multi_props/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-weight: bold;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_no_semicolon/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_no_semicolon/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'color: green'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_no_semicolon/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_no_semicolon/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: green"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_computed_template/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_computed_template/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :style="`color: ${hue}; font-size: ${size}px;`"></div>
+script:
+    let hue = "red"
+    let size = 14

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_computed_template/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_computed_template/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red; font-size: 14px;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="tgt" :style="s" @click="swap()"></div>
+script:
+    let s = "color: red;"
+    function swap(){ s = "color: blue;" }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tgt" style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_toggle_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".tgt").attr("style", "color: red;");
+  await click(".tgt");
+  expect(".tgt").attr("style", "color: blue;");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_var/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :style="s"></div>
+script:
+    let s = "color: blue;"

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_reactive_var/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_static_literal/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_static_literal/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'color: red;'"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_static_literal/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_static_literal/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_whitespace/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_whitespace/App.lunas
@@ -1,0 +1,3 @@
+html:
+    <div :style="'  color:   red;  '"></div>
+script:

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_whitespace/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_string_whitespace/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color:   red;"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <ul>
+        <li class="row" :for="item of items" :key="item.id" :style="{color: item.hue}" @click="cycle(item.id)">${item.label}</li>
+    </ul>
+script:
+    let items = [{id:1,label:"a",hue:"red"},{id:2,label:"b",hue:"blue"}]
+    function cycle(id){ items = items.map(it => it.id === id ? {...it, hue: "green"} : it) }

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><ul><li class="row" style="color: green;">a</li><li class="row" style="color: blue;">b</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li class="row" style="color: red;">a</li><li class="row" style="color: blue;">b</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/class_style/style_toggle_via_for_loop_click/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, click, expect }) => {
+  const rows = $$(".row");
+  expect(rows[0]).attr("style", "color: red;");
+  expect(rows[1]).attr("style", "color: blue;");
+  await click(rows[0]);
+  expect(rows[0]).attr("style", "color: green;");
+};


### PR DESCRIPTION
## Summary

Mass-produces E2E sample cases for the Lunas framework's `:class` / `:style` binding behavior, using the sample-directory harness (`crates/lunas_compiler/tests/runtime/samples/class_style/`). Adds **119 new cases** on top of the 2 existing seed cases (`class_merge`, `style_bind`), for **121 total** in the category.

Coverage:
- **`:class` string form** — static literal, reactive var, template concat, empty, whitespace collapse, ternary, reactive toggle via click.
- **`:class` object form** — single/multi keys, reactive vars, computed `[key]`, dashed keys, expression values, shorthand `{active}`, static-class merge, empty object, all-false, numeric/string truthiness, nested prop conditions, multi-flag independent toggles.
- **`:class` array form** — plain strings, vars, `&&` guards, objects-in-array, array-of-objects, nested arrays (incl. deep), mixed forms, falsy filtering, static merge, reactive swap, add/remove items, duplicates, dashed names, ternary items, whole-expression swap (array → object).
- **`:style` string form** — literal, reactive var, no-semicolon, multi-prop, empty, whitespace, `!important`, reactive toggle.
- **`:style` object form** — single/multi props, camelCase→kebab (`fontSize`, `backgroundColor`), numeric values, reactive vars, falsy-value dropping, `0` retained (legit CSS value), custom properties (`--x`), vendor-prefixed keys (`WebkitTransform`), static merge (with/without trailing `;`), `!important`, function-returned style object, ternary/nested-prop values, multi-prop reactive updates.
- **`:style` array form** — array of objects, left-to-right override, string+object mix, reactive var, empty, falsy entries dropped, nested arrays, reactive swap.
- **Reactivity via `steps.mjs`** — click-driven flag/value toggles, whole-expression swaps (object↔string↔array), array item add/remove, multiple independently-toggling elements, `:for`-loop bound class/style per item, combined `:class`+`:style` reactive updates.
- **Edge cases** — both static class/style plus dynamic bind present together, bare boolean/number bound directly to `:class`, dashed/quoted-with-space class keys, hyphenated style keys passed through unchanged, merge ordering with duplicate static+dynamic props.

### Surprises / documented runtime quirks (not fixed — captured as-is per instructions, noted in each case's `_config.json` description)

- A falsy **number `0`** inside a `:class` array (literal or reactive var) leaks as the literal string `"0"` — `normClass` only special-cases `null`/`false`, not `0`. See `class_array_falsy_number_zero_quirk`.
- A **bare non-string/array/object value** bound directly to `:class` (e.g. a bare `true`/`42`) falls through to `String(value)` and leaks as text — see `class_bool_var_direct_not_object`, `class_array_number_coerced_string_value`, `class_array_boolean_literal_items`.
- Same leak shape applies to raw booleans/numbers appearing directly inside a `:style` array (`style_array_boolean_and_number_items`).
- An **empty string** style value survives `normStyle`'s falsy check (`v == null || v === false` only) and renders as `prop: ;` — see `style_object_multiple_falsy_types_mixed`.
- `0` **is** retained for `:style` object values (unlike `:class` truthiness) since it's a legitimate CSS value — `style_object_zero_value_kept`.

All 121 cases compile with no diagnostics and pass `cargo test -p lunas_compiler --test runtime_samples`; generated `expected.html` / `expected.after.html` files are committed.

## Test plan

- [x] `UPDATE_EXPECTED=1 cargo test -p lunas_compiler --test runtime_samples` — regenerated and reviewed all `expected*.html` diffs.
- [x] `cargo test -p lunas_compiler --test runtime_samples` (no env var) — 147/147 pass, including the 121 in `class_style/`.
- [x] `cargo fmt --check` — clean (no Rust files touched; harness/build.rs untouched).
- [x] Scope check — only new directories under `samples/class_style/` added; no edits to harness, other categories, or `roadmap.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)