### PR TITLE
test(samples): conditional rendering (:if) E2E cases

### DIFF
--- a/crates/lunas_compiler/tests/runtime/samples/if/adjacent_independent_cascades/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/adjacent_independent_cascades/App.lunas
@@ -1,0 +1,12 @@
+html:
+    <div>
+        <p :if="a">A true</p>
+        <p :else>A false</p>
+        <span :if="b">B true</span>
+        <span :elseif="bc">B-c true</span>
+        <span :else>B false</span>
+    </div>
+script:
+    let a = true
+    let b = false
+    let bc = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/adjacent_independent_cascades/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/adjacent_independent_cascades/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>A true</p><span>B-c true</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/arithmetic_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/arithmetic_condition/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="total % 2 == 0">even</span></div>
+script:
+    let total = 8

--- a/crates/lunas_compiler/tests/runtime/samples/if/arithmetic_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/arithmetic_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>even</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/array_includes_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/array_includes_condition/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="tags.includes('vip')">vip badge</span></div>
+script:
+    let tags = ["new", "vip"]

--- a/crates/lunas_compiler/tests/runtime/samples/if/array_includes_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/array_includes_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>vip badge</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/blank_lines_between_branches/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/blank_lines_between_branches/App.lunas
@@ -1,0 +1,13 @@
+html:
+    <div>
+        <p :if="a">A</p>
+
+
+        <p :elseif="b">B</p>
+
+
+        <p :else>C</p>
+    </div>
+script:
+    let a = false
+    let b = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/blank_lines_between_branches/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/blank_lines_between_branches/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>C</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_attr_bind/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_attr_bind/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <a :if="show" :href="url">link</a>
+        <span :else>no link</span>
+    </div>
+script:
+    let show = true
+    let url = "/home"

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_attr_bind/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_attr_bind/expected.html
@@ -1,0 +1,1 @@
+<div><div><a href="/home">link</a></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <button :if="on" @click="inc()">plus (${n})</button>
+    </div>
+script:
+    let on = false
+    let n = 0
+    function toggle(){ on = !on }
+    function inc(){ n = n + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><button>plus (2)</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_button_increments_after_show/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $$, click, expect }) => {
+  expect("button").count(1);
+  await click($$("button")[0]);
+  expect("button").count(2);
+  const plus = $$("button")[1];
+  expect(plus).text("plus (0)");
+  await click(plus);
+  expect(plus).text("plus (1)");
+  await click(plus);
+  expect(plus).text("plus (2)");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_class_bind/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_class_bind/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="show" class="msg" :class="{ warn: isWarn }">Alert</p>
+        <p :else>Quiet</p>
+    </div>
+script:
+    let show = true
+    let isWarn = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_class_bind/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_class_bind/expected.html
@@ -1,0 +1,1 @@
+<div><div><p class="msg warn">Alert</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/App.lunas
@@ -1,0 +1,13 @@
+html:
+    <div>
+        <button @click="reveal()">reveal</button>
+        <div :if="shown">
+            <button @click="bump()">bump</button>
+            <span>count: ${n}</span>
+        </div>
+    </div>
+script:
+    let shown = false
+    let n = 0
+    function reveal(){ shown = true }
+    function bump(){ n = n + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>reveal</button><div><button>bump</button><span>count: 2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>reveal</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_event_inside_click/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $$, click, expect }) => {
+  expect("span").count(0);
+  await click($$("button")[0]);
+  expect("span").count(1);
+  expect("span").text("count: 0");
+  const bumpBtn = $$("button")[1];
+  await click(bumpBtn);
+  expect("span").text("count: 1");
+  await click(bumpBtn);
+  expect("span").text("count: 2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multi_element/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multi_element/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div :if="show">
+        <h1>Title</h1>
+        <p>Body text</p>
+        <footer>Footer</footer>
+    </div>
+script:
+    let show = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multi_element/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multi_element/expected.html
@@ -1,0 +1,1 @@
+<div><div><h1>Title</h1><p>Body text</p><footer>Footer</footer></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/App.lunas
@@ -1,0 +1,15 @@
+html:
+    <div>
+        <button @click="show()">show</button>
+        <div :if="visible">
+            <button @click="inc()">inc</button>
+            <button @click="dec()">dec</button>
+            <span>${n}</span>
+        </div>
+    </div>
+script:
+    let visible = false
+    let n = 5
+    function show(){ visible = true }
+    function inc(){ n = n + 1 }
+    function dec(){ n = n - 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button><div><button>inc</button><button>dec</button><span>4</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_multiple_events/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $$, click, expect }) => {
+  expect("span").count(0);
+  await click($$("button")[0]);
+  expect("span").text("5");
+  const [, inc, dec] = $$("button");
+  await click(inc);
+  expect("span").text("6");
+  await click(dec);
+  await click(dec);
+  expect("span").text("4");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_style_bind/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_style_bind/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="show" :style="{ color: hue }">Colored</p>
+        <p :else>Plain</p>
+    </div>
+script:
+    let show = true
+    let hue = "green"

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_style_bind/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_style_bind/expected.html
@@ -1,0 +1,1 @@
+<div><div><p style="color: green;">Colored</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_text_bind/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_text_bind/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="show">Hello, ${name}!</p>
+        <p :else>Anonymous</p>
+    </div>
+script:
+    let show = true
+    let name = "Ada"

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_text_bind/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_text_bind/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Hello, Ada!</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/App.lunas
@@ -1,0 +1,12 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <div :if="editing">
+            <input ::value="draft">
+            <span>${draft}</span>
+        </div>
+    </div>
+script:
+    let editing = false
+    let draft = "hi"
+    function toggle(){ editing = !editing }

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><div><input><span>bye</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/branch_two_way_input/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $, click, setValue, expect }) => {
+  expect("input").count(0);
+  await click("button");
+  expect("input").count(1);
+  expect("span").text("hi");
+  await setValue("input", "bye");
+  expect("span").text("bye");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_battery/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_battery/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="pct <= 20">Low battery</p>
+        <p :elseif="pct <= 80">Charging fine</p>
+        <p :else>Full</p>
+    </div>
+script:
+    let pct = 100

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_battery/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_battery/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Full</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_grade/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_grade/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="score >= 90">A</p>
+        <p :elseif="score >= 70">B</p>
+        <p :else>C</p>
+    </div>
+script:
+    let score = 75

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_grade/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_grade/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>B</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_priority/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_priority/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="priority == 1">Urgent</p>
+        <p :elseif="priority == 2">Normal</p>
+        <p :else>Low</p>
+    </div>
+script:
+    let priority = 1

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_priority/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_priority/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Urgent</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_role/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_role/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="role == 'owner'">Owner</p>
+        <p :elseif="role == 'editor'">Editor</p>
+        <p :else>Viewer</p>
+    </div>
+script:
+    let role = "editor"

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_role/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_role/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Editor</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_shipping_status/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_shipping_status/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="status == 'delivered'">Delivered</p>
+        <p :elseif="status == 'shipped'">Shipped</p>
+        <p :else>Processing</p>
+    </div>
+script:
+    let status = "processing"

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_shipping_status/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_shipping_status/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Processing</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_size/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_size/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="w < 100">Small</p>
+        <p :elseif="w < 500">Medium</p>
+        <p :else>Large</p>
+    </div>
+script:
+    let w = 250

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_size/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_size/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Medium</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_stock_level/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_stock_level/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="stock == 0">Out of stock</p>
+        <p :elseif="stock < 5">Low stock</p>
+        <p :else>In stock</p>
+    </div>
+script:
+    let stock = 0

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_stock_level/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_stock_level/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Out of stock</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_temperature/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_temperature/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="temp < 0">Freezing</p>
+        <p :elseif="temp < 25">Cool</p>
+        <p :else>Warm</p>
+    </div>
+script:
+    let temp = 30

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_temperature/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_temperature/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Warm</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_traffic_light/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_traffic_light/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="light == 'red'">Stop</p>
+        <p :elseif="light == 'yellow'">Slow</p>
+        <p :else>Go</p>
+    </div>
+script:
+    let light = "yellow"

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_traffic_light/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_traffic_light/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Slow</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_weekday_weekend_holiday/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_weekday_weekend_holiday/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <p :if="isHoliday">Holiday</p>
+        <p :elseif="isWeekend">Weekend</p>
+        <p :else>Weekday</p>
+    </div>
+script:
+    let isHoliday = false
+    let isWeekend = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade3_weekday_weekend_holiday/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade3_weekday_weekend_holiday/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Weekend</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_grade_letters/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_grade_letters/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <p :if="score >= 90">A</p>
+        <p :elseif="score >= 80">B</p>
+        <p :elseif="score >= 70">C</p>
+        <p :else>F</p>
+    </div>
+script:
+    let score = 72

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_grade_letters/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_grade_letters/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>C</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_http_status/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_http_status/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <p :if="code == 200">OK</p>
+        <p :elseif="code == 404">Not Found</p>
+        <p :elseif="code == 500">Server Error</p>
+        <p :else>Unknown</p>
+    </div>
+script:
+    let code = 500

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_http_status/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_http_status/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Server Error</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_season/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_season/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <p :if="month <= 2 || month == 12">Winter</p>
+        <p :elseif="month <= 5">Spring</p>
+        <p :elseif="month <= 8">Summer</p>
+        <p :else>Fall</p>
+    </div>
+script:
+    let month = 9

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade4_season/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade4_season/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Fall</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade5_weekday_names/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade5_weekday_names/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <p :if="day == 1">Monday</p>
+        <p :elseif="day == 2">Tuesday</p>
+        <p :elseif="day == 3">Wednesday</p>
+        <p :elseif="day == 4">Thursday</p>
+        <p :else>Other</p>
+    </div>
+script:
+    let day = 4

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade5_weekday_names/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade5_weekday_names/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Thursday</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade_only_last_condition_matters/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade_only_last_condition_matters/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="n == 1">One</p>
+        <p :elseif="n == 1">One again (unreachable)</p>
+        <p :else>Not one</p>
+    </div>
+script:
+    let n = 1

--- a/crates/lunas_compiler/tests/runtime/samples/if/cascade_only_last_condition_matters/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cascade_only_last_condition_matters/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>One</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n == 5">five</span></div>
+script:
+    let n = 4

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n == 5">five</span></div>
+script:
+    let n = 5

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_eq_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>five</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_gt_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_gt_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="score > 90">excellent</span></div>
+script:
+    let score = 95

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_gt_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_gt_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>excellent</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_gte_boundary/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_gte_boundary/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n >= 10">in range</span></div>
+script:
+    let n = 10

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_gte_boundary/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_gte_boundary/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>in range</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_lt_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_lt_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="age < 18">minor</span></div>
+script:
+    let age = 10

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_lt_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_lt_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>minor</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_lte_boundary/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_lte_boundary/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n <= 10">in range</span></div>
+script:
+    let n = 10

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_lte_boundary/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_lte_boundary/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>in range</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_neq_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_neq_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n != 5">not five</span></div>
+script:
+    let n = 3

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_neq_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_neq_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>not five</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_not_strict_eq_types/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_not_strict_eq_types/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="n !== '1'">different types</span></div>
+script:
+    let n = 1

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_not_strict_eq_types/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_not_strict_eq_types/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>different types</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_strict_eq_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_strict_eq_string/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="mode === 'dark'">dark mode</span></div>
+script:
+    let mode = "dark"

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_strict_eq_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_strict_eq_string/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>dark mode</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_string_lex/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_string_lex/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="name > 'm'">late alphabet</span></div>
+script:
+    let name = "zed"

--- a/crates/lunas_compiler/tests/runtime/samples/if/cmp_string_lex/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cmp_string_lex/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>late alphabet</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/App.lunas
@@ -1,0 +1,12 @@
+html:
+    <div>
+        <button @click="left()">left</button>
+        <button @click="right()">right</button>
+        <p :if="pos == 0">Left</p>
+        <p :elseif="pos == 1">Middle</p>
+        <p :else>Right</p>
+    </div>
+script:
+    let pos = 1
+    function left(){ if (pos > 0) pos = pos - 1 }
+    function right(){ if (pos < 2) pos = pos + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>left</button><button>right</button><p>Left</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>left</button><button>right</button><p>Middle</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_back_and_forth/steps.mjs
@@ -1,0 +1,12 @@
+export default async ({ $$, click, expect }) => {
+  const [left, right] = $$("button");
+  expect("p").text("Middle");
+  await click(right);
+  expect("p").text("Right");
+  await click(left);
+  expect("p").text("Middle");
+  await click(left);
+  expect("p").text("Left");
+  await click(left);
+  expect("p").text("Left");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/App.lunas
@@ -1,0 +1,15 @@
+html:
+    <div>
+        <button @click="next()">next</button>
+        <p :if="mode == 'a'">Mode A</p>
+        <p :elseif="mode == 'b'">Mode B</p>
+        <p :elseif="mode == 'c'">Mode C</p>
+        <p :else>Mode D</p>
+    </div>
+script:
+    let mode = "a"
+    let order = ["a", "b", "c", "d"]
+    function next(){
+        let i = order.indexOf(mode)
+        mode = order[(i + 1) % 4]
+    }

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>next</button><p>Mode A</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>next</button><p>Mode A</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_four_way/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ click, expect }) => {
+  expect("p").text("Mode A");
+  await click("button");
+  expect("p").text("Mode B");
+  await click("button");
+  expect("p").text("Mode C");
+  await click("button");
+  expect("p").text("Mode D");
+  await click("button");
+  expect("p").text("Mode A");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <button @click="next()">next</button>
+        <p :if="step == 1">Step One</p>
+        <p :elseif="step == 2">Step Two</p>
+        <p :else>Step Three</p>
+    </div>
+script:
+    let step = 1
+    function next(){ step = step == 3 ? 1 : step + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>next</button><p>Step One</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>next</button><p>Step One</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/cycle_elseif_three_way/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, expect }) => {
+  expect("p").text("Step One");
+  await click("button");
+  expect("p").text("Step Two");
+  await click("button");
+  expect("p").text("Step Three");
+  await click("button");
+  expect("p").text("Step One");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/elseif_short_circuit_order/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/elseif_short_circuit_order/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="n > 0">Positive</p>
+        <p :elseif="n > -100">Small negative or zero</p>
+        <p :else>Very negative</p>
+    </div>
+script:
+    let n = 0

--- a/crates/lunas_compiler/tests/runtime/samples/if/elseif_short_circuit_order/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/elseif_short_circuit_order/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Small negative or zero</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="show()">show</button>
+        <p :if="visible">Now visible</p>
+    </div>
+script:
+    let visible = false
+    function show(){ visible = true }

--- a/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button><p>Now visible</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/false_initially_absent/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ click, expect }) => {
+  expect("p").count(0);
+  await click("button");
+  expect("p").count(1);
+  expect("p").text("Now visible");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_nan/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_nan/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="ratio">shown</span></div>
+script:
+    let ratio = 0 / 0

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_nan/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_nan/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_null/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_null/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="user">shown</span></div>
+script:
+    let user = null

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_null/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_null/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_negzero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_negzero/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="count">shown</span></div>
+script:
+    let count = -0

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_negzero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_negzero/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_zero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_zero/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="count">shown</span></div>
+script:
+    let count = 0

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_zero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_number_zero/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_string_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_string_empty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="label">shown</span></div>
+script:
+    let label = ""

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_string_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_string_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_undefined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_undefined/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="user">shown</span></div>
+script:
+    let user = undefined

--- a/crates/lunas_compiler/tests/runtime/samples/if/falsy_undefined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/falsy_undefined/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_else_item/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_else_item/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <ul>
+        <li :for="item of items" :key="item.id">
+            <span :if="item.active">${item.label} (on)</span>
+            <span :else>${item.label} (off)</span>
+        </li>
+    </ul>
+script:
+    let items = [{id:1,label:"a",active:true},{id:2,label:"b",active:false}]

--- a/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_else_item/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_else_item/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li><span>a (on)</span></li><li><span>b (off)</span></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_item/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_item/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <ul><li :for="n of nums" :key="n"><span :if="n % 2 == 0">even ${n}</span><em :else>odd ${n}</em></li></ul>
+script:
+    let nums = [1, 2, 3, 4, 5]

--- a/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_item/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/for_containing_if_item/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li><em>odd 1</em></li><li><span>even 2</span></li><li><em>odd 3</em></li><li><span>even 4</span></li><li><em>odd 5</em></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_containing_for/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_containing_for/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div :if="show">
+        <ul><li :for="item of items" :key="item">${item}</li></ul>
+    </div>
+script:
+    let show = true
+    let items = ["a", "b", "c"]

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_containing_for/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_containing_for/expected.html
@@ -1,0 +1,1 @@
+<div><div><ul><li>a</li><li>b</li><li>c</li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_array_length/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_array_length/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="items.length > 0">Has items</p>
+        <p :else>Empty</p>
+    </div>
+script:
+    let items = []

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_array_length/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_array_length/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Empty</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_bool/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_bool/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="on">ON</p>
+        <p :else>OFF</p>
+    </div>
+script:
+    let on = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_bool/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_bool/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>ON</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_comparison/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_comparison/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="score >= 60">Pass</p>
+        <p :else>Fail</p>
+    </div>
+script:
+    let score = 45

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_comparison/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_comparison/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Fail</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_logical/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_logical/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="a && b">Both</p>
+        <p :else>Not both</p>
+    </div>
+script:
+    let a = true
+    let b = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_logical/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_logical/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Not both</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_negated/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_negated/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="!ready">Loading</p>
+        <p :else>Ready</p>
+    </div>
+script:
+    let ready = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_negated/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_negated/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Loading</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_number_range/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_number_range/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="temp > 30">Hot</p>
+        <p :else>Mild</p>
+    </div>
+script:
+    let temp = 32

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_number_range/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_number_range/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Hot</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_prop_access/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_prop_access/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="user.active">Active</p>
+        <p :else>Inactive</p>
+    </div>
+script:
+    let user = { active: false }

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_prop_access/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_prop_access/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Inactive</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_string_match/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_string_match/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="lang == 'en'">Hello</p>
+        <p :else>Bonjour</p>
+    </div>
+script:
+    let lang = "fr"

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_else_string_match/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_else_string_match/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Bonjour</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_for_same_element_wrap/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_for_same_element_wrap/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <ul>
+        <li :for="n of nums" :key="n"><span :if="n > 2">${n}</span></li>
+    </ul>
+script:
+    let nums = [1, 2, 3, 4]

--- a/crates/lunas_compiler/tests/runtime/samples/if/if_for_same_element_wrap/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/if_for_same_element_wrap/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li></li><li></li><li><span>3</span></li><li><span>4</span></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_and_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_and_false/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="loggedIn && isAdmin">admin panel</span></div>
+script:
+    let loggedIn = true
+    let isAdmin = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_and_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_and_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_and_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_and_true/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="loggedIn && isAdmin">admin panel</span></div>
+script:
+    let loggedIn = true
+    let isAdmin = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_and_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_and_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>admin panel</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_combined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_combined/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <div><span :if="(a && b) || cc">shown</span></div>
+script:
+    let a = false
+    let b = true
+    let cc = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_combined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_combined/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_not_and/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_not_and/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="!loading && ready">content</span></div>
+script:
+    let loading = false
+    let ready = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_not_and/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_not_and/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>content</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_or_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_or_false/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="isGuest || isAdmin">visible</span></div>
+script:
+    let isGuest = false
+    let isAdmin = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_or_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_or_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_or_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_or_true/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="isGuest || isAdmin">visible</span></div>
+script:
+    let isGuest = false
+    let isAdmin = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/logical_or_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/logical_or_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>visible</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/method_call_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/method_call_condition/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="isValid()">valid</span></div>
+script:
+    let n = 4
+    function isValid(){ return n > 0 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/method_call_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/method_call_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>valid</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/multiple_attrs_per_branch/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/multiple_attrs_per_branch/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <a :if="loggedIn" :href="profileUrl" class="link" target="_blank">Profile</a>
+        <a :else href="/login" class="link">Login</a>
+    </div>
+script:
+    let loggedIn = true
+    let profileUrl = "/u/42"

--- a/crates/lunas_compiler/tests/runtime/samples/if/multiple_attrs_per_branch/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/multiple_attrs_per_branch/expected.html
@@ -1,0 +1,1 @@
+<div><div><a class="link" href="/u/42" target="_blank">Profile</a></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/negate_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/negate_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="!on">shown</span></div>
+script:
+    let on = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/negate_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/negate_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/negate_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/negate_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="!on">shown</span></div>
+script:
+    let on = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/negate_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/negate_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div :if="outer">
+        <p :if="inner">Both true</p>
+        <p :else>Outer only</p>
+    </div>
+script:
+    let outer = true
+    let inner = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>Outer only</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if_deeper/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if_deeper/App.lunas
@@ -1,0 +1,12 @@
+html:
+    <div :if="a">
+        <div :if="b">
+            <p :if="cond3">ABC</p>
+            <p :else>AB only</p>
+        </div>
+        <p :else>A only</p>
+    </div>
+script:
+    let a = true
+    let b = true
+    let cond3 = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if_deeper/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/nested_if_in_if_deeper/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><p>ABC</p></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_middle_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_middle_true/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="n == 1">one</p>
+        <p :elseif="n == 2">two</p>
+        <p :elseif="n == 3">three</p>
+    </div>
+script:
+    let n = 2

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_middle_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_middle_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>two</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_single_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_single_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><p :if="show">Message</p></div>
+script:
+    let show = false

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_single_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_single_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_three_branches_all_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_three_branches_all_false/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <p :if="n == 1">one</p>
+        <p :elseif="n == 2">two</p>
+        <p :elseif="n == 3">three</p>
+    </div>
+script:
+    let n = 9

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_three_branches_all_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_three_branches_all_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="reveal()">show</button>
+        <p :if="show">Surprise</p>
+    </div>
+script:
+    let show = false
+    function reveal(){ show = true }

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button><p>Surprise</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>show</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_toggle_appear/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ click, expect }) => {
+  expect("p").count(0);
+  await click("button");
+  expect("p").count(1);
+  expect("p").text("Surprise");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_all_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_all_false/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="page == 'a'">A page</p>
+        <p :elseif="page == 'b'">B page</p>
+    </div>
+script:
+    let page = "c"

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_all_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_all_false/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_first_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_first_true/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="page == 'a'">A page</p>
+        <p :elseif="page == 'b'">B page</p>
+    </div>
+script:
+    let page = "a"

--- a/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_first_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/noelse_two_branches_first_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>A page</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <span :if="ready">A</span>
+        <em :if="ready">B</em>
+        <i :if="!ready">C</i>
+    </div>
+script:
+    let ready = false
+    function toggle(){ ready = !ready }

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><span>A</span><em>B</em></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><i>C</i></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_three_ifs/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, expect }) => {
+  expect("span").count(0);
+  expect("em").count(0);
+  expect("i").count(1);
+  await click("button");
+  expect("span").count(1);
+  expect("em").count(1);
+  expect("i").count(0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <span :if="dark">Dark Icon</span>
+        <p :if="dark">Dark Label</p>
+    </div>
+script:
+    let dark = false
+    function toggle(){ dark = !dark }

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/one_var_drives_two_ifs/steps.mjs
@@ -1,0 +1,12 @@
+export default async ({ click, expect }) => {
+  expect("span").count(0);
+  expect("p").count(0);
+  await click("button");
+  expect("span").count(1);
+  expect("p").count(1);
+  expect("span").text("Dark Icon");
+  expect("p").text("Dark Label");
+  await click("button");
+  expect("span").count(0);
+  expect("p").count(0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/parenthesized_condition/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/parenthesized_condition/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span :if="(x + y) > 10">big sum</span></div>
+script:
+    let x = 6
+    let y = 6

--- a/crates/lunas_compiler/tests/runtime/samples/if/parenthesized_condition/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/parenthesized_condition/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>big sum</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/root_element_if/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/root_element_if/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :if="show" class="panel">Panel content</div>
+script:
+    let show = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/root_element_if/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/root_element_if/expected.html
@@ -1,0 +1,1 @@
+<div><div class="panel">Panel content</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/App.lunas
@@ -1,0 +1,16 @@
+html:
+    <div>
+        <button @click="toA()">a</button>
+        <button @click="toB()">b</button>
+        <div :if="page == 'a'">
+            <button @click="bump()">bump</button>
+            <span>${n}</span>
+        </div>
+        <p :else>Page B</p>
+    </div>
+script:
+    let page = "a"
+    let n = 0
+    function toA(){ page = "a" }
+    function toB(){ page = "b" }
+    function bump(){ n = n + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button><div><button>bump</button><span>2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button><div><button>bump</button><span>0</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_cascade_switch_resets/steps.mjs
@@ -1,0 +1,16 @@
+export default async ({ $$, click, expect }) => {
+  const [toA, toB] = $$("button");
+  const bumpBtn = () => $$("button")[2];
+  expect("span").text("0");
+  await click(bumpBtn());
+  await click(bumpBtn());
+  expect("span").text("2");
+  await click(toB);
+  expect("p").text("Page B");
+  expect("span").count(0);
+  await click(toA);
+  // `n` is component-level state, so it survived the cascade switch even
+  // though the branch's DOM (the <div>/<button>/<span>) was torn down and
+  // rebuilt fresh.
+  expect("span").text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="bump()">bump</button>
+        <p :if="n > 0">count is ${n}</p>
+        <p :else>zero</p>
+    </div>
+script:
+    let n = 0
+    function bump(){ n = n + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>bump</button><p>count is 2</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>bump</button><p>zero</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_persists_while_visible/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ click, expect }) => {
+  expect("p").text("zero");
+  await click("button");
+  expect("p").text("count is 1");
+  await click("button");
+  expect("p").text("count is 2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/App.lunas
@@ -1,0 +1,13 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <div :if="on">
+            <button @click="bump()">bump</button>
+            <span>${n}</span>
+        </div>
+    </div>
+script:
+    let on = true
+    let n = 0
+    function toggle(){ on = !on }
+    function bump(){ n = n + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><div><button>bump</button><span>2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><div><button>bump</button><span>0</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_counter_resets_on_hide/steps.mjs
@@ -1,0 +1,16 @@
+// `n` is component-level reactive state (not scoped to the branch), so it does
+// NOT reset when the branch is torn down and rebuilt — only the DOM nodes are
+// recreated. This documents that the *value* survives across hide/reshow while
+// the DOM subtree itself is a fresh mount each time.
+export default async ({ $$, click, expect }) => {
+  const toggleBtn = () => $$("button")[0];
+  const bumpBtn = () => $$("button")[1];
+  expect("span").text("0");
+  await click(bumpBtn());
+  await click(bumpBtn());
+  expect("span").text("2");
+  await click(toggleBtn()); // hide
+  expect("span").count(0);
+  await click(toggleBtn()); // reshow
+  expect("span").text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <input :if="on" placeholder="scratch">
+    </div>
+script:
+    let on = true
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><input placeholder="scratch"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><input placeholder="scratch"></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_input_resets_on_hide/steps.mjs
@@ -1,0 +1,13 @@
+// Un-bound local DOM state (an uncommitted input value with no ::value bind)
+// is genuinely destroyed on hide: the element itself is torn down, so a fresh
+// <input> mounts empty on reshow.
+export default async ({ $, click, setValue, expect }) => {
+  expect("input").count(1);
+  await setValue("input", "scratch note");
+  expect("input").value("scratch note");
+  await click("button"); // hide
+  expect("input").count(0);
+  await click("button"); // reshow
+  expect("input").count(1);
+  expect("input").value("");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <ul :if="on"><li :for="item of items" :key="item">${item}</li></ul>
+    </div>
+script:
+    let on = true
+    let items = ["x", "y"]
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><ul><li>x</li><li>y</li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><ul><li>x</li><li>y</li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_nested_for_rebuilds/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, expect }) => {
+  expect("li").count(2);
+  await click("button"); // hide
+  expect("ul").count(0);
+  expect("li").count(0);
+  await click("button"); // reshow rebuilds the for-list fresh from `items`
+  expect("li").count(2);
+  expect("li").text("x");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <span :if="on" class="tag">TAG</span>
+    </div>
+script:
+    let on = false
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><span class="tag">TAG</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_rebuild_off_on/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ click, expect }) => {
+  expect("span").count(0);
+  await click("button");
+  expect("span").count(1);
+  expect("span").attr("class", "tag");
+  await click("button");
+  expect("span").count(0);
+  await click("button");
+  expect("span").count(1);
+  expect("span").attr("class", "tag");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <header>Header</header>
+        <button @click="toggle()">toggle</button>
+        <p :if="on">Middle content</p>
+        <footer>Footer</footer>
+    </div>
+script:
+    let on = false
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><header>Header</header><button>toggle</button><p>Middle content</p><footer>Footer</footer></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/expected.html
@@ -1,0 +1,1 @@
+<div><div><header>Header</header><button>toggle</button><footer>Footer</footer></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/state_sibling_static_stays_put/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ expect, click }) => {
+  expect("header").text("Header");
+  expect("footer").text("Footer");
+  expect("p").count(0);
+  await click("button");
+  expect("header").text("Header");
+  expect("footer").text("Footer");
+  expect("p").count(1);
+  expect("p").text("Middle content");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/App.lunas
@@ -1,0 +1,11 @@
+html:
+    <div>
+        <button @click="add()">add</button>
+        <button @click="clear()">clear</button>
+        <p :if="items.length == 0">No items</p>
+        <p :else>${items.length} items</p>
+    </div>
+script:
+    let items = []
+    function add(){ items.push(items.length) }
+    function clear(){ items = [] }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><button>clear</button><p>No items</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><button>clear</button><p>No items</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_array_length/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ $$, click, expect }) => {
+  const [add, clear] = $$("button");
+  expect("p").text("No items");
+  await click(add);
+  expect("p").text("1 items");
+  await click(add);
+  expect("p").text("2 items");
+  await click(clear);
+  expect("p").text("No items");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="flip()">flip</button>
+        <p :if="on">ON</p>
+        <p :else>OFF</p>
+    </div>
+script:
+    let on = false
+    function flip(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button><p>OFF</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button><p>OFF</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_bool/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ $$, click, expect }) => {
+  expect("p").count(1);
+  expect("p").text("OFF");
+  await click("button");
+  expect("p").count(1);
+  expect("p").text("ON");
+  await click("button");
+  expect("p").text("OFF");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="add()">add</button>
+        <p :if="count > 3">Big</p>
+        <p :else>Small</p>
+    </div>
+script:
+    let count = 0
+    function add(){ count = count + 2 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><p>Big</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><p>Small</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_flip_comparison/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ click, expect }) => {
+  expect("p").text("Small");
+  await click("button");
+  expect("p").text("Small");
+  await click("button");
+  expect("p").text("Big");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <p :if="!!visible">Visible</p>
+        <p :else>Hidden</p>
+    </div>
+script:
+    let visible = false
+    function toggle(){ visible = !visible }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><p>Hidden</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><p>Hidden</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_negation_chain/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ click, expect }) => {
+  expect("p").text("Hidden");
+  await click("button");
+  expect("p").text("Visible");
+  await click("button");
+  expect("p").text("Hidden");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/App.lunas
@@ -1,0 +1,9 @@
+html:
+    <div>
+        <button @click="inc()">inc</button>
+        <p :if="count >= 3">Threshold reached</p>
+        <p :else>Below threshold (${count})</p>
+    </div>
+script:
+    let count = 0
+    function inc(){ count = count + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><p>Threshold reached</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><p>Below threshold (0)</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_number_threshold/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, expect }) => {
+  expect("p").text("Below threshold (0)");
+  await click("button");
+  expect("p").text("Below threshold (1)");
+  await click("button");
+  expect("p").text("Below threshold (2)");
+  await click("button");
+  expect("p").text("Threshold reached");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="flip()">flip</button>
+        <span :if="on">HERE</span>
+    </div>
+script:
+    let on = false
+    function flip(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button><span>HERE</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_rapid_double/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ click, expect }) => {
+  expect("span").count(0);
+  await click("button");
+  await click("button");
+  expect("span").count(0);
+  await click("button");
+  expect("span").count(1);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/App.lunas
@@ -1,0 +1,13 @@
+html:
+    <div>
+        <button @click="setLang('en')">en</button>
+        <button @click="setLang('fr')">fr</button>
+        <button @click="setLang('jp')">jp</button>
+        <p :if="lang == 'en'">Hello</p>
+        <p :elseif="lang == 'fr'">Bonjour</p>
+        <p :elseif="lang == 'jp'">Konnichiwa</p>
+        <p :else>???</p>
+    </div>
+script:
+    let lang = "en"
+    function setLang(l){ lang = l }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>en</button><button>fr</button><button>jp</button><p>Hello</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>en</button><button>fr</button><button>jp</button><p>Hello</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_string_switch/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ $$, click, expect }) => {
+  const [en, fr, jp] = $$("button");
+  expect("p").text("Hello");
+  await click(fr);
+  expect("p").text("Bonjour");
+  await click(jp);
+  expect("p").text("Konnichiwa");
+  await click(en);
+  expect("p").text("Hello");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <button @click="flip()">flip</button>
+        <span :if="on">HERE</span>
+    </div>
+script:
+    let on = false
+    function flip(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>flip</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_three_cycles/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, expect }) => {
+  for (let i = 0; i < 3; i++) {
+    expect("span").count(0);
+    await click("button");
+    expect("span").count(1);
+    await click("button");
+  }
+  expect("span").count(0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <div>
+        <input ::value="query">
+        <p :if="query.length > 0">Searching: ${query}</p>
+        <p :else>Type to search</p>
+    </div>
+script:
+    let query = ""

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><input><p>Type to search</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/expected.html
@@ -1,0 +1,1 @@
+<div><div><input><p>Type to search</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_input_derived/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ setValue, expect }) => {
+  expect("p").text("Type to search");
+  await setValue("input", "cats");
+  expect("p").text("Searching: cats");
+  await setValue("input", "");
+  expect("p").text("Type to search");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/App.lunas
@@ -1,0 +1,12 @@
+html:
+    <div>
+        <button @click="showA()">a</button>
+        <button @click="showB()">b</button>
+        <p :if="which == 'a'">Panel A</p>
+        <p :elseif="which == 'b'">Panel B</p>
+        <p :else>None</p>
+    </div>
+script:
+    let which = "none"
+    function showA(){ which = "a" }
+    function showB(){ which = "b" }

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button><p>Panel B</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button><p>None</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/toggle_via_two_clicks_diff_buttons/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ $$, click, expect }) => {
+  const [a, b] = $$("button");
+  expect("p").text("None");
+  await click(a);
+  expect("p").text("Panel A");
+  await click(b);
+  expect("p").text("Panel B");
+  await click(b);
+  expect("p").text("Panel B");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_empty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="items">shown</span></div>
+script:
+    let items = []

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_nonempty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_nonempty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="items">shown</span></div>
+script:
+    let items = [1, 2]

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_nonempty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_array_nonempty/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_negative/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_negative/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="temp">shown</span></div>
+script:
+    let temp = -5

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_negative/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_negative/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_nonzero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_nonzero/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="count">shown</span></div>
+script:
+    let count = 5

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_nonzero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_number_nonzero/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_object_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_object_empty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="obj">shown</span></div>
+script:
+    let obj = {}

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_object_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_object_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_string_nonempty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_string_nonempty/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div><span :if="label">shown</span></div>
+script:
+    let label = "hi"

--- a/crates/lunas_compiler/tests/runtime/samples/if/truthy_string_nonempty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/truthy_string_nonempty/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>shown</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/App.lunas
@@ -1,0 +1,10 @@
+html:
+    <div>
+        <button @click="toggle()">toggle</button>
+        <p :if="locked">Locked: ${value}</p>
+        <input :else ::value="value">
+    </div>
+script:
+    let locked = false
+    let value = "edit me"
+    function toggle(){ locked = !locked }

--- a/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><p>Locked: changed</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>toggle</button><input></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/two_way_input_inside_else_branch/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ click, setValue, expect }) => {
+  expect("input").count(1);
+  expect("input").value("edit me");
+  await setValue("input", "changed");
+  expect("input").value("changed");
+  await click("button");
+  expect("p").text("Locked: changed");
+  expect("input").count(0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/whitespace_between_branches/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/whitespace_between_branches/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <div>
+        <p :if="a">A</p>          <p :elseif="b">B</p>          <p :else>C</p>
+    </div>
+script:
+    let a = false
+    let b = true

--- a/crates/lunas_compiler/tests/runtime/samples/if/whitespace_between_branches/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/whitespace_between_branches/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>B</p></div></div>


### PR DESCRIPTION
## Summary

Mass-produces E2E sample test cases for the `:if`/`:elseif`/`:else` conditional-rendering category of the sample-directory harness (`crates/lunas_compiler/tests/runtime/samples/if/`).

- 108 new cases added, for **112 total** in `samples/if/` (4 pre-existing seeds: `cascade`, `static_true`, `static_false`, `toggle`).
- Coverage:
  - Truthy/falsy conditions: booleans, numbers (incl. `0`, `-0`, `NaN`, negatives), strings (empty/non-empty), arrays (empty/non-empty — both truthy), objects (`{}` — truthy), `null`, `undefined`, negation.
  - Comparisons (`==`, `!=`, `<`, `>`, `<=`, `>=`, `===`, `!==`), string lexical comparison.
  - Logical/expression conditions: `&&`, `||`, `!`, combined/parenthesized expressions, arithmetic (`%`), method-call conditions, `Array.includes`.
  - `:if`/`:else` 2-branch cascades across condition types (bool, comparison, string match, logical, negated, property access, array length).
  - 3/4/5-branch `:if`/`:elseif`/`:else` cascades (grade bands, traffic light, HTTP status, weekdays, seasons, etc.) and no-`:else` cascades (all-false, first-true, middle-true).
  - Heavy `steps.mjs` interaction coverage (the toggling point of the category): flipping booleans, cycling through 3-/4-way `:elseif` chains, back-and-forth navigation, one reactive variable driving multiple independent `:if` blocks, two-way-bound inputs feeding a condition.
  - Content inside branches: text/attr/class/style bindings, click handlers wired up *after* a branch is shown, multi-element branches, nested `:if`-in-`:if` (including 3 levels deep), `:if` containing `:for`, `:for` containing `:if`/`:if-else` per item.
  - State-preservation edges: component-level reactive state survives a branch teardown/rebuild (value persists) while the branch's own DOM subtree (including unbound input values) is genuinely destroyed and rebuilt fresh; static siblings around a cascade are undisturbed.
  - Structural edges: whitespace/blank-line-tolerant cascades, adjacent independent `:if` chains, `:if` false initially (asserted via absence in `expected.html`), `:if`+`:for` combined correctly by wrapping (same-element combination is an unsupported codegen path — see Surprises), two-way input inside an `:else` branch.

Every case compiles clean and passes `cargo test -p lunas_compiler --test runtime_samples` (136 total sample tests pass, 112 of them in `if/`). Only `samples/if/` was touched — no harness, runtime, other sample categories, or `roadmap.yml` changes.

## Surprises / notes for reviewers

- **`:if` + `:for` on the same element parses fine but codegen currently voids it** with `` `:if` on the same element as `:for` is not supported yet (wrap the element in the `:if` instead) ``. Cases needing both wrap `:if` on an inner element instead (see `if_for_same_element_wrap`, `for_containing_if_item`, `for_containing_if_else_item`).
- **`:if` on a component is also unsupported by codegen** (parses, but voids at emit time) — all branch bodies in this PR are plain HTML elements.
- **A reactive variable literally named `c` collides** with the compiler's generated runtime-context parameter name in the emitted closures (`SyntaxError: Identifier 'c' has already been declared`) when it's referenced from an `:if` condition guarded by more than one branch's dependency set. Renamed the handful of cases that hit this (`cc`, `bc`, `cond3`) — worth a note for anyone else hand-authoring cases with single-letter variable names.
- A comment between `:elseif`/`:else` siblings breaks the cascade into orphans (compile error) per existing parser tests (`crates/lunas_parser/tests/template_edge.rs`) — not exercised here since this harness only asserts on successful renders, not diagnostics, but blank lines and inline whitespace between branches are confirmed cascade-safe (`whitespace_between_branches`, `blank_lines_between_branches`).

## Test plan

- [x] `UPDATE_EXPECTED=1 cargo test -p lunas_compiler --test runtime_samples -- if__` — generates and reviews `expected.html`/`expected.after.html` for all 112 cases.
- [x] `cargo test -p lunas_compiler --test runtime_samples` (no filter) — full suite green, 136 passed / 0 failed.
- [x] Spot-checked generated HTML for nested cascades, class/style binds, two-way inputs, and state-preservation cases for semantic correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)