### PR TITLE
test(samples): slots (default/named/scoped) E2E cases

### DIFF
--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+@use Chip from "./Chip.lunas"
+html:
+    <div><Box><template #head><Chip :label="t"/></template></Box></div>
+script:
+    let t = "hello"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/Chip.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/Chip.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span class="chip">${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_named_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header><div><span class="chip">hello</span></div></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+@use Chip from "./Chip.lunas"
+html:
+    <div><Box><Chip :label="word"/></Box></div>
+script:
+    let word = "hi"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/Chip.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/Chip.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span class="chip">${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><span class="chip">hi</span></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/App.lunas
@@ -1,0 +1,7 @@
+@use Box from "./Box.lunas"
+@use Chip from "./Chip.lunas"
+html:
+    <div><button @click="inc()">i</button><Box><Chip :n="v"/></Box></div>
+script:
+    let v = 1
+    function inc(){ v++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/Chip.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/Chip.lunas
@@ -1,0 +1,3 @@
+@input n:number = 0
+html:
+    <span class="chip">${n}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>i</button><div><section><div><span class="chip">2</span></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>i</button><div><section><div><span class="chip">1</span></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_in_slot_reactive/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect(".chip").text("1");
+  await click("button");
+  expect(".chip").text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Panel from "./Panel.lunas"
+html:
+    <div><Panel :title="t">body ${b}</Panel></div>
+script:
+    let t = "Head"
+    let b = "content"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/Panel.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/Panel.lunas
@@ -1,0 +1,3 @@
+@input title:string = ""
+html:
+    <section><h2>${title}</h2><main><slot></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/component_with_props_and_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><h2>Head</h2><main>body content</main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #body><ul><li :for="w of words" :key="w" class="it">${w}</li></ul></template></Box></div>
+script:
+    let words = ["a", "b", "c"]

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><main><slot name="body"></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="host"><main><ul><li class="it">a</li><li class="it">b</li><li class="it">c</li></ul></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="add()">a</button><Box><template #body><ul><li :for="w of words" :key="w" class="it">${w}</li></ul></template></Box></div>
+script:
+    let words = ["a", "b"]
+    function add(){ words.push("c") }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><main><slot name="body"></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><div><section class="host"><main><ul><li class="it">a</li><li class="it">b</li><li class="it">c</li></ul></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><div><section class="host"><main><ul><li class="it">a</li><li class="it">b</li></ul></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/for_list_in_named_slot_reactive/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $$, click, equal }) => {
+  equal($$(".it").length, 2);
+  await click("button");
+  equal($$(".it").length, 3);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/App.lunas
@@ -1,0 +1,4 @@
+@use Box from "./Box.lunas"
+@use Counter from "./Counter.lunas"
+html:
+    <div><Box><Counter/></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/Counter.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/Counter.lunas
@@ -1,0 +1,5 @@
+html:
+    <button @click="inc()">n=${n}</button>
+script:
+    let n = 0
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><button>n=1</button></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><button>n=0</button></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/inner_component_own_state/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("button").text("n=0");
+  await click("button");
+  expect("button").text("n=1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/App.lunas
@@ -1,0 +1,4 @@
+@use Box from "./Box.lunas"
+@use Card from "./Card.lunas"
+html:
+    <div><Box><template #body><Card><template #title>T</template></Card></template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="outer"><main><slot name="body"></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/Card.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/Card.lunas
@@ -1,0 +1,2 @@
+html:
+    <article class="inner"><h1><slot name="title"></slot></h1></article>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_named_slotting/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="outer"><main><div><article class="inner"><h1>T</h1></article></div></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/App.lunas
@@ -1,0 +1,4 @@
+@use Box from "./Box.lunas"
+@use Card from "./Card.lunas"
+html:
+    <div><Box><Card>inner content</Card></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="outer"><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/Card.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/Card.lunas
@@ -1,0 +1,2 @@
+html:
+    <article class="inner"><slot>ifb</slot></article>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/nested_slotting/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="outer"><div><article class="inner">inner content</article></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>shown</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><div :if="ready"><slot></slot></div></section>
+script:
+    let ready = true

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/slot_inside_child_if/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div>shown</div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/App.lunas
@@ -1,0 +1,8 @@
+@use Box from "./Box.lunas"
+html:
+    <div class="w"><button class="t" @click="t()">t</button><button class="i" @click="inc()">i</button><span :if="on"><Box><b>n=${n}</b></Box></span></div>
+script:
+    let on = true
+    let n = 1
+    function t(){ on = !on }
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="w"><button class="t">t</button><button class="i">i</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/expected.html
@@ -1,0 +1,1 @@
+<div><div class="w"><button class="t">t</button><button class="i">i</button><span><div><section><b>n=1</b></section></div></span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/teardown_on_unmount/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ $, $$, click, expect, equal }) => {
+  expect("b").text("n=1");
+  await click(".t");
+  equal($$("section").length, 0);
+  equal($$("b").length, 0);
+  // mutating parent state after teardown must not resurrect content
+  await click(".i");
+  equal($$("section").length, 0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/App.lunas
@@ -1,0 +1,7 @@
+@use Box from "./Box.lunas"
+@use Chip from "./Chip.lunas"
+html:
+    <div><Box><Chip :label="a"/><Chip :label="b"/></Box></div>
+script:
+    let a = "x"
+    let b = "y"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/Chip.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/Chip.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span class="chip">${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/composition/two_components_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><span class="chip">x</span></div><div><span class="chip">y</span></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><span class="tag">boxed</span></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/attr_on_projected_element/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><span class="tag">boxed</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>real</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot><em>fallback</em></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/content_overrides_fallback/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>real</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><p>count is ${n}</p></Box></div>
+script:
+    let n = 42

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/element_with_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><p>count is 42</p></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot><em>none yet</em></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_element/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><em>none yet</em></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot><span>a</span><span>b</span></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_multi_node/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><span>a</span><span>b</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot>the fallback</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/fallback_shown/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>the fallback</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>${name}</Box></div>
+script:
+    let name = "ada"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/interpolation_only/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>ada</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>[${v}]</Box></div>
+script:
+    let v = "mid"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/leading_trailing_static/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>[mid]</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><ul><li>one</li><li>two</li></ul></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/list_in_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><ul><li>one</li><li>two</li></ul></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>hello ${who}!</Box></div>
+script:
+    let who = "world"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/mixed_static_interp/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>hello world!</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><span>one</span><span>two</span></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/multiple_nodes/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><span>one</span><span>two</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><article><h1>title</h1><p>body</p></article></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/nested_markup/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><article><h1>title</h1><p>body</p></article></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>projected content</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot>fb</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/projection_basic/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>projected content</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>middle</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header>top</header><slot></slot><footer>bot</footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/sibling_dom_around_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>top</header>middle<footer>bot</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>deep</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><div><main><slot></slot></main></div></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/slot_in_deep_child_dom/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><main>deep</main></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>first</Box><Box>second</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot>fb</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_boxes_independent/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>first</section></div><div><section>second</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>${a} and ${b}</Box></div>
+script:
+    let a = "x"
+    let b = "y"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/default/two_interps_in_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>x and y</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/App.lunas
@@ -1,0 +1,4 @@
+@use Box from "./Box.lunas"
+@use Chip from "./Chip.lunas"
+html:
+    <div><Box><Chip/></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot>fb</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/Chip.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/Chip.lunas
@@ -1,0 +1,2 @@
+html:
+    <span class="chip">chip</span>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/content_only_component/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><span class="chip">chip</span></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot><div><p><em>deep fb</em></p></div></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/deeply_nested_fallback/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><p><em>deep fb</em></p></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/empty_both_sides/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="host"></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/Box.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><slot><button @click="inc()">c=${cnt}</button></slot></section>
+script:
+    let cnt = 0
+    function inc(){ cnt++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><section><button>c=1</button></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><button>c=0</button></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_reactive_child/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("button").text("c=0");
+  await click("button");
+  expect("button").text("c=1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot>default ${name}</slot></section>
+script:
+    let name = "child"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/fallback_with_interpolation/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>default child</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>pre ${a}<b>bold</b> post ${z}</Box></div>
+script:
+    let a = "1"
+    let z = "9"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/mixed_text_element_interp/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>pre 1<b>bold</b> post 9</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head></template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header class="h"><slot name="head">fb</slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/named_empty_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header class="h"></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/no_fallback_no_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="host"></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>content</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot class="ignored" id="s1">fb</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/slot_with_attributes/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>content</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>a &amp; b</Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/special_chars/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>a & b</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>   </Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><slot>fb</slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/edge/whitespace_only_content/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="host">fb</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head">h fb</slot></header><footer><slot name="foot">f fb</slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/all_named_missing/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>h fb</header><footer>f fb</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #top-bar>TB</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="top-bar">fb</slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/dashed_name/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>TB</header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>H</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><main><slot>default fb</slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/default_fallback_only/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><main>default fb</main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head><h1>Title</h1></template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/element_in_named/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header><h1>Title</h1></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/App.lunas
@@ -1,0 +1,3 @@
+@use Card from "./Card.lunas"
+html:
+    <div><Card><template #head>Dashboard</template>welcome<template #foot>2026</template></Card></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/Card.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/Card.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="card"><header><slot name="head">untitled</slot></header><main><slot>empty</slot></main><footer><slot name="foot"></slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/head_body_foot_full/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="card"><header>Dashboard</header><main>welcome</main><footer>2026</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>user: ${user}</template></Box></div>
+script:
+    let user = "root"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/interp_in_named/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>user: root</header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>H</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><footer><slot name="foot">no foot</slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/missing_uses_fallback/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><footer>no foot</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>D<template #head>SH</template><template slot="foot">LF</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><main><slot></slot></main><footer><slot name="foot"></slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/mixed_forms/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>SH</header><main>D</main><footer>LF</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head><span>a</span><span>b</span></template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multi_node_in_named/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header><span>a</span><span>b</span></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>H</template><template #foot>F</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><footer><slot name="foot"></slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/multiple_named/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><footer>F</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>H</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><main class="m"><slot></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_only_default_empty/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><main class="m"></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box>body text<template #head>H</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><main><slot></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/named_plus_default/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><main>body text</main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #foot>F</template><template #head>H</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><footer><slot name="foot"></slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/ordering_independent_of_dom/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>H</header><footer>F</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head>the head</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head">fb</slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/single_named/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>the head</header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template slot="head">long form</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head">fb</slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/slot_long_form/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>long form</header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template>into default</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><main><slot>fb</slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/template_noname_is_default/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><main>into default</main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #a>A</template>mid<template #b>B</template><template #c>C</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><i><slot name="a"></slot></i><main><slot></slot></main><i><slot name="b"></slot></i><i><slot name="c"></slot></i></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/named/three_named_and_default/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><i>A</i><main>mid</main><i>B</i><i>C</i></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="go()">g</button><Box><a :href="url">link</a></Box></div>
+script:
+    let url = "/a"
+    function go(){ url = "/b" }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>g</button><div><section><a href="/b">link</a></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>g</button><div><section><a href="/a">link</a></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/attr_bind_in_slot/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("a").attr("href", "/a");
+  await click("button");
+  expect("a").attr("href", "/b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="t()">t</button><Box><span :class="on ? 'on' : 'off'">x</span></Box></div>
+script:
+    let on = false
+    function t(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>t</button><div><section><span class="on">x</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>t</button><div><section><span class="off">x</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/conditional_class_in_slot/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("span").attr("class", "off");
+  await click("button");
+  expect("span").attr("class", "on");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #foot><button @click="inc()">v=${v}</button></template></Box></div>
+script:
+    let v = 5
+    function inc(){ v++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><footer><slot name="foot"></slot></footer></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><section><footer><button>v=6</button></footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><footer><button>v=5</button></footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/counter_in_named_slot/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("button").text("v=5");
+  await click("button");
+  expect("button").text("v=6");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><input ::value="text"/><span>${text}</span></Box></div>
+script:
+    let text = "hi"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><section><input><span>bye</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><input><span>hi</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/input_binding_in_slot/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, setValue, expect }) => {
+  expect("span").text("hi");
+  await setValue("input", "bye");
+  expect("span").text("bye");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="inc()">inc</button><Box><template #head><b>${n}</b></template></Box></div>
+script:
+    let n = 0
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><header><b>1</b></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><header><b>0</b></header></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/named_slot_updates/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("b").text("0");
+  await click("button");
+  expect("b").text("1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div class="w"><button @click="next()">n</button><Box><p :if="step == 0">zero</p><p :if="step == 1">one</p></Box></div>
+script:
+    let step = 0
+    function next(){ step++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="w"><button>n</button><div><section class="host"></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div class="w"><button>n</button><div><section class="host"><p>zero</p></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/nested_if_in_slot/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".host").html("<p>zero</p>");
+  await click("button");
+  expect(".host").html("<p>one</p>");
+  await click("button");
+  expect(".host").html("");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="inc()">inc</button><Box><span>n=${n}</span></Box></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><span>n=3</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><span>n=1</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/parent_state_updates/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect("span").text("n=1");
+  await click("button");
+  expect("span").text("n=2");
+  await click("button");
+  expect("span").text("n=3");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/App.lunas
@@ -1,0 +1,7 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button class="add" @click="add()">a</button><Box><button class="clr" @click="clear()">clr</button><ul><li :for="i of items" :key="i">${i}</li></ul></Box></div>
+script:
+    let items = [1, 2]
+    function add(){ items.push(items.length + 1) }
+    function clear(){ items = [] }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="add">a</button><div><section><button class="clr">clr</button><ul></ul></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="add">a</button><div><section><button class="clr">clr</button><ul><li>1</li><li>2</li></ul></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/reset_from_slot_button/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $, $$, click, equal }) => {
+  const n = () => $$("li").length;
+  equal(n(), 2);
+  await click(".add");
+  equal(n(), 3);
+  await click(".clr");
+  equal(n(), 0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="inc()">i</button><Box><template #default="p">${p.fixed}/${n}</template></Box></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section class="host"><slot :fixed="seed"></slot></section>
+script:
+    let seed = 50

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/_config.json
@@ -1,0 +1,1 @@
+{ "description": "scoped prop stays snapshot(50); parent state n reacts to click" }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>i</button><div><section class="host">50/2</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>i</button><div><section class="host">50/1</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/scoped_snapshot_parent_reactive/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ $, click, expect }) => {
+  // scoped prop is a build-time snapshot (50); the parent's n reacts.
+  expect(".host").text("50/1");
+  await click("button");
+  expect(".host").text("50/2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="add()">add</button><Box><ul><li :for="i of items" :key="i">${i}</li></ul></Box></div>
+script:
+    let items = ["a", "b"]
+    function add(){ items.push("c") }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><div><section><ul><li>a</li><li>b</li><li>c</li></ul></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>add</button><div><section><ul><li>a</li><li>b</li></ul></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_for/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ $$, click, equal }) => {
+  const labels = () => $$("li").map((n) => n.innerHTMLString()).join(",");
+  equal(labels(), "a,b");
+  await click("button");
+  equal(labels(), "a,b,c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><button @click="inc()">c=${cnt}</button></Box></div>
+script:
+    let cnt = 0
+    function inc(){ cnt++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><section><button>c=2</button></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><button>c=0</button></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/slot_content_own_event/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect("button").text("c=0");
+  await click("button");
+  expect("button").text("c=1");
+  await click("button");
+  expect("button").text("c=2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="grow()">g</button><Box><span :style="'width:' + w + 'px'">bar</span></Box></div>
+script:
+    let w = 10
+    function grow(){ w += 5 }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>g</button><div><section><span style="width:15px">bar</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>g</button><div><section><span style="width:10px">bar</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/style_bind_in_slot/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect("span").attr("style", "width:10px");
+  await click("button");
+  expect("span").attr("style", "width:15px");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div class="wrap"><button @click="t()">t</button><span :if="on"><Box><b>content</b></Box></span></div>
+script:
+    let on = true
+    function t(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/expected.after.html
@@ -1,0 +1,1 @@
+<div><div class="wrap"><button>t</button><span><div><section><b>content</b></section></div></span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/expected.html
@@ -1,0 +1,1 @@
+<div><div class="wrap"><button>t</button><span><div><section><b>content</b></section></div></span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_box_via_parent_if/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, $$, click, equal }) => {
+  equal($$("section").length, 1);
+  await click("button");
+  equal($$("section").length, 0);
+  await click("button");
+  equal($$("section").length, 1);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="t()">t</button><Box><span :if="on">visible</span></Box></div>
+script:
+    let on = false
+    function t(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section class="host"><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>t</button><div><section class="host"></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>t</button><div><section class="host"></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/toggle_slotted_via_if/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".host").html("");
+  await click("button");
+  expect(".host").html("<span>visible</span>");
+  await click("button");
+  expect(".host").html("");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/App.lunas
@@ -1,0 +1,8 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button class="a" @click="ia()">a</button><button class="b" @click="ib()">b</button><Box><span class="x">${a}</span></Box><Box><span class="y">${b}</span></Box></div>
+script:
+    let a = 0
+    let b = 0
+    function ia(){ a++ }
+    function ib(){ b++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><slot></slot></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><section><span class="x">1</span></section></div><div><section><span class="y">2</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><section><span class="x">0</span></section></div><div><section><span class="y">0</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_boxes_independent_counters/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $, click, expect }) => {
+  expect(".x").text("0");
+  expect(".y").text("0");
+  await click(".a");
+  expect(".x").text("1");
+  expect(".y").text("0");
+  await click(".b");
+  await click(".b");
+  expect(".x").text("1");
+  expect(".y").text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/App.lunas
@@ -1,0 +1,6 @@
+@use Box from "./Box.lunas"
+html:
+    <div><button @click="inc()">inc</button><Box><span class="d">d${n}</span><template #head><span class="h">h${n}</span></template></Box></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/Box.lunas
@@ -1,0 +1,2 @@
+html:
+    <section><header><slot name="head"></slot></header><main><slot></slot></main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><header><span class="h">h2</span></header><main><span class="d">d2</span></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>inc</button><div><section><header><span class="h">h1</span></header><main><span class="d">d1</span></main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/reactive/two_slots_share_parent_state/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect(".d").text("d1");
+  expect(".h").text("h1");
+  await click("button");
+  expect(".d").text("d2");
+  expect(".h").text("h2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">first=${p.list[0]}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :list="items"></slot></section>
+script:
+    let items = ["a", "b"]

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/array_scoped/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>first=a</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">sum=${p.total}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/Box.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><slot :total="a + b"></slot></section>
+script:
+    let a = 2
+    let b = 3

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/computed_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>sum=5</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">got ${p.item}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :item="row"></slot></section>
+script:
+    let row = "apple"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/expose_value/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>got apple</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/App.lunas
@@ -1,0 +1,5 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">${label}:${p.item}</template></Box></div>
+script:
+    let label = "tag"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :item="row"></slot></section>
+script:
+    let row = "val"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/mixes_parent_and_scoped/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>tag:val</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">${p.a}-${p.b}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/Box.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><slot :a="x" :b="y"></slot></section>
+script:
+    let x = "L"
+    let y = "R"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/multiple_props/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>L-R</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="d">d:${d.a}</template><template #foot="f">f:${f.b}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/Box.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><main><slot :a="one"></slot></main><footer><slot name="foot" :b="two"></slot></footer></section>
+script:
+    let one = "P"
+    let two = "Q"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_and_default_scoped/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><main>d:P</main><footer>f:Q</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #foot="s">rows: ${s.count}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><footer><slot name="foot" :count="rows"></slot></footer></section>
+script:
+    let rows = 3

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/named_scoped/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><footer>rows: 3</footer></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">n=${p.n}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :n="count"></slot></section>
+script:
+    let count = 7

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/number_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>n=7</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">${p.row.label}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :row="data"></slot></section>
+script:
+    let data = { label: "hi", id: 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/object_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>hi</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p"><span>${p.item}</span></template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :item="row"></slot></section>
+script:
+    let row = "wrapped"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_in_element/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><span>wrapped</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">${p.user.name}#${p.user.id}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :user="account"></slot></section>
+script:
+    let account = { name: "ada", id: 7 }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_nested_field/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>ada#7</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #default="p">value ${p.v}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :v="seed"></slot></section>
+script:
+    let seed = 100

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/_config.json
@@ -1,0 +1,1 @@
+{ "description": "scoped prop captured as build-time snapshot; correct on first paint" }

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_prop_snapshot/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>value 100</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :item="row">fallback ${row}</slot></section>
+script:
+    let row = "z"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/scoped_with_default_fallback/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>fallback z</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template slot="default" slot-scope="p">v=${p.item}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/Box.lunas
@@ -1,0 +1,4 @@
+html:
+    <section><slot :item="row"></slot></section>
+script:
+    let row = "banana"

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/slot_scope_long_form/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section>v=banana</section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/App.lunas
@@ -1,0 +1,3 @@
+@use Box from "./Box.lunas"
+html:
+    <div><Box><template #head="h">h:${h.t}</template><template #foot="f">f:${f.c}</template></Box></div>

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/Box.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/Box.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><header><slot name="head" :t="title"></slot></header><footer><slot name="foot" :c="count"></slot></footer></section>
+script:
+    let title = "T"
+    let count = 9

--- a/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/slot/scoped/two_named_scoped/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><header>h:T</header><footer>f:9</footer></section></div></div></div>


### PR DESCRIPTION
## Summary

Mass-produces **89 sample-directory E2E cases** under `crates/lunas_compiler/tests/runtime/samples/slot/`, covering the full slot feature surface (default / named / scoped, plus reactivity, composition, and edge cases). No harness, runtime, or roadmap changes — new sample directories only.

All cases compile clean and pass the `runtime_samples` runner (green in both normal and `UPDATE_EXPECTED=1` modes). `expected.html` is committed for every case; the 21 interaction cases also commit `expected.after.html` alongside explicit `expect(...)` assertions in `steps.mjs`.

## Breakdown (89 new cases)

| Subcategory | Count | Coverage |
|---|---|---|
| `default/` | 17 | projection, fallback, mixed static+interp, multiple/nested nodes, siblings around outlet, fallback variants |
| `named/` | 18 | single/multiple named, named+default, ordering independent of child DOM, missing→fallback, `#x` vs `slot=` long form, bare `<template>`→default, dashed names |
| `scoped/` | 15 | expose value, multiple/object/array/computed props, named+scoped, `slot-scope` long form, snapshot semantics |
| `reactive/` | 16 | parent state in slot content reacts to `@click`; slotted `:if`/`:for`/two-way/`:class`/`:style`/`:attr`; toggling; scoped snapshot fixed while parent stays reactive |
| `composition/` | 12 | component-in-slot (+reactive), `:for` list in named slot, nested slotting, component in named slot, teardown on unmount |
| `edge/` | 11 | empty both sides, whitespace-only, slot attributes, fallback with child dynamics, special chars, mixed content |

## Framework limits encountered (documented, not forced)

- **`:for` on a component is not supported yet** (compiler warning) — covered list growth via `:for` on a plain element inside slot content instead.
- **`slot-scope` long form requires an explicit `slot="name"`** — a bare `<template slot-scope="p">` drops the binding; the long-form case uses `slot="default"`.
- **Scoped props are a build-time snapshot** (live child→parent updates deferred). Covered as correct-on-first-paint per the documented semantics; `reactive/scoped_snapshot_parent_reactive` asserts the scoped value stays fixed while the parent-scoped part reacts.
- A script identifier `c` collides with the compiler-generated context var — renamed affected vars to `cnt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)