### PR TITLE
test(samples): attribute-binding E2E cases

### DIFF
--- a/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><a :href="url">link</a><input :value="val"></div>
+script:
+    let url = "/go"
+    let val = "hello"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><a href="/go">link</a><input></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/expected.html
@@ -1,0 +1,1 @@
+<div><div><a href="/go">link</a><input></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/attr_vs_prop_value_and_href/steps.mjs
@@ -1,0 +1,4 @@
+export default async ({ expect }) => {
+  expect("a").attr("href", "/go");
+  expect("input").value("hello");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input type="checkbox" :checked="isChecked">
+script:
+    let isChecked = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/expected.after.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/expected.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_false/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").prop("checked", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <input type="checkbox" :checked="on" @click="toggle()">
+script:
+    let on = false
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_toggle/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ expect, click }) => {
+  expect("input").prop("checked", false);
+  await click("input");
+  expect("input").prop("checked", true);
+  await click("input");
+  expect("input").prop("checked", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input type="checkbox" :checked="isChecked">
+script:
+    let isChecked = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/expected.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_checked_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").prop("checked", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="flag">go</button>
+script:
+    let flag = ""

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_empty_string/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="isDisabled">go</button>
+script:
+    let isDisabled = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_false/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="flag">go</button>
+script:
+    let flag = "yes"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_nonempty_string/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="flag">go</button>
+script:
+    let flag = 1

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_one/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><button :disabled="locked">save</button><button @click="unlock()">unlock</button></div>
+script:
+    let locked = true
+    function unlock(){ locked = false }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>save</button><button>unlock</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>save</button><button>unlock</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_toggle/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $$, expect, click }) => {
+  expect($$("button")[0]).prop("disabled", true);
+  await click($$("button")[1]);
+  expect($$("button")[0]).prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="isDisabled">go</button>
+script:
+    let isDisabled = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="flag">go</button>
+script:
+    let flag = 0

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_disabled_zero/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <span :hidden="isHidden">secret</span>
+script:
+    let isHidden = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><span>secret</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/expected.html
@@ -1,0 +1,1 @@
+<div><span>secret</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_hidden_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("span").prop("hidden", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <input :disabled="d" :readonly="r" :required="req">
+script:
+    let d = true
+    let r = false
+    let req = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/expected.after.html
@@ -1,0 +1,1 @@
+<div><input required="true"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/expected.html
@@ -1,0 +1,1 @@
+<div><input required="true"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_attrs_combo/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect }) => {
+  expect("input").prop("disabled", true);
+  expect("input").prop("readOnly", false);
+  expect("input").attr("required", "true");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <select :multiple="isMulti"><option value="a">A</option></select>
+script:
+    let isMulti = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/expected.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_multiple_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("select").prop("multiple", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <details :open="isOpen"><summary>s</summary>body</details>
+script:
+    let isOpen = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_false/expected.html
@@ -1,0 +1,1 @@
+<div><details open="false"><summary>s</summary>body</details></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <details :open="isOpen"><summary>s</summary>body</details>
+script:
+    let isOpen = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_open_true/expected.html
@@ -1,0 +1,1 @@
+<div><details open="true"><summary>s</summary>body</details></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :readonly="ro">
+script:
+    let ro = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_readonly_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").prop("readOnly", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :required="isRequired">
+script:
+    let isRequired = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_false/expected.html
@@ -1,0 +1,1 @@
+<div><input required="false"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :required="isRequired">
+script:
+    let isRequired = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_required_true/expected.html
@@ -1,0 +1,1 @@
+<div><input required="true"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <select><option :selected="isSel" value="a">A</option></select>
+script:
+    let isSel = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/expected.after.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/expected.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bool_selected_true/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("option").prop("selected", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_accept/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_accept/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input type="file" :accept="types">
+script:
+    let types = "image/png,image/jpeg"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_accept/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_accept/expected.html
@@ -1,0 +1,1 @@
+<div><input accept="image/png,image/jpeg" type="file"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_action/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_action/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <form :action="endpoint">form</form>
+script:
+    let endpoint = "/submit"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_action/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_action/expected.html
@@ -1,0 +1,1 @@
+<div><form action="/submit">form</form></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_alt/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_alt/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <img src="/static/logo.png" :alt="altText">
+script:
+    let altText = "company logo"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_alt/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_alt/expected.html
@@ -1,0 +1,1 @@
+<div><img alt="company logo" src="/static/logo.png"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_aria_star/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_aria_star/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <button :aria-label="label" :aria-pressed="pressed">btn</button>
+script:
+    let label = "toggle sidebar"
+    let pressed = "false"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_aria_star/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_aria_star/expected.html
@@ -1,0 +1,1 @@
+<div><button aria-label="toggle sidebar" aria-pressed="false">btn</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_colspan/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_colspan/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <table><tr><td :colspan="span">wide</td></tr></table>
+script:
+    let span = 3

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_colspan/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_colspan/expected.html
@@ -1,0 +1,1 @@
+<div><table><tr><td colspan="3">wide</td></tr></table></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_data_star/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_data_star/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div :data-id="itemId" :data-role="itemRole">row</div>
+script:
+    let itemId = "42"
+    let itemRole = "listitem"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_data_star/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_data_star/expected.html
@@ -1,0 +1,1 @@
+<div><div data-id="42" data-role="listitem">row</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_download/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_download/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a href="/file.zip" :download="filename">get</a>
+script:
+    let filename = "archive.zip"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_download/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_download/expected.html
@@ -1,0 +1,1 @@
+<div><a download="archive.zip" href="/file.zip">get</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_href/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_href/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a :href="url">link</a>
+script:
+    let url = "https://example.com/a"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_href/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_href/expected.html
@@ -1,0 +1,1 @@
+<div><a href="https://example.com/a">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_id/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_id/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :id="elId">x</div>
+script:
+    let elId = "main-panel"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_id/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_id/expected.html
@@ -1,0 +1,1 @@
+<div><div id="main-panel">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_lang/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_lang/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <p :lang="code">bonjour</p>
+script:
+    let code = "fr"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_lang/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_lang/expected.html
@@ -1,0 +1,1 @@
+<div><p lang="fr">bonjour</p></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_maxlength/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_maxlength/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :maxlength="max">
+script:
+    let max = 10

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_maxlength/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_maxlength/expected.html
@@ -1,0 +1,1 @@
+<div><input maxlength="10"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_method/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_method/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <form action="/submit" :method="m">form</form>
+script:
+    let m = "post"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_method/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_method/expected.html
@@ -1,0 +1,1 @@
+<div><form action="/submit" method="post">form</form></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_min_max/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_min_max/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <input type="number" :min="lo" :max="hi">
+script:
+    let lo = 0
+    let hi = 100

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_min_max/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_min_max/expected.html
@@ -1,0 +1,1 @@
+<div><input max="100" min="0" type="number"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_multiple_attrs_one_el/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_multiple_attrs_one_el/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <input :id="elId" :name="n" :type="t" :placeholder="ph">
+script:
+    let elId = "q"
+    let n = "search"
+    let t = "search"
+    let ph = "Search…"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_multiple_attrs_one_el/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_multiple_attrs_one_el/expected.html
@@ -1,0 +1,1 @@
+<div><input id="q" name="search" placeholder="Search…" type="search"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_name/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_name/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :name="fieldName">
+script:
+    let fieldName = "email"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_name/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_name/expected.html
@@ -1,0 +1,1 @@
+<div><input name="email"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_numeric_expr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_numeric_expr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :tabindex="base + 1">x</div>
+script:
+    let base = 4

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_numeric_expr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_numeric_expr/expected.html
@@ -1,0 +1,1 @@
+<div><div tabindex="5">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_pattern/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_pattern/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :pattern="p">
+script:
+    let p = "[0-9]{3}"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_pattern/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_pattern/expected.html
@@ -1,0 +1,1 @@
+<div><input pattern="[0-9]{3}"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_placeholder/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_placeholder/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :placeholder="hint">
+script:
+    let hint = "Enter your name"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_placeholder/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_placeholder/expected.html
@@ -1,0 +1,1 @@
+<div><input placeholder="Enter your name"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_rel/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_rel/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a href="/x" :rel="relVal">link</a>
+script:
+    let relVal = "noopener noreferrer"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_rel/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_rel/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/x" rel="noopener noreferrer">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_role/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_role/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :role="r">alert box</div>
+script:
+    let r = "alert"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_role/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_role/expected.html
@@ -1,0 +1,1 @@
+<div><div role="alert">alert box</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_src/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_src/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <img :src="imgSrc">
+script:
+    let imgSrc = "/static/logo.png"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_src/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_src/expected.html
@@ -1,0 +1,1 @@
+<div><img src="/static/logo.png"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_srcset/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_srcset/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <img src="/a.png" :srcset="set">
+script:
+    let set = "/a-1x.png 1x, /a-2x.png 2x"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_srcset/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_srcset/expected.html
@@ -1,0 +1,1 @@
+<div><img src="/a.png" srcset="/a-1x.png 1x, /a-2x.png 2x"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_step/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_step/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input type="number" :step="s">
+script:
+    let s = 0.5

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_step/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_step/expected.html
@@ -1,0 +1,1 @@
+<div><input step="0.5" type="number"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_string_concat/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_string_concat/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <a :href="base + '/' + slug">link</a>
+script:
+    let base = "https://site.test"
+    let slug = "posts/1"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_string_concat/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_string_concat/expected.html
@@ -1,0 +1,1 @@
+<div><a href="https://site.test/posts/1">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_tabindex/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_tabindex/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :tabindex="idx">focusable</div>
+script:
+    let idx = -1

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_tabindex/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_tabindex/expected.html
@@ -1,0 +1,1 @@
+<div><div tabindex="-1">focusable</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_target/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_target/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a href="/x" :target="targetVal">link</a>
+script:
+    let targetVal = "_blank"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_target/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_target/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/x" target="_blank">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_ternary_expr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_ternary_expr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :title="isBig ? 'big' : 'small'">x</div>
+script:
+    let isBig = true

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_ternary_expr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_ternary_expr/expected.html
@@ -1,0 +1,1 @@
+<div><div title="big">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_title_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_title_attr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <span :title="hint">hover me</span>
+script:
+    let hint = "helpful text"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_title_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_title_attr/expected.html
@@ -1,0 +1,1 @@
+<div><span title="helpful text">hover me</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_type/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_type/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :type="inputType">
+script:
+    let inputType = "password"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_type/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_type/expected.html
@@ -1,0 +1,1 @@
+<div><input type="password"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_width_height/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_width_height/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <img src="/a.png" :width="w" :height="h">
+script:
+    let w = 100
+    let h = 50

--- a/crates/lunas_compiler/tests/runtime/samples/attr/bound_width_height/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/bound_width_height/expected.html
@@ -1,0 +1,1 @@
+<div><img height="50" src="/a.png" width="100"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_empty_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_empty_string/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = ""

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_empty_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_empty_string/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_false/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="false">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_name_with_dashes/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_name_with_dashes/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-my-custom-thing="val">x</div>
+script:
+    let val = "yep"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_name_with_dashes/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_name_with_dashes/expected.html
@@ -1,0 +1,1 @@
+<div><div data-my-custom-thing="yep">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_null/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_null/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = null

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_null/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_null/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="null">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_undefined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_undefined/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = undefined

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_undefined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_undefined/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="undefined">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_with_spaces/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_with_spaces/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :title="msg">x</div>
+script:
+    let msg = "  padded value  "

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_with_spaces/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_with_spaces/expected.html
@@ -1,0 +1,1 @@
+<div><div title="  padded value  ">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_zero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_zero/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = 0

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_zero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_attr_zero/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="0">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_boolean_str_true_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_boolean_str_true_false/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-flag="flagStr">x</div>
+script:
+    let flagStr = "true"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_boolean_str_true_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_boolean_str_true_false/expected.html
@@ -1,0 +1,1 @@
+<div><div data-flag="true">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_class_interp_falsy_segment/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_class_interp_falsy_segment/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div class="box ${maybe}">x</div>
+script:
+    let maybe = ""

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_class_interp_falsy_segment/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_class_interp_falsy_segment/expected.html
@@ -1,0 +1,1 @@
+<div><div class="box">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="d">go</button>
+script:
+    let d = null

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_null/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button :disabled="d">go</button>
+script:
+    let d = undefined

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/expected.html
@@ -1,0 +1,1 @@
+<div><button>go</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_disabled_undefined/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_empty_static_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_empty_static_attr/App.lunas
@@ -1,0 +1,2 @@
+html:
+    <div title="">x</div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_empty_static_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_empty_static_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div title="">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_href_interp_undefined_segment/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_href_interp_undefined_segment/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a href="/x/${seg}">link</a>
+script:
+    let seg = undefined

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_href_interp_undefined_segment/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_href_interp_undefined_segment/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/x/undefined">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_html_escape_in_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_html_escape_in_value/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-x="x">x</div>
+script:
+    let x = "<script>alert(1)</" + "script>"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_html_escape_in_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_html_escape_in_value/expected.html
@@ -1,0 +1,1 @@
+<div><div data-x="<script>alert(1)</script>">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_bound_and_static_mixed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_bound_and_static_mixed/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <a href="/base" :title="hint" target="_blank" :data-id="id">link</a>
+script:
+    let hint = "opens new tab"
+    let id = 5

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_bound_and_static_mixed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_bound_and_static_mixed/expected.html
@@ -1,0 +1,1 @@
+<div><a data-id="5" href="/base" target="_blank" title="opens new tab">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_elements_same_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_elements_same_attr/App.lunas
@@ -1,0 +1,2 @@
+html:
+    <ul><li :data-idx="0">a</li><li :data-idx="1">b</li><li :data-idx="2">c</li></ul>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_elements_same_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_multiple_elements_same_attr/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li data-idx="0">a</li><li data-idx="1">b</li><li data-idx="2">c</li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_negative_number_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_negative_number_attr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :tabindex="n">x</div>
+script:
+    let n = -1

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_negative_number_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_negative_number_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div tabindex="-1">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_number_as_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_number_as_attr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-count="n">x</div>
+script:
+    let n = 3.14

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_number_as_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_number_as_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div data-count="3.14">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :readonly="n">
+script:
+    let n = 1

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_readonly_numeric_truthy/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").prop("readOnly", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <input :required="r" :disabled="d">
+script:
+    let r = false
+    let d = false

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/expected.after.html
@@ -1,0 +1,1 @@
+<div><input required="false"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/expected.html
@@ -1,0 +1,1 @@
+<div><input required="false"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_required_and_disabled_both_false/steps.mjs
@@ -1,0 +1,4 @@
+export default async ({ expect }) => {
+  expect("input").prop("disabled", false);
+  expect("input").attr("required", "false");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_ampersand/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_ampersand/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a :href="url">link</a>
+script:
+    let url = "/a?x=1&y=2"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_ampersand/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_ampersand/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/a?x=1&amp;y=2">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_quotes/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_quotes/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :title='msg'>x</div>
+script:
+    let msg = "she said \"hi\" & left"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_quotes/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_special_chars_quotes/expected.html
@@ -1,0 +1,1 @@
+<div><div title="she said &quot;hi&quot; &amp; left">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :value="v">
+script:
+    let v = null

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_value_null/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect }) => {
+  // :value binds the IDL property directly (no coercion); the DOM (and the
+  // shim) normalize a null/undefined value read-back to "".
+  expect("input").value("");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_very_long_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_very_long_value/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div :data-blob="blob">x</div>
+script:
+    let blob = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/edge_very_long_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/edge_very_long_value/expected.html
@@ -1,0 +1,1 @@
+<div><div data-blob="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_alt_text/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_alt_text/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <img src="/a.png" alt="Photo of ${subject}">
+script:
+    let subject = "a cat"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_alt_text/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_alt_text/expected.html
@@ -1,0 +1,1 @@
+<div><img alt="Photo of a cat" src="/a.png"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_multi/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_multi/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div class="a ${x} b ${y} c">x</div>
+script:
+    let x = "one"
+    let y = "two"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_multi/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_multi/expected.html
@@ -1,0 +1,1 @@
+<div><div class="a one b two c">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_prefix/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_prefix/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div class="${flavor} tag">x</div>
+script:
+    let flavor = "sweet"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_prefix/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_prefix/expected.html
@@ -1,0 +1,1 @@
+<div><div class="sweet tag">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_suffix/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_suffix/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div class="tag ${flavor}">x</div>
+script:
+    let flavor = "sweet"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_suffix/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_class_suffix/expected.html
@@ -1,0 +1,1 @@
+<div><div class="tag sweet">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_data_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_data_attr/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div data-item="item-${id}">row</div>
+script:
+    let id = 99

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_data_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_data_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div data-item="item-99">row</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_expr_inside/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_expr_inside/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div title="total: ${a + b}">x</div>
+script:
+    let a = 2
+    let b = 3

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_expr_inside/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_expr_inside/expected.html
@@ -1,0 +1,1 @@
+<div><div title="total: 5">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_path/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_path/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <a href="/users/${id}/profile">profile</a>
+script:
+    let id = 7

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_path/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_path/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/users/7/profile">profile</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_query/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_query/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <a href="/search?q=${term}&page=${page}">search</a>
+script:
+    let term = "lunas"
+    let page = 2

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_query/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_href_query/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/search?q=lunas&amp;page=2">search</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_numeric_value/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_numeric_value/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div data-count="count: ${n}">x</div>
+script:
+    let n = 5

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_numeric_value/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_numeric_value/expected.html
@@ -1,0 +1,1 @@
+<div><div data-count="count: 5">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_only_no_literal/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_only_no_literal/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div class="${cls}">x</div>
+script:
+    let cls = "solo"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_only_no_literal/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_only_no_literal/expected.html
@@ -1,0 +1,1 @@
+<div><div class="solo">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_placeholder_text/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_placeholder_text/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input placeholder="Search ${category}...">
+script:
+    let category = "books"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_placeholder_text/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_placeholder_text/expected.html
@@ -1,0 +1,1 @@
+<div><input placeholder="Search books..."></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><span class="badge ${status}">s</span><button @click="next()">n</button></div>
+script:
+    let status = "idle"
+    function next(){ status = "busy" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><span class="badge busy">s</span><button>n</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/expected.html
@@ -1,0 +1,1 @@
+<div><div><span class="badge idle">s</span><button>n</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_reactive_update/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("span").attr("class", "badge idle");
+  await click("button");
+  expect("span").attr("class", "badge busy");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_multi/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_multi/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div style="color: ${clr}; font-size: ${sz}px">x</div>
+script:
+    let clr = "blue"
+    let sz = 14

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_multi/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_multi/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: blue; font-size: 14px">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_plain/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_plain/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <div style="color: ${clr}">x</div>
+script:
+    let clr = "red"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_plain/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_style_plain/expected.html
@@ -1,0 +1,1 @@
+<div><div style="color: red">x</div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_title_sentence/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_title_sentence/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <span title="Hello, ${name}! You have ${count} messages.">hover</span>
+script:
+    let name = "Ada"
+    let count = 3

--- a/crates/lunas_compiler/tests/runtime/samples/attr/interp_title_sentence/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/interp_title_sentence/expected.html
@@ -1,0 +1,1 @@
+<div><span title="Hello, Ada! You have 3 messages.">hover</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :value="name">
+script:
+    let name = "Ada"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_bind/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").value("Ada");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <input :value="count">
+script:
+    let count = 42

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_numeric/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("input").prop("value", 42);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><input :value="text"><button @click="bump()">+</button></div>
+script:
+    let text = "v1"
+    function bump(){ text = "v2" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><input><button>+</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><input><button>+</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_reactive/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("input").value("v1");
+  await click("button");
+  expect("input").value("v2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <select :value="chosen"><option value="a">A</option><option value="b">B</option></select>
+script:
+    let chosen = "b"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/expected.after.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option><option value="b">B</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/expected.html
@@ -1,0 +1,1 @@
+<div><select><option value="a">A</option><option value="b">B</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_select/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("select").prop("value", "b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <textarea :value="content"></textarea>
+script:
+    let content = "line one"

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/expected.after.html
@@ -1,0 +1,1 @@
+<div><textarea></textarea></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/expected.html
@@ -1,0 +1,1 @@
+<div><textarea></textarea></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/prop_value_textarea/steps.mjs
@@ -1,0 +1,3 @@
+export default async ({ expect }) => {
+  expect("textarea").value("line one");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <span :title="count + ' clicks'" @click="inc()">x</span>
+script:
+    let count = 0
+    function inc(){ count++ }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/expected.after.html
@@ -1,0 +1,1 @@
+<div><span title="1 clicks">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/expected.html
@@ -1,0 +1,1 @@
+<div><span title="0 clicks">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_attr_from_computed/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("span").attr("title", "0 clicks");
+  await click("span");
+  expect("span").attr("title", "1 clicks");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <input type="checkbox" :checked="remaining == 0" @click="dec()">
+script:
+    let remaining = 1
+    function dec(){ remaining-- }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/expected.after.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/expected.html
@@ -1,0 +1,1 @@
+<div><input type="checkbox"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_checked_from_derived_bool/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("input").prop("checked", false);
+  await click("input");
+  expect("input").prop("checked", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <span class="box ${theme}" @click="darken()">x</span>
+script:
+    let theme = "light"
+    function darken(){ theme = "dark" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/expected.after.html
@@ -1,0 +1,1 @@
+<div><span class="box dark">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/expected.html
@@ -1,0 +1,1 @@
+<div><span class="box light">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_class_interp_on_click/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("span").attr("class", "box light");
+  await click("span");
+  expect("span").attr("class", "box dark");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <a :href="url" :title="label" @click="go()">nav</a>
+script:
+    let url = "/step1"
+    let label = "Step 1"
+    function go(){ url = "/step2"; label = "Step 2" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/expected.after.html
@@ -1,0 +1,1 @@
+<div><a href="/step2" title="Step 2">nav</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/step1" title="Step 1">nav</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_href_and_title_together/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("a").attr("href", "/step1").attr("title", "Step 1");
+  await click("a");
+  expect("a").attr("href", "/step2").attr("title", "Step 2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/App.lunas
@@ -1,0 +1,7 @@
+html:
+    <input :id="elId" :placeholder="ph" :disabled="d" @focus="activate()">
+script:
+    let elId = "field1"
+    let ph = "type here"
+    let d = true
+    function activate(){ d = false }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/expected.after.html
@@ -1,0 +1,1 @@
+<div><input id="field1" placeholder="type here"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/expected.html
@@ -1,0 +1,1 @@
+<div><input id="field1" placeholder="type here"></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multi_attrs_one_el/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, dispatch }) => {
+  expect("input").attr("id", "field1").attr("placeholder", "type here").prop("disabled", true);
+  await dispatch("input", "focus");
+  expect("input").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><button :disabled="busy" @click="go()">a</button><button :disabled="busy" @click="go()">b</button></div>
+script:
+    let busy = false
+    function go(){ busy = true }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>a</button><button>b</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_multiple_elements_shared_state/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, expect, click }) => {
+  expect($$("button")[0]).prop("disabled", false);
+  expect($$("button")[1]).prop("disabled", false);
+  await click($$("button")[0]);
+  expect($$("button")[0]).prop("disabled", true);
+  expect($$("button")[1]).prop("disabled", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <details :open="isOpen"><summary @click="toggle()">s</summary>body</details>
+script:
+    let isOpen = false
+    function toggle(){ isOpen = !isOpen }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><details open="true"><summary>s</summary>body</details></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><details open="false"><summary>s</summary>body</details></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_open_details_toggle/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("details").attr("open", "false");
+  await click("summary");
+  expect("details").attr("open", "true");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <span :tabindex="idx" @click="cycle()">x</span>
+script:
+    let idx = 0
+    function cycle(){ idx = idx + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><span tabindex="1">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><span tabindex="0">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_tabindex_numeric_toggle/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("span").attr("tabindex", "0");
+  await click("span");
+  expect("span").attr("tabindex", "1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <button :disabled="busy" @click="toggle()">save</button>
+script:
+    let busy = false
+    function toggle(){ busy = !busy }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>save</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/expected.html
@@ -1,0 +1,1 @@
+<div><button>save</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_disabled_button/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ expect, click }) => {
+  expect("button").prop("disabled", false);
+  await click("button");
+  expect("button").prop("disabled", true);
+  await click("button");
+  expect("button").prop("disabled", false);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><p :hidden="isHidden">msg</p><button @click="toggle()">t</button></div>
+script:
+    let isHidden = false
+    function toggle(){ isHidden = !isHidden }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><p>msg</p><button>t</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/expected.html
@@ -1,0 +1,1 @@
+<div><div><p>msg</p><button>t</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_hidden_div/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("p").prop("hidden", false);
+  await click("button");
+  expect("p").prop("hidden", true);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <a :href="url" @click="swap()">link</a>
+script:
+    let url = "/a"
+    function swap(){ url = "/b" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/expected.after.html
@@ -1,0 +1,1 @@
+<div><a href="/b">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/expected.html
@@ -1,0 +1,1 @@
+<div><a href="/a">link</a></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_href/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("a").attr("href", "/a");
+  await click("a");
+  expect("a").attr("href", "/b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <span :title="hint" @click="next()">x</span>
+script:
+    let hint = "first"
+    function next(){ hint = "second" }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/expected.after.html
@@ -1,0 +1,1 @@
+<div><span title="second">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/expected.html
@@ -1,0 +1,1 @@
+<div><span title="first">x</span></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_toggle_title/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ expect, click }) => {
+  expect("span").attr("title", "first");
+  await click("span");
+  expect("span").attr("title", "second");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/App.lunas
@@ -1,0 +1,6 @@
+html:
+    <input :value="val" :disabled="locked" @click="unlock()">
+script:
+    let val = "x"
+    let locked = true
+    function unlock(){ locked = false }

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/expected.after.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/expected.html
@@ -1,0 +1,1 @@
+<div><input></div>

--- a/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/attr/react_value_and_disabled_together/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ expect, click }) => {
+  expect("input").value("x");
+  expect("input").prop("disabled", true);
+  await click("input");
+  expect("input").prop("disabled", false);
+};


### PR DESCRIPTION
## Summary
- Adds 107 new sample-directory E2E cases under `crates/lunas_compiler/tests/runtime/samples/attr/` (110 total in the category including the 3 pre-existing seeds), covering the attribute-binding surface end to end:
  - **bound attributes**: `id`, `title`, `href`, `src`, `alt`, `data-*`, `aria-*`, `role`, `name`, `type`, `placeholder`, `colspan`, `tabindex`, `min`/`max`/`step`, `srcset`, `download`, computed/concatenated/ternary expressions, multiple binds on one element.
  - **boolean attributes**: `disabled`, `checked`, `selected`, `readonly`, `multiple`, `hidden` (the compiler's hardcoded `boolean_property` IDL list — truthy/falsy via `!!(value)`, asserted with `.prop(...)`), plus `required`/`open` (NOT in that list — plain `setAttribute`, so the literal stringified value is asserted with `.attr(...)`).
  - **property vs attribute**: `:value` on `input`/`textarea`/`select` (IDL property, asserted with `.value`/`.prop`) vs plain attribute binds like `:href`.
  - **interpolated static attrs**: `class="a ${x}"`, `style="color: ${c}"`, multi-interpolation, prefix/suffix text, `href`/`title`/`data-*`/`placeholder`/`alt` with embedded expressions — confirmed these do **not** go through the `:class`/`:style` object-merge helper (that's a separate `Bound` codegen path), just plain interpolated `setAttribute`.
  - **reactivity** (`steps.mjs`): `@click` toggling `disabled`/`hidden`/`title`/`href`/`class`/`tabindex`, multiple attrs on one element updating together, an attribute driven by an inline computed expression (`:title="count + ' clicks'"`).
  - **edge cases**: `null`/`undefined`/`false`/`0`/`""` values (discovered via `UPDATE_EXPECTED=1`, not assumed — e.g. plain attrs stringify literally: `data-x="undefined"`, no auto-removal; `:value=null` reads back as `""` per IDL reflection; boolean-property attrs like `disabled`/`checked`/`hidden` aren't reflected into `outerHTML` at all, only observable via `.prop()`), special characters/quotes/ampersands, very long values, multiple elements sharing an attribute name.

## Surprises / findings worth flagging
- **Not a compiler bug, but a test-harness gotcha**: the mounted component is always wrapped in a synthetic root `<div>` (see `README.md`). A case whose *authored* root element is also a bare `<div>` with `expect("div")` in `steps.mjs` matches the **wrapper**, not the intended element, since the kit's selector walk visits the root before its children. Fixed by using a distinct root tag (`<span>`) in the handful of cases that needed root-level attribute assertions in `steps.mjs`.
- `:for="someId"` (binding the HTML `for` attribute) collides with the `:for` list-loop directive keyword and is rejected by the parser as an "unrecognized `:for` header" diagnostic — dropped the two cases that tried this (`label[for]` binding isn't expressible via `:for=`, only via plain/interpolated `for="..."`).
- Confirmed the boolean-attribute IDL list is exactly `checked`, `disabled`, `selected`, `readonly` (→ `readOnly`), `multiple`, `hidden` (`crates/lunas_compiler/src/codegen/emit.rs::boolean_property`); the IDL-property list is just `value` (`::idl_property`). Everything else — including `required`, `open`, `className`, `htmlFor` written directly — falls through to plain `setAttribute`.
- Static-interpolated `class="a ${x}"` (no leading colon) is *not* routed through the `:class` merge/normalization helper (`setClass`/`normClass`); it's a plain interpolated `setAttribute("class", ...)`, so it won't merge with a co-existing `:class` binding on the same element the way two `:class` sources would.

## Test plan
- [x] `UPDATE_EXPECTED=1 cargo test -p lunas_compiler --test runtime_samples` (from `crates/`) to generate/regenerate `expected.html`/`expected.after.html`, reviewed diffs.
- [x] `cargo test -p lunas_compiler --test runtime_samples` — full suite green: 135 passed (110 in `attr/`, 25 pre-existing elsewhere), 0 failed.
- [x] `cargo fmt --check` — clean (no Rust source touched).
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] Confirmed no files outside `samples/attr/` were modified (`git status`/`git diff --stat` clean elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)