### PR TITLE
test(samples): components & props E2E cases

### DIFF
--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :count="a * b + 1"/></div>
+script:
+    let a = 3
+    let b = 4

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_arithmetic_expr_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>13</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :items="list"/></div>
+script:
+    let list = ["a", "b", "c"]

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input items:array = []
+html:
+    <span>${items.length}:${items[0]}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_array_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>3:a</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :on="flag"/></div>
+script:
+    let flag = false

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/Child.lunas
@@ -1,0 +1,3 @@
+@input on:boolean = true
+html:
+    <span>${on ? "Y" : "N"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_false/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>N</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :on="flag"/></div>
+script:
+    let flag = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/Child.lunas
@@ -1,0 +1,3 @@
+@input on:boolean = false
+html:
+    <span>${on ? "Y" : "N"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_boolean_prop_true/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>Y</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :a="x" :b="y"/></div>
+script:
+    let x = "1"
+    let y = "2"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/Child.lunas
@@ -1,0 +1,4 @@
+@input a:string = ""
+@input b:string = ""
+html:
+    <span>${a}</span><span>${b}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_multiple_roots/expected.html
@@ -1,0 +1,1 @@
+<div><div><span>1</span><span>2</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/App.lunas
@@ -1,0 +1,3 @@
+@use Clock from "./Clock.lunas"
+html:
+    <div><Clock/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/Clock.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/Clock.lunas
@@ -1,0 +1,4 @@
+html:
+    <span>${label}</span>
+script:
+    let label = "tick"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_no_props_local_only/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>tick</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child code="404"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/Child.lunas
@@ -1,0 +1,3 @@
+@input code:string = ""
+html:
+    <span>${code}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_static_number_like_string/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>404</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/App.lunas
@@ -1,0 +1,6 @@
+@use Link from "./Link.lunas"
+html:
+    <div><Link :href="url" :text="label"/></div>
+script:
+    let url = "/docs"
+    let label = "Docs"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/Link.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/Link.lunas
@@ -1,0 +1,4 @@
+@input href:string = "#"
+@input text:string = ""
+html:
+    <a :href="href">${text}</a>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_child_uses_prop_in_text_and_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><a href="/docs">Docs</a></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input on:boolean = true
+html:
+    <span>${on ? "Y" : "N"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_boolean_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>Y</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 100
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_number_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>100</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input user:object = { name: "def", age: 0 }
+html:
+    <span>${user.name}-${user.age}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_object_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>def-0</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="given"/></div>
+script:
+    let given = "override"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = "fallback"
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_overridden/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>override</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = "fallback"
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/_config.json
@@ -1,0 +1,1 @@
+{"description": "omitted prop uses the child @input default"}

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_default_prop_used/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>fallback</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="a + b"/></div>
+script:
+    let a = "foo"
+    let b = "bar"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_interpolated_expr_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>foobar</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child kind="lead" :count="n"/></div>
+script:
+    let n = 9

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/Child.lunas
@@ -1,0 +1,4 @@
+@input kind:string = "plain"
+@input count:number = 0
+html:
+    <span>${kind}#${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_mixed_static_and_bound/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>lead#9</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/App.lunas
@@ -1,0 +1,7 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :name="who" :count="n" :on="flag"/></div>
+script:
+    let who = "ada"
+    let n = 3
+    let flag = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/Child.lunas
@@ -1,0 +1,5 @@
+@input name:string = ""
+@input count:number = 0
+@input on:boolean = false
+html:
+    <span>${name}:${count}:${on ? "on" : "off"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_multiple_props/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>ada:3:on</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :count="7"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_literal_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>7</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :count="n"/></div>
+script:
+    let n = 42

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_number_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>42</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :user="obj"/></div>
+script:
+    let obj = { name: "ada", age: 3 }

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input user:object = {}
+html:
+    <span>${user.name}-${user.age}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_object_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>ada-3</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :note="msg"/></div>
+script:
+    let msg = "here"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/Child.lunas
@@ -1,0 +1,3 @@
+@input note:string?
+html:
+    <span>[${note ?? "none"}]</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_given/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>[here]</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/Child.lunas
@@ -1,0 +1,3 @@
+@input note:string?
+html:
+    <span>[${note ?? "none"}]</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/_config.json
@@ -1,0 +1,1 @@
+{"description": "optional prop with no default and no value passed"}

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_optional_prop_no_default/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>[none]</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :disabled="d"/></div>
+script:
+    let d = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/Child.lunas
@@ -1,0 +1,3 @@
+@input disabled:boolean = false
+html:
+    <button :class="{ off: disabled }">${disabled ? "no" : "yes"}</button>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_boolean_in_ternary_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button class="off">no</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :tone="t"/></div>
+script:
+    let t = "warn"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/Child.lunas
@@ -1,0 +1,3 @@
+@input tone:string = "plain"
+html:
+    <span class="badge ${tone}">x</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_string_interp_in_class/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span class="badge warn">x</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :url="link"/></div>
+script:
+    let link = "/home"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/Child.lunas
@@ -1,0 +1,3 @@
+@input url:string = "/"
+html:
+    <a :href="url">go</a>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><a href="/home">go</a></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :active="flag"/></div>
+script:
+    let flag = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/Child.lunas
@@ -1,0 +1,3 @@
+@input active:boolean = false
+html:
+    <span class="base" :class="{ active: active }">x</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_class/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span class="base active">x</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :hue="color"/></div>
+script:
+    let color = "red"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/Child.lunas
@@ -1,0 +1,3 @@
+@input hue:string = "black"
+html:
+    <span :style="{ color: hue }">x</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_prop_used_in_style/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span style="color: red;">x</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :name="who"/></div>
+script:
+    let who = "ada"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input name:string = "def"
+html:
+    <span>${name}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_reactive_string_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>ada</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/Child.lunas
@@ -1,0 +1,2 @@
+html:
+    <span>hi from child</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_single_child/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>hi from child</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child name="hello"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input name:string = "def"
+html:
+    <span>${name}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_static_string_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>hello</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :name="'literal'"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input name:string = "def"
+html:
+    <span>${name}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_string_literal_bound_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>literal</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="n > 0 ? 'pos' : 'neg'"/></div>
+script:
+    let n = 5

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_ternary_expr_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>pos</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :a="x"/></div>
+script:
+    let x = "AA"

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/Child.lunas
@@ -1,0 +1,4 @@
+@input a:string = "da"
+@input b:string = "db"
+html:
+    <span>${a}-${b}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/basic_two_props_one_default_one_given/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>AA-db</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :featured="f"/></div>
+script:
+    let f = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/Child.lunas
@@ -1,0 +1,6 @@
+@input featured:boolean = false
+html:
+    <button @click="toggle()" class="card" :class="{ featured: featured, open: open }">x</button>
+script:
+    let open = false
+    function toggle(){ open = !open }

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button class="card featured open">x</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button class="card featured">x</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_conditional_class_from_prop_and_local/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  const el = $("button.card");
+  expect(el).hasClass("featured");
+  await click(el);
+  expect(el).hasClass("open");
+  expect(el).hasClass("featured");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :step="s"/></div>
+script:
+    let s = 3

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/Child.lunas
@@ -1,0 +1,6 @@
+@input step:number = 1
+html:
+    <button @click="add()">${clicks * step}</button>
+script:
+    let clicks = 0
+    function add(){ clicks++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>6</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button>0</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_event_uses_prop/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect($("button")).text("0");
+  await click("button");
+  expect($("button")).text("3");
+  await click("button");
+  expect($("button")).text("6");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/App.lunas
@@ -1,0 +1,5 @@
+@use List from "./List.lunas"
+html:
+    <div><List :items="data"/></div>
+script:
+    let data = ["x", "y"]

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/List.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/List.lunas
@@ -1,0 +1,5 @@
+@input items:array = []
+html:
+    <ul><li :for="it of items" :key="it">${prefix}${it}</li></ul>
+script:
+    let prefix = "- "

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_for_over_prop_with_local_prefix/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><ul><li>- x</li><li>- y</li></ul></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :mode="m"/></div>
+script:
+    let m = "two"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input mode:string = "one"
+html:
+    <div><p :if="mode == 'one'">ONE</p><p :elseif="mode == 'two'">TWO</p><p :else>OTHER</p></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_elseif_else_from_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div><p>TWO</p></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="l"/></div>
+script:
+    let l = "content"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/Child.lunas
@@ -1,0 +1,6 @@
+@input label:string = ""
+html:
+    <div><button @click="toggle()">t</button><p :if="open">${label}</p></div>
+script:
+    let open = false
+    function toggle(){ open = !open }

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><div><button>t</button><p>content</p></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div><button>t</button></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_if_from_local_toggled_by_button/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ click, expect }) => {
+  expect("p").count(0);
+  await click("button");
+  expect("p").count(1);
+  expect("p").text("content");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/App.lunas
@@ -1,0 +1,3 @@
+@use Counter from "./Counter.lunas"
+html:
+    <div><Counter/><Counter/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/Counter.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/Counter.lunas
@@ -1,0 +1,5 @@
+html:
+    <button @click="inc()">${n}</button>
+script:
+    let n = 0
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>2</button></div><div><button>0</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button>0</button></div><div><button>0</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_counter_does_not_leak_to_sibling/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, click, expect }) => {
+  const [a, b] = $$("button");
+  await click(a);
+  await click(a);
+  expect(a).text("2");
+  expect(b).text("0");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :prefix="p"/></div>
+script:
+    let p = "P"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/Child.lunas
@@ -1,0 +1,5 @@
+@input prefix:string = ""
+html:
+    <span>${prefix}-${suffix}</span>
+script:
+    let suffix = "S"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_local_state_and_prop_mixed/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>P-S</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :a="p1" :b="p2"/></div>
+script:
+    let p1 = "A"
+    let p2 = "B"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/Child.lunas
@@ -1,0 +1,7 @@
+@input a:string = ""
+@input b:string = ""
+html:
+    <span>${a}${b}${loc1}${loc2}</span>
+script:
+    let loc1 = "C"
+    let loc2 = "D"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_multiple_locals_and_props/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>ABCD</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="l"/></div>
+script:
+    let l = "given"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/Child.lunas
@@ -1,0 +1,5 @@
+@input label:string = "def"
+html:
+    <span>${label}-${mode}</span>
+script:
+    let mode = "auto"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_own_default_not_overridden/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>given-auto</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :tag="label"/></div>
+script:
+    let label = "hi"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/Child.lunas
@@ -1,0 +1,6 @@
+@input tag:string = ""
+html:
+    <button @click="reveal()">${shown ? tag : ""}</button>
+script:
+    let shown = false
+    function reveal(){ shown = true }

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>hi</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button></button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_prop_in_event_handler_arg/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("button")).text("");
+  await click("button");
+  expect($("button")).text("hi");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :items="list"/></div>
+script:
+    let list = ["x", "y", "z"]

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input items:array = []
+html:
+    <ul><li :for="it of items" :key="it">${it}</li></ul>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_for_from_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><ul><li>x</li><li>y</li><li>z</li></ul></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :show="flag"/></div>
+script:
+    let flag = true

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input show:boolean = false
+html:
+    <section><span :if="show">visible</span></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_own_if_from_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><span>visible</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :name="who"/></div>
+script:
+    let who = "ada"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/Child.lunas
@@ -1,0 +1,3 @@
+@input name:string = ""
+html:
+    <div :title="name"><span>${name}</span><b>${name}!</b></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_prop_in_multiple_places/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div title="ada"><span>ada</span><b>ada!</b></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/App.lunas
@@ -1,0 +1,5 @@
+@use Panel from "./Panel.lunas"
+html:
+    <div><Panel :title="t"/></div>
+script:
+    let t = "Settings"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/Panel.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/Panel.lunas
@@ -1,0 +1,3 @@
+@input title:string = ""
+html:
+    <section class="panel"><header>${title}</header><main>content</main></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_renders_slot_free_static_markup/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section class="panel"><header>Settings</header><main>content</main></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :init="seed"/></div>
+script:
+    let seed = "hello"

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/Child.lunas
@@ -1,0 +1,5 @@
+@input init:string = ""
+html:
+    <div><input ::value="text"><span>${text}</span></div>
+script:
+    let text = init

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><div><input><span>world</span></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div><input><span>hello</span></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/child_two_way_input_local/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, setValue, expect }) => {
+  expect($("span")).text("hello");
+  await setValue("input", "world");
+  expect($("span")).text("world");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/><Child :on="true"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/Child.lunas
@@ -1,0 +1,3 @@
+@input on:boolean = false
+html:
+    <span>${on ? "T" : "F"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_bool_prop_default_when_omitted_vs_given/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>F</span></div><div><span>T</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input base:number = 10
+html:
+    <span>${base * 2}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_default_expr_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>20</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child label="static"/><Child :label="dyn"/></div>
+script:
+    let dyn = "bound"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = "def"
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_child_reused_static_vs_bound/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>static</span></div><div><span>bound</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/App.lunas
@@ -1,0 +1,3 @@
+@use Mid from "./Mid.lunas"
+html:
+    <div><Mid/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/Leaf.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/Leaf.lunas
@@ -1,0 +1,3 @@
+@input tag:string = "leafDef"
+html:
+    <b>${tag}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/Mid.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/Mid.lunas
@@ -1,0 +1,4 @@
+@use Leaf from "./Leaf.lunas"
+@input tag:string = "midDef"
+html:
+    <section><Leaf/></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_missing_optional_uses_default_deep/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><b>leafDef</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child/><Child :label="x"/><Child/></div>
+script:
+    let x = "mid"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = "D"
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_multiple_children_mixed_defaults/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>D</span></div><div><span>mid</span></div><div><span>D</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :cfg="config"/></div>
+script:
+    let config = { theme: { name: "dark", level: 2 } }

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/Child.lunas
@@ -1,0 +1,3 @@
+@input cfg:object = {}
+html:
+    <span>${cfg.theme.name}/${cfg.theme.level}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_object_prop_nested_access/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>dark/2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :csv="parts.join(',')"/></div>
+script:
+    let parts = ["a", "b", "c"]

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/Child.lunas
@@ -1,0 +1,3 @@
+@input csv:string = ""
+html:
+    <span>${csv}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_array_join_expr/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>a,b,c</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="e"/></div>
+script:
+    let e = ""

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = "def"
+html:
+    <span>[${label}]</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_empty_string/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>[]</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/App.lunas
@@ -1,0 +1,8 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button class="a" @click="incA()">a</button><button class="b" @click="incB()">b</button><Child :sum="a + b"/></div>
+script:
+    let a = 1
+    let b = 2
+    function incA(){ a++ }
+    function incB(){ b++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/Child.lunas
@@ -1,0 +1,3 @@
+@input sum:number = 0
+html:
+    <span>${sum}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><span>5</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><span>3</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expr_recomputed_on_dep_change/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("3");
+  await click(".a");
+  expect($("span")).text("4");
+  await click(".b");
+  expect($("span")).text("5");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="name.toUpperCase()"/></div>
+script:
+    let name = "ada"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_expression_with_method_call/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>ADA</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :count="0"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 99
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/_config.json
@@ -1,0 +1,1 @@
+{"description": "explicit 0 prop overrides default (not treated as omitted)"}

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_falsy_zero/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>0</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="a"/><Child :label="b"/></div>
+script:
+    let a = "first"
+    let b = "second"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_name_collides_across_children/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>first</span></div><div><span>second</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/App.lunas
@@ -1,0 +1,5 @@
+@use Mid from "./Mid.lunas"
+html:
+    <div><Mid :msg="text"/></div>
+script:
+    let text = "deep"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/Leaf.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/Leaf.lunas
@@ -1,0 +1,3 @@
+@input msg:string = ""
+html:
+    <b>${msg}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/Mid.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/Mid.lunas
@@ -1,0 +1,4 @@
+@use Leaf from "./Leaf.lunas"
+@input msg:string = ""
+html:
+    <section><Leaf :msg="msg"/></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><b>deep</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/App.lunas
@@ -1,0 +1,6 @@
+@use Mid from "./Mid.lunas"
+html:
+    <div><button @click="swap()">p</button><Mid :msg="text"/></div>
+script:
+    let text = "one"
+    function swap(){ text = "two" }

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/Leaf.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/Leaf.lunas
@@ -1,0 +1,3 @@
+@input msg:string = ""
+html:
+    <b>${msg}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/Mid.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/Mid.lunas
@@ -1,0 +1,4 @@
+@use Leaf from "./Leaf.lunas"
+@input msg:string = ""
+html:
+    <section><Leaf :msg="msg"/></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><section><div><b>two</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><section><div><b>one</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_passthrough_two_levels_reactive/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("b")).text("one");
+  await click("button");
+  expect($("b")).text("two");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/App.lunas
@@ -1,0 +1,4 @@
+@use Num from "./Num.lunas"
+@use Str from "./Str.lunas"
+html:
+    <div><Num :value="7"/><Str :value="'seven'"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/Num.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/Num.lunas
@@ -1,0 +1,3 @@
+@input value:number = 0
+html:
+    <span>n:${value}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/Str.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/Str.lunas
@@ -1,0 +1,3 @@
+@input value:string = ""
+html:
+    <span>s:${value}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_same_name_different_types/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>n:7</span></div><div><span>s:seven</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :rows="data"/></div>
+script:
+    let data = [[1,2],[3,4]]

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/Child.lunas
@@ -1,0 +1,3 @@
+@input rows:array = []
+html:
+    <div :for="row of rows" :key="row" class="r"><b :for="c of row" :key="c">${c}</b></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_prop_used_in_nested_for_of_child/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div class="r"><b>1</b><b>2</b></div><div class="r"><b>3</b><b>4</b></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :value="v"/></div>
+script:
+    let v = "parent"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/Child.lunas
@@ -1,0 +1,5 @@
+@input value:string = ""
+html:
+    <span>${value}|${value2}</span>
+script:
+    let value2 = "child"

--- a/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/edge_same_prop_name_as_local/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>parent|child</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><span :if="on"><Child :label="msg"/></span></div>
+script:
+    let on = false
+    let msg = "hidden"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <b>${label}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/_config.json
@@ -1,0 +1,1 @@
+{"description": "component under a false :if container is not rendered"}

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_hidden/expected.html
@@ -1,0 +1,1 @@
+<div><div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><span :if="on"><Child :label="msg"/></span></div>
+script:
+    let on = true
+    let msg = "visible"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <b>${label}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_inside_if_shown/expected.html
@@ -1,0 +1,1 @@
+<div><div><span><div><b>visible</b></div></span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/App.lunas
@@ -1,0 +1,6 @@
+@use Badge from "./Badge.lunas"
+html:
+    <div><Badge :text="a" :tone="'lead'"/><Badge :text="b" :tone="'warn'"/></div>
+script:
+    let a = "alpha"
+    let b = "beta"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/Badge.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/Badge.lunas
@@ -1,0 +1,4 @@
+@input text:string = "?"
+@input tone:string = "plain"
+html:
+    <span class="badge ${tone}">${text}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_child_reused_different_props/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span class="badge lead">alpha</span></div><div><span class="badge warn">beta</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/App.lunas
@@ -1,0 +1,5 @@
+@use Item from "./Item.lunas"
+html:
+    <ul><li :for="it of items" :key="it.id"><Item :label="it.label" :n="it.id"/></li></ul>
+script:
+    let items = [{id:10,label:"x"},{id:20,label:"y"}]

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/Item.lunas
@@ -1,0 +1,4 @@
+@input label:string = ""
+@input n:number = 0
+html:
+    <span>${n}=${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_for_with_index_prop/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li><div><span>10=x</span></div></li><li><div><span>20=y</span></div></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/App.lunas
@@ -1,0 +1,5 @@
+@use Item from "./Item.lunas"
+html:
+    <ul><li :for="it of items" :key="it.id"><Item :label="it.label"/></li></ul>
+script:
+    let items = [{id:1,label:"a"},{id:2,label:"b"},{id:3,label:"c"}]

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_children_list_via_for/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li><li><div><span>c</span></div></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/App.lunas
@@ -1,0 +1,7 @@
+@use Head from "./Head.lunas"
+@use Body from "./Body.lunas"
+html:
+    <div><Head :title="t"/><Body :text="b"/></div>
+script:
+    let t = "Title"
+    let b = "Body text"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/Body.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/Body.lunas
@@ -1,0 +1,3 @@
+@input text:string = ""
+html:
+    <p>${text}</p>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/Head.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/Head.lunas
@@ -1,0 +1,3 @@
+@input title:string = ""
+html:
+    <h1>${title}</h1>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_different_child_types/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><h1>Title</h1></div><div><p>Body text</p></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/App.lunas
@@ -1,0 +1,5 @@
+@use L1 from "./L1.lunas"
+html:
+    <div><L1 :v="n"/></div>
+script:
+    let n = 1

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L1.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L1.lunas
@@ -1,0 +1,4 @@
+@use L2 from "./L2.lunas"
+@input v:number = 0
+html:
+    <div class="l1"><L2 :v="v + 1"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L2.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L2.lunas
@@ -1,0 +1,4 @@
+@use L3 from "./L3.lunas"
+@input v:number = 0
+html:
+    <div class="l2"><L3 :v="v + 1"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L3.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/L3.lunas
@@ -1,0 +1,3 @@
+@input v:number = 0
+html:
+    <span class="l3">${v}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_three_levels/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><div class="l1"><div><div class="l2"><div><span class="l3">3</span></div></div></div></div></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :v="n"/></div>
+script:
+    let n = 5

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/Child.lunas
@@ -1,0 +1,4 @@
+@use Grand from "./Grand.lunas"
+@input v:number = 0
+html:
+    <section><Grand :w="v"/></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/Grand.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/Grand.lunas
@@ -1,0 +1,3 @@
+@input w:number = 0
+html:
+    <b>${w}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_grandchild_two_levels/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><section><div><b>5</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/App.lunas
@@ -1,0 +1,9 @@
+@use Head from "./Head.lunas"
+@use Body from "./Body.lunas"
+@use Foot from "./Foot.lunas"
+html:
+    <div><Head :title="t"/><Body :text="b"/><Foot :note="f"/></div>
+script:
+    let t = "T"
+    let b = "B"
+    let f = "F"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Body.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Body.lunas
@@ -1,0 +1,3 @@
+@input text:string = ""
+html:
+    <p>${text}</p>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Foot.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Foot.lunas
@@ -1,0 +1,3 @@
+@input note:string = ""
+html:
+    <footer>${note}</footer>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Head.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/Head.lunas
@@ -1,0 +1,3 @@
+@input title:string = ""
+html:
+    <h1>${title}</h1>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_header_body_footer_components/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><h1>T</h1></div><div><p>B</p></div><div><footer>F</footer></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child label="first"/><Child label="second"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_mixed_static_children/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>first</span></div><div><span>second</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/App.lunas
@@ -1,0 +1,5 @@
+@use Cell from "./Cell.lunas"
+html:
+    <div :for="row of rows" :key="row.id" class="row"><span :for="c of row.cells" :key="c.k"><Cell :v="c.v"/></span></div>
+script:
+    let rows = [{id:1,cells:[{k:1,v:1},{k:2,v:2}]},{id:2,cells:[{k:3,v:3},{k:4,v:4}]}]

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/Cell.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/Cell.lunas
@@ -1,0 +1,3 @@
+@input v:number = 0
+html:
+    <b>${v}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_nested_for_children/expected.html
@@ -1,0 +1,1 @@
+<div><div class="row"><span><div><b>1</b></div></span><span><div><b>2</b></div></span></div><div class="row"><span><div><b>3</b></div></span><span><div><b>4</b></div></span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :n="shared"/><Child :n="shared"/></div>
+script:
+    let shared = 8

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/Child.lunas
@@ -1,0 +1,3 @@
+@input n:number = 0
+html:
+    <span>${n}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_siblings_share_parent_state/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>8</span></div><div><span>8</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/App.lunas
@@ -1,0 +1,3 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :n="1"/><Child :n="2"/><Child :n="3"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/Child.lunas
@@ -1,0 +1,3 @@
+@input n:number = 0
+html:
+    <span>${n}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_three_instances/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>1</span></div><div><span>2</span></div><div><span>3</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child :label="a"/><Child :label="b"/></div>
+script:
+    let a = "one"
+    let b = "two"

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/multi_two_instances_same_type/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><span>one</span></div><div><span>two</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="add()">p</button><Child :items="list"/></div>
+script:
+    let list = ["a"]
+    function add(){ list = [...list, "b"] }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/Child.lunas
@@ -1,0 +1,3 @@
+@input items:array = []
+html:
+    <span>${items.length}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>1</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_array_prop_length_change/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("1");
+  await click("button");
+  expect($("span")).text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="toggle()">p</button><Child :on="flag"/></div>
+script:
+    let flag = false
+    function toggle(){ flag = !flag }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/Child.lunas
@@ -1,0 +1,3 @@
+@input on:boolean = false
+html:
+    <span>${on ? "ON" : "OFF"}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>OFF</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>OFF</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_boolean_prop_toggle/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("OFF");
+  await click("button");
+  expect($("span")).text("ON");
+  await click("button");
+  expect($("span")).text("OFF");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/App.lunas
@@ -1,0 +1,5 @@
+@use Counter from "./Counter.lunas"
+html:
+    <div><Counter :start="seed"/></div>
+script:
+    let seed = 5

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/Counter.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/Counter.lunas
@@ -1,0 +1,6 @@
+@input start:number = 0
+html:
+    <button @click="inc()">count: ${value}</button>
+script:
+    let value = start
+    function inc(){ value++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>count: 6</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button>count: 5</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_button_updates_own_text/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("button")).text("count: 5");
+  await click("button");
+  expect($("button")).text("count: 6");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :count="n"/></div>
+script:
+    let n = 0
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count == 0 ? "empty" : count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>1</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>empty</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_conditional_text_from_prop/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("empty");
+  await click("button");
+  expect($("span")).text("1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button class="p" @click="toggle()">p</button><Child :disabled="d"/></div>
+script:
+    let d = false
+    function toggle(){ d = !d }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/Child.lunas
@@ -1,0 +1,3 @@
+@input disabled:boolean = false
+html:
+    <button class="c" :class="{ off: disabled }">go</button>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="p">p</button><div><button class="c">go</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="p">p</button><div><button class="c">go</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_disabled_prop_toggle/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $, click, expect }) => {
+  const c = $("button.c");
+  expect(c).attr("class", "c");
+  await click(".p");
+  expect(c).hasClass("off");
+  await click(".p");
+  expect(c).attr("class", "c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/App.lunas
@@ -1,0 +1,7 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="toggle()">p</button><span :if="on"><Child :label="msg"/></span></div>
+script:
+    let on = false
+    let msg = "now shown"
+    function toggle(){ on = !on }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/Child.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <b>${label}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_in_if_toggle/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ click, expect }) => {
+  expect("b").count(0);
+  await click("button");
+  expect("b").count(1);
+  expect("b").text("now shown");
+  await click("button");
+  expect("b").count(0);
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/App.lunas
@@ -1,0 +1,5 @@
+@use Child from "./Child.lunas"
+html:
+    <div><span class="p">${n}</span><Child/></div>
+script:
+    let n = 0

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/Child.lunas
@@ -1,0 +1,5 @@
+html:
+    <section><button @click="bump()">c</button><span class="c">${local}</span></section>
+script:
+    let local = 0
+    function bump(){ local++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><span class="p">0</span><div><section><button>c</button><span class="c">1</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/expected.html
@@ -1,0 +1,1 @@
+<div><div><span class="p">0</span><div><section><button>c</button><span class="c">0</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_local_state_isolated/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $, click, expect }) => {
+  expect($(".p")).text("0");
+  expect($(".c")).text("0");
+  await click("button");
+  expect($(".c")).text("1");
+  // parent state untouched by child-local mutation
+  expect($(".p")).text("0");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/App.lunas
@@ -1,0 +1,6 @@
+@use Item from "./Item.lunas"
+html:
+    <div><button @click="edit()">p</button><ul><li :for="it of items" :key="it.id"><Item :label="it.label"/></li></ul></div>
+script:
+    let items = [{id:1,label:"a"},{id:2,label:"b"}]
+    function edit(){ items = [{id:1,label:"A"},{id:2,label:"b"}] }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>A</span></div></li><li><div><span>b</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_child_prop_from_list_item_edit/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ $$, click, expect }) => {
+  const spans = $$("span");
+  expect(spans[0]).text("a");
+  await click("button");
+  expect($$("span")[0]).text("A");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :doubled="n * 2"/></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/Child.lunas
@@ -1,0 +1,3 @@
+@input doubled:number = 0
+html:
+    <span>${doubled}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>6</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_computed_prop_recomputed/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("2");
+  await click("button");
+  expect($("span")).text("4");
+  await click("button");
+  expect($("span")).text("6");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/App.lunas
@@ -1,0 +1,6 @@
+@use Item from "./Item.lunas"
+html:
+    <div><button @click="drop()">p</button><ul><li :for="it of items" :key="it.id"><Item :label="it.label"/></li></ul></div>
+script:
+    let items = [{id:1,label:"a"},{id:2,label:"b"},{id:3,label:"c"}]
+    function drop(){ items.splice(1, 1) }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li><li><div><span>c</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li><li><div><span>c</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_remove_keyed/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, click, expect }) => {
+  expect("span").count(3);
+  await click("button");
+  expect("span").count(2);
+  const spans = $$("span");
+  expect(spans[1]).text("c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/App.lunas
@@ -1,0 +1,6 @@
+@use Item from "./Item.lunas"
+html:
+    <div><button @click="rev()">p</button><ul><li :for="it of items" :key="it.id"><Item :label="it.label"/></li></ul></div>
+script:
+    let items = [{id:1,label:"a"},{id:2,label:"b"},{id:3,label:"c"}]
+    function rev(){ items = [items[2], items[1], items[0]] }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>c</span></div></li><li><div><span>b</span></div></li><li><div><span>a</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li><li><div><span>c</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_child_reorder_keyed/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $$, click, expect }) => {
+  let spans = $$("span");
+  expect(spans[0]).text("a");
+  await click("button");
+  spans = $$("span");
+  expect(spans[0]).text("c");
+  expect(spans[2]).text("a");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/App.lunas
@@ -1,0 +1,6 @@
+@use Item from "./Item.lunas"
+html:
+    <div><button @click="add()">p</button><ul><li :for="it of items" :key="it.id"><Item :label="it.label"/></li></ul></div>
+script:
+    let items = [{id:1,label:"a"}]
+    function add(){ items.push({id: items.length + 1, label: "x"}) }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li><li><div><span>x</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><ul><li><div><span>a</span></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_for_children_push/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $$, click, expect }) => {
+  expect("span").count(1);
+  await click("button");
+  expect("span").count(2);
+  const spans = $$("span");
+  expect(spans[1]).text("x");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :v="n"/></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/Child.lunas
@@ -1,0 +1,4 @@
+@use Grand from "./Grand.lunas"
+@input v:number = 0
+html:
+    <section><Grand :w="v"/></section>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/Grand.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/Grand.lunas
@@ -1,0 +1,3 @@
+@input w:number = 0
+html:
+    <b>${w}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><section><div><b>2</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><section><div><b>1</b></div></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_grandchild_receives_update/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("b")).text("1");
+  await click("button");
+  expect($("b")).text("2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :count="n"/><Child :count="n"/></div>
+script:
+    let n = 0
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>1</span></div><div><span>1</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>0</span></div><div><span>0</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_multiple_children_one_var/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $$, click, expect }) => {
+  const spans = $$("span");
+  expect(spans[0]).text("0");
+  expect(spans[1]).text("0");
+  await click("button");
+  expect(spans[0]).text("1");
+  expect(spans[1]).text("1");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="up()">p</button><Child :cfg="config"/></div>
+script:
+    let config = { level: 1 }
+    function up(){ config = { level: config.level + 1 } }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/Child.lunas
@@ -1,0 +1,3 @@
+@input cfg:object = {}
+html:
+    <span>lvl ${cfg.level}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>lvl 2</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>lvl 1</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_nested_object_field_reactive/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("lvl 1");
+  await click("button");
+  expect($("span")).text("lvl 2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="rename()">p</button><Child :user="obj"/></div>
+script:
+    let obj = { name: "ada" }
+    function rename(){ obj = { name: "grace" } }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/Child.lunas
@@ -1,0 +1,3 @@
+@input user:object = {}
+html:
+    <span>${user.name}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>grace</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>ada</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_object_field_change/steps.mjs
@@ -1,0 +1,6 @@
+export default async ({ $, click, expect }) => {
+  const span = $("span");
+  expect(span).text("ada");
+  await click("button");
+  expect(span).text("grace");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button class="pbtn" @click="inc()">p</button><Child :count="n"/></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/Child.lunas
@@ -1,0 +1,6 @@
+@input count:number = 0
+html:
+    <section><button class="cbtn" @click="bump()">c</button><span>${count}+${local}</span></section>
+script:
+    let local = 0
+    function bump(){ local++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="pbtn">p</button><div><section><button class="cbtn">c</button><span>3+2</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="pbtn">p</button><div><section><button class="cbtn">c</button><span>1+0</span></section></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_and_child_independent/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $, click, expect }) => {
+  const span = $("span");
+  expect(span).text("1+0");
+  await click(".pbtn");
+  expect(span).text("2+0");
+  await click(".cbtn");
+  expect(span).text("2+1");
+  await click(".pbtn");
+  await click(".cbtn");
+  expect(span).text("3+2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :count="n"/></div>
+script:
+    let n = 1
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>3</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>1</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_click_updates_child/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $, click, expect }) => {
+  const span = $("span");
+  expect(span).text("1");
+  await click("button");
+  expect(span).text("2");
+  await click("button");
+  expect(span).text("3");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="inc()">p</button><Child :base="n"/></div>
+script:
+    let n = 10
+    function inc(){ n++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/Child.lunas
@@ -1,0 +1,6 @@
+@input base:number = 0
+html:
+    <button @click="add()">go</button><span>${base + extra}</span>
+script:
+    let extra = 0
+    function add(){ extra = extra + 5 }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><button>go</button><span>16</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><button>go</button><span>10</span></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_prop_and_child_local_combined/steps.mjs
@@ -1,0 +1,9 @@
+export default async ({ $, $$, click, expect }) => {
+  const span = $("span");
+  const [pbtn, cbtn] = $$("button");
+  expect(span).text("10");
+  await click(pbtn);
+  expect(span).text("11");
+  await click(cbtn);
+  expect(span).text("16");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/App.lunas
@@ -1,0 +1,7 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="go()">p</button><Child :a="x" :b="y"/></div>
+script:
+    let x = 1
+    let y = 10
+    function go(){ x++; y = y + 10 }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/Child.lunas
@@ -1,0 +1,4 @@
+@input a:number = 0
+@input b:number = 0
+html:
+    <span>${a}/${b}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>2/20</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>1/10</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_parent_updates_two_props_of_one_child/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("1/10");
+  await click("button");
+  expect($("span")).text("2/20");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="go()">p</button><Child :url="link"/></div>
+script:
+    let link = "/a"
+    function go(){ link = "/b" }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/Child.lunas
@@ -1,0 +1,3 @@
+@input url:string = "/"
+html:
+    <a :href="url">go</a>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><a href="/b">go</a></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><a href="/a">go</a></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_attr/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("a")).attr("href", "/a");
+  await click("button");
+  expect($("a")).attr("href", "/b");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="toggle()">p</button><Child :active="flag"/></div>
+script:
+    let flag = false
+    function toggle(){ flag = !flag }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/Child.lunas
@@ -1,0 +1,3 @@
+@input active:boolean = false
+html:
+    <span class="base" :class="{ active: active }">x</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span class="base">x</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span class="base">x</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_prop_drives_child_class/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ $, click, expect }) => {
+  const span = $("span.base");
+  await click("button");
+  expect(span).hasClass("active");
+  await click("button");
+  expect(span).attr("class", "base");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button @click="swap()">p</button><Child :name="who"/></div>
+script:
+    let who = "ada"
+    function swap(){ who = "grace" }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/Child.lunas
@@ -1,0 +1,3 @@
+@input name:string = ""
+html:
+    <span>hi ${name}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>hi grace</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><div><span>hi ada</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_string_prop_change/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ $, click, expect }) => {
+  expect($("span")).text("hi ada");
+  await click("button");
+  expect($("span")).text("hi grace");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/App.lunas
@@ -1,0 +1,8 @@
+@use Child from "./Child.lunas"
+html:
+    <div><button class="a" @click="incA()">a</button><button class="b" @click="incB()">b</button><Child :count="x"/><Child :count="y"/></div>
+script:
+    let x = 0
+    let y = 10
+    function incA(){ x++ }
+    function incB(){ y++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/Child.lunas
@@ -1,0 +1,3 @@
+@input count:number = 0
+html:
+    <span>${count}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><span>1</span></div><div><span>11</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="a">a</button><button class="b">b</button><div><span>0</span></div><div><span>10</span></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_children_separate_vars/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $$, click, expect }) => {
+  const spans = $$("span");
+  expect(spans[0]).text("0");
+  expect(spans[1]).text("10");
+  await click(".a");
+  expect(spans[0]).text("1");
+  expect(spans[1]).text("10");
+  await click(".b");
+  expect(spans[0]).text("1");
+  expect(spans[1]).text("11");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/App.lunas
@@ -1,0 +1,3 @@
+@use Counter from "./Counter.lunas"
+html:
+    <div><Counter :start="1"/><Counter :start="100"/></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/Counter.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/Counter.lunas
@@ -1,0 +1,6 @@
+@input start:number = 0
+html:
+    <button @click="inc()">${value}</button>
+script:
+    let value = start
+    function inc(){ value++ }

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>2</button></div><div><button>101</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button>1</button></div><div><button>100</button></div></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/react_two_counters_isolated/steps.mjs
@@ -1,0 +1,11 @@
+export default async ({ $$, click, expect }) => {
+  const [b1, b2] = $$("button");
+  expect(b1).text("1");
+  expect(b2).text("100");
+  await click(b1);
+  expect(b1).text("2");
+  expect(b2).text("100");
+  await click(b2);
+  expect(b1).text("2");
+  expect(b2).text("101");
+};


### PR DESCRIPTION
Mass-produces **103 new** sample-directory E2E cases under `crates/lunas_compiler/tests/runtime/samples/component/`, covering the COMPONENTS & PROPS surface of the framework. Combined with the 3 existing seeds, the `component/` category now has **106 cases**, all green (compile clean, no warnings, pass the sample runner). 34 of them exercise real parent↔child reactivity via `steps.mjs` with committed `expected.after.html` snapshots.

## Coverage
- **Basic props:** static / reactive; number, boolean, string, object, array; interpolated / ternary / arithmetic expression props; literals; multiple props; mixed static+bound; defaults (used / overridden); optional props (with/without default); prop used in child text / attr / class / style.
- **Multiple children:** several instances; list via `:for`; child inside a `:if` container; grandchild (2 & 3 levels); siblings sharing parent state; child reused with different props; nested `:for` children; header/body/footer composition.
- **Reactivity (`steps.mjs`):** parent `@click` mutates a prop → child DOM updates; child-local `@click` stays isolated from parent (context isolation); object-field change; multiple children reacting to one parent var; computed/recomputed prop expressions; prop-driven child attr/class; grandchild receiving updates; keyed `:for` push/remove/reorder of component instances.
- **Child internals:** child renders its own text/attr/event/`:if`/`:elseif`/`:else`/`:for` from props + local state; two-way input seeded by a prop; own default not overridden.
- **Edge cases:** prop-name/local collisions; two-level passthrough (static + reactive); missing-optional-uses-default deep; prop expr recomputed on dep change; static-vs-bound reuse; same name different types; falsy `0` / empty-string props; nested object access; method-call / array-join prop expressions.

## Runtime notes discovered while authoring (behavior preserved, cases shaped around it)
- `:if` **directly on a component** is unsupported today (`"\`:if\` on a component is not supported yet"`). Cases wrap the component in a `:if` container element instead.
- A prop read inside a **child event-handler / script body** returns the wrapped ref (`[object Object]`) rather than the unwrapped value — props only auto-unwrap in template positions. Two affected cases were reshaped to derive from the prop in the template.
- **Nested `:for`** that mounts a component fails with a **primitive `:key`** (`Cannot create property '_children' on number`); using object items with an `id`/`k` key field works. Case uses object items.

Scope: only new dirs under `samples/component/` — no harness/runtime/roadmap changes. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)