### PR TITLE
fix(compiler): inline template handler mutations now trigger updates

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -380,6 +380,7 @@ No signal-tracking stack, no VDOM, no per-node effect objects.
 | `:name="e"` | `bind(c, deps, () => setAttr(el, "name", e))` (or `el.prop =` for known props) |
 | `::name="lv"` | above **+** `on(el, "input", () => lv = el.value)` (write-back) |
 | `@event="h()"` | `on(el, "event", h)` — box setters notify, so no explicit write mask needed |
+| `@event="n = n+1"` / `@event="n++"` / `@event="o.k = v"` (inline mutation) | `on(el, "event", () => { n.v = n.v+1 })` — the handler body is `.v`-rewritten (program-mode) so the inline assignment/update reaches the box setter and marks the var; the mutated binding is numbered reactive (its assignment target counts as a mutation). Multiple statements (`a++; b++`) and member/index writes (→ `deepBox`) are supported |
 | static `class="a ${x}"` | text nodes / attr set; interpolations become `bind`s |
 | `:if` / `:elseif` / `:else` | one `ifBlock` chain per cascade, anchored; branch built by its own `innerHTML` when shown |
 | `:for="n of items"` | `forBlock`; **initial render = one `innerHTML` of the concatenated items**, updates = keyed diff |

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -264,6 +264,15 @@ impl<'a> Emitter<'a> {
                     deep_hint.push_str(" = 0;");
                 }
             }
+            // Inline `@event` handlers can deeply mutate a binding directly from
+            // the template (`@click="obj.k = 1"`, `@click="items.push(x)"`). The
+            // handler text is itself the mutation, so appending it lets the
+            // textual `is_deeply_mutated` scan classify the target as a `deepBox`
+            // (a plain `box` would never fire on an in-place member/index write).
+            for h in event_handler_texts(template) {
+                deep_hint.push('\n');
+                deep_hint.push_str(&h);
+            }
         }
         // Names that would shadow a runtime helper if imported bare: every
         // top-level script binding plus every prop. A helper whose canonical
@@ -1990,7 +1999,12 @@ impl<'a> Emitter<'a> {
 
     fn emit_event(&mut self, b: &mut String, node: &str, event: &str, handler: &str, frag: &Frag) {
         self.use_helper("on");
-        let body = rewrite_expr(handler, &self.component.reactive_vars, frag.shadowed);
+        // A handler body is a statement sequence, not a single expression, so it
+        // is rewritten via the program-mode analyzer — this makes inline
+        // assignments (`n = n + 1`, `count++`, `a++; b++`, `obj.k = v`) compile
+        // to the `.v` box-setter path so the write marks the var and the DOM
+        // updates. Function-call handlers (`inc()`) are unaffected.
+        let body = rewrite_handler(handler, &self.component.reactive_vars, frag.shadowed);
         push_indent(b, frag.indent);
         b.push_str(self.helper("on"));
         b.push('(');
@@ -2310,6 +2324,27 @@ fn two_way_lvalues(template: &Template) -> Vec<String> {
         for attr in attrs {
             if let TemplateAttr::TwoWay { lvalue, .. } = attr {
                 out.push(lvalue.text.clone());
+            }
+        }
+    });
+    out
+}
+
+/// The raw text of every inline `@event` handler anywhere in the template. Fed
+/// into `deep_hint` so an inline member/index mutation (`@click="obj.k = 1"`,
+/// `@click="items.push(x)"`) classifies its target as a `deepBox` — the same
+/// textual `is_deeply_mutated` scan the script body goes through.
+fn event_handler_texts(template: &Template) -> Vec<String> {
+    let mut out = Vec::new();
+    template.visit(&mut |node: &TemplateNode| {
+        let attrs = match node {
+            TemplateNode::Element(e) => &e.attrs,
+            TemplateNode::Component(c) => &c.props,
+            _ => return,
+        };
+        for attr in attrs {
+            if let TemplateAttr::Event { handler, .. } = attr {
+                out.push(handler.text.clone());
             }
         }
     });
@@ -2656,8 +2691,45 @@ fn apply_edits(src: &str, mut edits: Vec<(u32, u32, String)>) -> String {
 /// arrow parameter of the same name) are left alone. `shadowed` names (loop
 /// bindings of enclosing `:for` items) are excluded from rewriting.
 fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String {
+    rewrite_with(
+        expr,
+        vars,
+        shadowed,
+        lunas_script::free_identifiers_with_spans,
+    )
+}
+
+/// Like [`rewrite_expr`], but for an inline `@event` handler body. A handler is
+/// a statement sequence (`n = n + 1`, `count++`, `a++; b++`), not a single
+/// expression, so it must be parsed as a program — otherwise the `(…)`-wrapped
+/// expression parser rejects multi-statement / bare-assignment handlers and the
+/// `.v` rewrite is silently skipped (assignments would not reach the box setter
+/// and the DOM would never update). A handler that only *calls* a function is
+/// left untouched by the identifier rewrite except for its reactive arguments,
+/// which is exactly right.
+fn rewrite_handler(handler: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String {
+    rewrite_with(
+        handler,
+        vars,
+        shadowed,
+        lunas_script::free_identifiers_with_spans_program,
+    )
+}
+
+/// Shared body of the `.v`-rewrite: appends `.v` after every free occurrence of
+/// a (non-shadowed) reactive binding, using the supplied span analyzer to locate
+/// occurrences. On a parse error the source is returned unchanged (never-panic).
+fn rewrite_with(
+    src: &str,
+    vars: &[ReactiveVar],
+    shadowed: &[String],
+    spans_of: impl Fn(
+        &str,
+    )
+        -> Result<Vec<(String, lunas_span::TextRange)>, lunas_script::ScriptParseError>,
+) -> String {
     if vars.is_empty() {
-        return expr.trim().to_string();
+        return src.trim().to_string();
     }
     let reactive: std::collections::HashSet<&str> = vars
         .iter()
@@ -2665,11 +2737,11 @@ fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String
         .filter(|n| !shadowed.iter().any(|s| s == n))
         .collect();
     if reactive.is_empty() {
-        return expr.trim().to_string();
+        return src.trim().to_string();
     }
-    let spans = match lunas_script::free_identifiers_with_spans(expr) {
+    let spans = match spans_of(src) {
         Ok(s) => s,
-        Err(_) => return expr.trim().to_string(),
+        Err(_) => return src.trim().to_string(),
     };
     let mut edits: Vec<(u32, u32, String)> = Vec::new();
     for (name, range) in spans {
@@ -2677,7 +2749,7 @@ fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String
             edits.push((range.end().raw(), range.end().raw(), ".v".to_string()));
         }
     }
-    apply_edits(expr, edits).trim().to_string()
+    apply_edits(src, edits).trim().to_string()
 }
 
 // --- attribute set special cases -----------------------------------------

--- a/crates/lunas_compiler/src/lib.rs
+++ b/crates/lunas_compiler/src/lib.rs
@@ -59,12 +59,17 @@ pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
         })
         .collect();
 
-    // A two-way binding (`::name="lvalue"`) writes back into its target, so the
-    // lvalue's root binding is mutated even if the script never assigns it.
+    // Constructs in the template that mutate a top-level binding, so the
+    // resolver numbers it reactive even when the `script:` block never assigns
+    // it: two-way binding write-backs (`::name="lvalue"`), template refs
+    // (`:ref="name"`), and — crucially — assignments/updates written *inline*
+    // in an `@event` handler (`@click="n = n + 1"`, `@click="count++"`,
+    // `@click="obj.k = v"`). Vue/Svelte both treat inline handler mutations as
+    // reactive writes; without this, such a mutation would be silently ignored.
     let template_mutated = file
         .html
         .as_ref()
-        .map(|h| two_way_mutation_roots(&h.template))
+        .map(|h| template_mutation_roots(&h.template))
         .unwrap_or_default();
 
     let mut reactive_vars = match &file.script {
@@ -125,7 +130,11 @@ pub fn resolve(source: &str) -> (ResolvedComponent, Vec<Diagnostic>) {
 ///     deep-writes `o`.
 ///   - template refs: `:ref="name"` assigns the element into `name`, so `name`
 ///     is mutated (a plain `let name;` in script is the natural declaration).
-fn two_way_mutation_roots(template: &lunas_parser::Template) -> HashSet<String> {
+///   - inline `@event` handlers: `@click="n = n + 1"` / `@click="count++"` /
+///     `@click="obj.k = v"` assign a top-level binding directly from the
+///     template; the assignment target's root is mutated. A handler that merely
+///     *calls* a function is handled separately (function mutation graph).
+fn template_mutation_roots(template: &lunas_parser::Template) -> HashSet<String> {
     use lunas_parser::{TemplateAttr, TemplateNode};
     let mut roots = HashSet::new();
     template.visit(&mut |node: &TemplateNode| {
@@ -144,6 +153,16 @@ fn two_way_mutation_roots(template: &lunas_parser::Template) -> HashSet<String> 
                 TemplateAttr::Bound { name, expr, .. } if name == "ref" => {
                     if let Some(root) = leading_identifier(&expr.text) {
                         roots.insert(root.to_string());
+                    }
+                }
+                TemplateAttr::Event { handler, .. } => {
+                    // Assignments/updates written inline in the handler
+                    // (`n = n + 1`, `count++`, `obj.k = v`) mutate their target's
+                    // root binding. `assigned_identifiers` already reports the
+                    // root object for member/index targets and never panics on a
+                    // malformed expression (it returns an error we drop here).
+                    if let Ok(assigned) = assigned_identifiers(&handler.text) {
+                        roots.extend(assigned);
                     }
                 }
                 _ => {}

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -1005,3 +1005,147 @@ fn slot_component_in_slot_content() {
         "slot content renders: {out}"
     );
 }
+
+// --- inline template-handler mutations (fix/inline-handler-mutations) --------
+//
+// A mutation written INLINE in an `@event` handler (`@click="n = n + 1"`,
+// `@click="count++"`, `@click="obj.k = 1"`, `@click="a++; b++"`) must be
+// recognized as a reactive write and compiled through the `.v` box-setter path,
+// so the DOM updates on click — matching Vue/Svelte. Previously such mutations
+// were silently ignored unless routed through a named script function.
+
+#[test]
+fn inline_handler_assignment_updates_dom() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // `n = n + 1` written inline, `n` never assigned in script.
+    let source = "html:\n\
+        \x20   <button @click=\"n = n + 1\">count: ${n}</button>\n\
+        script:\n\
+        \x20   let n = 0\n";
+    let driver = "\
+        const root = factory({});\n\
+        const btn = root.childNodes[0];\n\
+        console.log('INITIAL:' + btn.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('AFTER:' + btn.innerHTMLString());\n";
+    let out = run_component("inline_assign", source, driver);
+    assert!(out.contains("INITIAL:count: 0"), "initial render: {out}");
+    assert!(
+        out.contains("AFTER:count: 2"),
+        "inline assign updates DOM: {out}"
+    );
+}
+
+#[test]
+fn inline_handler_increment_updates_dom() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // `n++` written inline.
+    let source = "html:\n\
+        \x20   <button @click=\"n++\">count: ${n}</button>\n\
+        script:\n\
+        \x20   let n = 5\n";
+    let driver = "\
+        const root = factory({});\n\
+        const btn = root.childNodes[0];\n\
+        console.log('INITIAL:' + btn.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('AFTER:' + btn.innerHTMLString());\n";
+    let out = run_component("inline_incr", source, driver);
+    assert!(out.contains("INITIAL:count: 5"), "initial render: {out}");
+    assert!(
+        out.contains("AFTER:count: 6"),
+        "inline ++ updates DOM: {out}"
+    );
+}
+
+#[test]
+fn inline_handler_deep_member_assignment_updates_dom() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // `obj.k = 1` (deep member write): the target must be a deepBox so the
+    // in-place mutation marks the var.
+    let source = "html:\n\
+        \x20   <button @click=\"obj.k = obj.k + 10\">v: ${obj.k}</button>\n\
+        script:\n\
+        \x20   let obj = { k: 1 }\n";
+    let driver = "\
+        const root = factory({});\n\
+        const btn = root.childNodes[0];\n\
+        console.log('INITIAL:' + btn.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('AFTER:' + btn.innerHTMLString());\n";
+    let out = run_component("inline_deep", source, driver);
+    assert!(out.contains("INITIAL:v: 1"), "initial render: {out}");
+    assert!(
+        out.contains("AFTER:v: 11"),
+        "inline member assign updates DOM: {out}"
+    );
+}
+
+#[test]
+fn inline_handler_multiple_statements_update_dom() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Two statements in one handler: `a++; b++`.
+    let source = "html:\n\
+        \x20   <button @click=\"a++; b++\">${a}-${b}</button>\n\
+        script:\n\
+        \x20   let a = 0\n\
+        \x20   let b = 10\n";
+    let driver = "\
+        const root = factory({});\n\
+        const btn = root.childNodes[0];\n\
+        console.log('INITIAL:' + btn.innerHTMLString());\n\
+        btn.dispatch('click'); await tick();\n\
+        console.log('AFTER:' + btn.innerHTMLString());\n";
+    let out = run_component("inline_multi", source, driver);
+    assert!(out.contains("INITIAL:0-10"), "initial render: {out}");
+    assert!(
+        out.contains("AFTER:1-11"),
+        "multi-statement handler updates DOM: {out}"
+    );
+}
+
+#[test]
+fn inline_and_function_call_handlers_mix() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // One button mutates inline; another calls a script function. Both must work
+    // and drive the same reactive state.
+    let source = "html:\n\
+        \x20   <div><button @click=\"n = n + 1\">inc</button><button @click=\"reset()\">reset</button><p>${n}</p></div>\n\
+        script:\n\
+        \x20   let n = 0\n\
+        \x20   function reset(){ n = 0 }\n";
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const btns = div.childNodes.filter((c) => c.tag === 'button');\n\
+        const p = div.childNodes.find((c) => c.tag === 'p');\n\
+        console.log('INITIAL:' + p.innerHTMLString());\n\
+        btns[0].dispatch('click'); await tick();\n\
+        btns[0].dispatch('click'); await tick();\n\
+        console.log('MID:' + p.innerHTMLString());\n\
+        btns[1].dispatch('click'); await tick();\n\
+        console.log('AFTER:' + p.innerHTMLString());\n";
+    let out = run_component("inline_mixed", source, driver);
+    assert!(out.contains("INITIAL:0"), "initial render: {out}");
+    assert!(out.contains("MID:2"), "inline handler drives state: {out}");
+    assert!(
+        out.contains("AFTER:0"),
+        "function-call handler still works: {out}"
+    );
+}

--- a/crates/lunas_compiler/tests/robustness.rs
+++ b/crates/lunas_compiler/tests/robustness.rs
@@ -41,3 +41,32 @@ script:
         &[c.reactive_index("n").unwrap()]
     );
 }
+
+#[test]
+fn inline_handler_mutations_never_panic() {
+    // Inline `@event` handler analysis (assignment detection + `.v` rewrite via
+    // the program-mode parser) must never panic, however malformed the handler.
+    let cases = [
+        // Well-formed inline mutations of various shapes.
+        "html:\n    <button @click=\"n = n + 1\">${n}</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"n++\">${n}</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"obj.k = 1\">${obj.k}</button>\nscript:\n    let obj = {}",
+        "html:\n    <button @click=\"a++; b++\">${a}${b}</button>\nscript:\n    let a=0\n    let b=0",
+        "html:\n    <button @click=\"arr[i] = 1\">x</button>\nscript:\n    let arr=[]\n    let i=0",
+        // Malformed / partial handler bodies.
+        "html:\n    <button @click=\"n = \">x</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"++\">x</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"@#$%(\">x</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"n = n +;;\">x</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"() => { n = \">x</button>\nscript:\n    let n = 0",
+        "html:\n    <button @click=\"日本語 = 1; 🦀++\">x</button>\nscript:\n    let n = 0",
+        // Inline mutation with no script block at all.
+        "html:\n    <button @click=\"n = 1\">x</button>",
+    ];
+    for case in cases {
+        let (_c, _d) = lunas_compiler::resolve(case);
+        // The full compile path (which runs the `.v` handler rewrite) must also
+        // never panic.
+        let (_js, _d2) = lunas_compiler::compile(case);
+    }
+}

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><button class="inc" @click="n = n + 1">inc</button><button class="reset" @click="reset()">reset</button><p>${n}</p></div>
+script:
+    let n = 0
+    function reset(){ n = 0 }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/_config.json
@@ -1,0 +1,1 @@
+{ "description": "one inline-mutation handler and one function-call handler drive the same state" }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="inc">inc</button><button class="reset">reset</button><p>0</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="inc">inc</button><button class="reset">reset</button><p>0</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_and_function_handlers_mixed/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ click, expect }) => {
+  expect("p").text("0");
+  await click(".inc");
+  await click(".inc");
+  expect("p").text("2");
+  await click(".reset");
+  expect("p").text("0");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button @click="n = n + 1">count: ${n}</button>
+script:
+    let n = 0

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/_config.json
@@ -1,0 +1,1 @@
+{ "description": "inline @click assignment n = n + 1 updates text (no script function)" }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>count: 2</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/expected.html
@@ -1,0 +1,1 @@
+<div><button>count: 0</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_assignment_updates_text/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ click, expect }) => {
+  expect("button").text("count: 0");
+  await click("button");
+  expect("button").text("count: 1");
+  await click("button");
+  expect("button").text("count: 2");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button @click="n++">count: ${n}</button>
+script:
+    let n = 5

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/_config.json
@@ -1,0 +1,1 @@
+{ "description": "inline @click increment n++ updates text (no script function)" }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>count: 6</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/expected.html
@@ -1,0 +1,1 @@
+<div><button>count: 5</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_increment_updates_text/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ click, expect }) => {
+  expect("button").text("count: 5");
+  await click("button");
+  expect("button").text("count: 6");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <button @click="a++; b++">${a}-${b}</button>
+script:
+    let a = 0
+    let b = 10

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/_config.json
@@ -1,0 +1,1 @@
+{ "description": "inline @click with two statements a++; b++ updates text" }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>2-12</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/expected.html
@@ -1,0 +1,1 @@
+<div><button>0-10</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_multiple_statements/steps.mjs
@@ -1,0 +1,7 @@
+export default async ({ click, expect }) => {
+  expect("button").text("0-10");
+  await click("button");
+  expect("button").text("1-11");
+  await click("button");
+  expect("button").text("2-12");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/App.lunas
@@ -1,0 +1,4 @@
+html:
+    <button @click="obj.k = obj.k + 10">v: ${obj.k}</button>
+script:
+    let obj = { k: 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/_config.json
@@ -1,0 +1,1 @@
+{ "description": "inline @click deep member assignment obj.k = ... updates text" }

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/expected.after.html
@@ -1,0 +1,1 @@
+<div><button>v: 11</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/expected.html
@@ -1,0 +1,1 @@
+<div><button>v: 1</button></div>

--- a/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/event/inline_click_object_field_assignment/steps.mjs
@@ -1,0 +1,5 @@
+export default async ({ click, expect }) => {
+  expect("button").text("v: 1");
+  await click("button");
+  expect("button").text("v: 11");
+};

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -242,6 +242,40 @@ pub fn free_identifiers_with_spans(
         .collect())
 }
 
+/// Like [`free_identifiers_with_spans`] but parses `code` as a *program* (a
+/// sequence of statements), not a single wrapped expression. This is what an
+/// inline `@event` handler needs: a handler value may be several statements
+/// (`a++; b++`) or a bare assignment (`n = n + 1`), neither of which parses when
+/// wrapped in `(…)`. Spans are 0-based byte offsets within `code`. Never panics;
+/// a malformed handler returns a parse error the caller can drop.
+///
+/// ```
+/// use lunas_script::free_identifiers_with_spans_program;
+///
+/// let ids = free_identifiers_with_spans_program("a++; b = a + 1").unwrap();
+/// let names: Vec<_> = ids.iter().map(|(n, _)| n.as_str()).collect();
+/// assert_eq!(names, ["a", "b", "a"]);
+/// assert_eq!(ids[0].1.slice("a++; b = a + 1"), Some("a"));
+/// ```
+pub fn free_identifiers_with_spans_program(
+    code: &str,
+) -> Result<Vec<(String, lunas_span::TextRange)>, ScriptParseError> {
+    let (module, fm) = parse_source_with_fm(code.to_string())?;
+    let mut c = ScopedFreeCollector::default();
+    module.visit_with(&mut c);
+
+    let base = fm.start_pos.0;
+    let code_len = code.len() as u32;
+    Ok(c.free
+        .into_iter()
+        .filter_map(|(name, lo, hi)| {
+            let lo = lo.checked_sub(base)?;
+            let hi = hi.checked_sub(base)?;
+            (hi <= code_len && lo <= hi).then(|| (name, lunas_span::TextRange::at(lo, hi)))
+        })
+        .collect())
+}
+
 struct SpanRefCollector {
     items: Vec<(String, u32, u32)>,
 }

--- a/crates/lunas_script/src/lib.rs
+++ b/crates/lunas_script/src/lib.rs
@@ -21,9 +21,10 @@ mod transform;
 
 pub use analysis::{
     analyze_script, assigned_identifiers, declared_bindings, declared_bindings_with_spans,
-    free_identifiers, free_identifiers_with_spans, function_dependencies, function_mutations,
-    module_binding_references, referenced_identifiers, referenced_identifiers_with_spans,
-    top_level_declarations, BindingRef, DeclKind, ScriptAnalysis, TopLevelDecl,
+    free_identifiers, free_identifiers_with_spans, free_identifiers_with_spans_program,
+    function_dependencies, function_mutations, module_binding_references, referenced_identifiers,
+    referenced_identifiers_with_spans, top_level_declarations, BindingRef, DeclKind,
+    ScriptAnalysis, TopLevelDecl,
 };
 pub use ast::{parse_to_ast_json, ScriptParseError};
 pub use for_header::{parse_for, ForKind, ParsedFor};


### PR DESCRIPTION
## Problem

A mutation written **inline** in an `@event` handler was silently ignored — the DOM never updated:

- `@click="n = n + 1"`
- `@click="count++"`
- `@click="obj.k = v"` (deep member)
- `@click="a++; b++"` (multiple statements)

Only mutations routed through a **named `script:` function** were tracked as reactive writes. Vue and Svelte both treat inline handler mutations as reactive writes, so this was a silent-correctness bug (~54 test samples had to route mutations through script functions to work).

## Root cause (two gaps)

1. **Reactive-var detection** (`resolve_reactive_vars`) gathered mutations from script functions, top-level script assignments, and two-way bindings — but **not** from inline `@event` handler bodies. A binding mutated only by an inline handler was never numbered reactive, so it was never boxed and its writes could not notify.
2. **Listener-body emission**: the `@event` handler was `.v`-rewritten via the *expression-mode* analyzer, which wraps its input in `(…)` and therefore cannot parse a statement sequence. Multi-statement / bare-assignment handlers were emitted **without** the `.v` box-setter rewrite even when the var was reactive.

## Fix

- `template_mutation_roots` (renamed from `two_way_mutation_roots`) now also collects `assigned_identifiers` of every inline `@event` handler, so the assignment/update target's root binding is numbered reactive.
- Inline member/index handler mutations (`obj.k = 1`, `items.push(x)`) feed the emitter's `deep_hint`, classifying the target as a `deepBox` (a plain `box` never fires on an in-place write).
- New `lunas_script::free_identifiers_with_spans_program` parses the handler as a *program* (statement sequence); `emit_event` uses it (`rewrite_handler`) so inline assignments compile to the `.v` box-setter path. Function-call handlers (`inc()`) are unaffected.
- Never-panics on malformed inline handler expressions (both the assignment detection and the rewrite drop parse errors).

Consistent with `output-design.md` §4/§6 (box setter marks the var; `handlers[].writes` is compile-time); the doc's syntax→output table gains an inline-mutation row.

## Tests

- `codegen_exec.rs`: 5 new tests — inline assign, `n++`, deep `obj.k`, multi-statement `a++; b++`, mixed inline + function-call — each **compiled and run under node**, asserting DOM text updates after a click.
- `runtime/samples/event/`: 5 new sample cases with `steps.mjs` clicking + asserting updates; expected HTML generated via `UPDATE_EXPECTED=1`.
- `robustness.rs`: never-panic coverage for malformed/partial inline handler exprs through both `resolve` and `compile`.

## Quality gates (all green)

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `node packages/lunas/test/run-all.mjs` (36 files)

Note: emit.rs changes are localized to the `@event` listener-body emission and the resolve/write-set path, per the concurrent-edit note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)