### PR TITLE
fix: :for mounting a component crashes on primitive items

### DIFF
--- a/crates/lunas_compiler/docs/for-diff-design.md
+++ b/crates/lunas_compiler/docs/for-diff-design.md
@@ -235,6 +235,17 @@ handle.scope = scope;                 // { subs: [...], children: [...] }
   then recurse into child scopes (nested `:if`/`:for` items). A queued-but-
   dropped record is skipped at flush via its `q`/alive flag, so removal during
   a pending flush is safe.
+  - **Child components in an item**: a `<Child/>` mounted inside the item body
+    calls `mountChild(c, …)` with the enclosing component context `c` (not the
+    item datum). Because a scope is open when the item is built, `mountChild`
+    registers the child's `unmount` as a **disposer** on that item scope
+    (`scope.disposers`); `dropScope` runs disposers after unbinding, so removing
+    the item unmounts the child — its `onDestroy` fires and it is unlinked from
+    `c._children`. Without this, removed items would leak child contexts on the
+    parent's `_children` list even though their DOM was gone. mountChild also
+    hardens the link write: it never sets `_children` on a non-object `c`, so a
+    primitive slipping through can never throw "Cannot create property
+    '_children' on number" (never-panic).
 - **Move**: no scope work at all — registration is per-component, not
   per-position.
 - **Patch**: the item's data cell is a per-item slot (`handle.data` or an

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -347,6 +347,117 @@ fn for_initial_push_splice_and_reorder() {
     );
 }
 
+#[test]
+fn for_over_primitive_items_mounts_child_per_item() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Regression: a `:for` over PRIMITIVE items (numbers) whose body mounts a
+    // child component used to crash at runtime — mountChild wrote `_children`
+    // onto the primitive item ("Cannot create property '_children' on number").
+    // Now: each item mounts a Child with the correct component context; list
+    // mutation (push/remove/reorder) updates and tears children down cleanly.
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div>\n\
+        \x20     <button @click=\"push4()\">p</button>\n\
+        \x20     <button @click=\"dropMid()\">d</button>\n\
+        \x20     <button @click=\"reorder()\">r</button>\n\
+        \x20     <ul><li :for=\"n of nums\" :key=\"n\"><Child :x=\"n\"/></li></ul>\n\
+        \x20   </div>\n\
+        script:\n\
+        \x20   let nums = [1,2,3]\n\
+        \x20   function push4(){ nums.push(4) }\n\
+        \x20   function dropMid(){ nums = nums.filter((v) => v !== 2) }\n\
+        \x20   function reorder(){ nums = [nums[nums.length-1], ...nums.slice(0,-1)] }\n";
+    let child = "@input x:number = 0\n\
+        html:\n\
+        \x20   <b>x=${x}</b>\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const c = root.__lunasCtx;\n\
+        const div = root.childNodes[0];\n\
+        const [pBtn, dBtn, rBtn, ul] = div.childNodes;\n\
+        const lis = () => ul.childNodes.filter(n => n.tag === 'li');\n\
+        const shown = () => lis().map(n => n.innerHTMLString()).join(',');\n\
+        const kids = () => (c._children ? c._children.length : 0);\n\
+        console.log('INITIAL:' + shown());\n\
+        console.log('KIDS0:' + kids());\n\
+        pBtn.dispatch('click'); await tick();\n\
+        console.log('PUSH:' + shown());\n\
+        console.log('KIDS1:' + kids());\n\
+        dBtn.dispatch('click'); await tick();\n\
+        console.log('DROP:' + shown());\n\
+        console.log('KIDS2:' + kids());\n\
+        rBtn.dispatch('click'); await tick();\n\
+        console.log('REORDER:' + shown());\n\
+        console.log('KIDS3:' + kids());\n";
+
+    let out = run_parent_child("for_prim_child", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:<div><b>x=1</b></div>,<div><b>x=2</b></div>,<div><b>x=3</b></div>"),
+        "each primitive item mounts a Child with the right prop: {out}"
+    );
+    assert!(
+        out.contains("KIDS0:3"),
+        "three children linked initially: {out}"
+    );
+    assert!(
+        out.contains(
+            "PUSH:<div><b>x=1</b></div>,<div><b>x=2</b></div>,<div><b>x=3</b></div>,<div><b>x=4</b></div>"
+        ),
+        "push mounts a new child: {out}"
+    );
+    assert!(out.contains("KIDS1:4"), "four children after push: {out}");
+    assert!(
+        out.contains("DROP:<div><b>x=1</b></div>,<div><b>x=3</b></div>,<div><b>x=4</b></div>"),
+        "removing an item tears its child down: {out}"
+    );
+    assert!(
+        out.contains("KIDS2:3"),
+        "removed item's child de-registered from _children (no leak): {out}"
+    );
+    assert!(
+        out.contains("REORDER:<div><b>x=4</b></div>,<div><b>x=1</b></div>,<div><b>x=3</b></div>"),
+        "reorder reflects the new order: {out}"
+    );
+    assert!(
+        out.contains("KIDS3:3"),
+        "reorder does not duplicate or drop child links: {out}"
+    );
+}
+
+#[test]
+fn for_over_string_items_mounts_child_per_item() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Same regression for STRING primitives (the other primitive-item shape).
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <ul><li :for=\"s of words\" :key=\"s\"><Child :x=\"s\"/></li></ul>\n\
+        script:\n\
+        \x20   let words = [\"a\",\"b\",\"c\"]\n";
+    let child = "@input x:string = \"\"\n\
+        html:\n\
+        \x20   <b>${x}</b>\n";
+
+    let driver = "\
+        const root = factory({});\n\
+        const ul = root.childNodes[0];\n\
+        const lis = () => ul.childNodes.filter(n => n.tag === 'li');\n\
+        console.log('INITIAL:' + lis().map(n => n.innerHTMLString()).join(','));\n";
+
+    let out = run_parent_child("for_str_child", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:<div><b>a</b></div>,<div><b>b</b></div>,<div><b>c</b></div>"),
+        "string primitives each mount a Child without crashing: {out}"
+    );
+}
+
 // --- child components -----------------------------------------------------
 
 #[test]

--- a/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/App.lunas
@@ -1,0 +1,5 @@
+@use Item from "./Item.lunas"
+html:
+    <ul><li :for="s of words" :key="s"><Item :label="s"/></li></ul>
+script:
+    let words = ["a","b","c"]

--- a/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/Item.lunas
@@ -1,0 +1,3 @@
+@input label:string = ""
+html:
+    <span>${label}</span>

--- a/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/expected.after.html
@@ -1,0 +1,1 @@
+<div><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li><li><div><span>c</span></div></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/expected.html
@@ -1,0 +1,1 @@
+<div><ul><li><div><span>a</span></div></li><li><div><span>b</span></div></li><li><div><span>c</span></div></li></ul></div>

--- a/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/component/for_over_primitive_strings/steps.mjs
@@ -1,0 +1,8 @@
+// `:for` over PRIMITIVE string items each mounting a child component. Regression
+// guard: this must render without the "_children on string" crash.
+export default async ({ $$, expect }) => {
+  expect("span").count(3);
+  expect($$("span")[0]).text("a");
+  expect($$("span")[1]).text("b");
+  expect($$("span")[2]).text("c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/App.lunas
@@ -1,0 +1,7 @@
+@use Item from "./Item.lunas"
+html:
+    <div><button @click="push4()">p</button><button @click="dropMid()">d</button><ul><li :for="n of nums" :key="n"><Item :x="n"/></li></ul></div>
+script:
+    let nums = [1,2,3]
+    function push4(){ nums.push(4) }
+    function dropMid(){ nums = nums.filter((v) => v !== 2) }

--- a/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/Item.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/Item.lunas
@@ -1,0 +1,3 @@
+@input x:number = 0
+html:
+    <b>x=${x}</b>

--- a/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><button>d</button><ul><li><div><b>x=1</b></div></li><li><div><b>x=3</b></div></li><li><div><b>x=4</b></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/expected.html
@@ -1,0 +1,1 @@
+<div><div><button>p</button><button>d</button><ul><li><div><b>x=1</b></div></li><li><div><b>x=2</b></div></li><li><div><b>x=3</b></div></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/for/component_over_primitive_numbers/steps.mjs
@@ -1,0 +1,21 @@
+// A `:for` over PRIMITIVE items (numbers) that mounts a child component per
+// item used to crash (mountChild wrote `_children` onto the number). Assert the
+// initial render, then push (mount a new child) and remove (tear a child down).
+export default async ({ $$, click, expect, equal }) => {
+  expect("b").count(3);
+  expect($$("b")[0]).text("x=1");
+  expect($$("b")[2]).text("x=3");
+
+  // push 4 -> a fourth child mounts
+  await click($$("button")[0]);
+  expect("b").count(4);
+  expect($$("b")[3]).text("x=4");
+
+  // remove the middle item (2) -> its child tears down, order preserved
+  await click($$("button")[1]);
+  expect("b").count(3);
+  equal(
+    $$("b").map((n) => n.innerHTMLString()).join(","),
+    "x=1,x=3,x=4"
+  );
+};

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -19,6 +19,7 @@ import {
   endScope,
   dropScope,
   runScope,
+  addDisposer,
 } from "./core.mjs";
 import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
 import { isLive, runMount, runDestroy, onDestroy } from "./lifecycle.mjs";
@@ -375,13 +376,43 @@ export function mountChild(c, anchor, childFactory, props) {
   const p = anchor.parentNode;
   for (const n of nodes) p.insertBefore(n, anchor);
   const childCtx = root && root.__lunasCtx;
+  // Guard the `_children` link: only a real context object can carry it. If the
+  // caller passes a non-object `c` (a primitive :for item slipping through, a
+  // bad handle), we still mount and drive the child — we just skip the parent
+  // link rather than throwing "Cannot create property '_children' on number".
+  const canLink = childCtx && c != null && (typeof c === "object" || typeof c === "function");
   if (childCtx) {
-    childCtx.parent = c;
-    (c._children || (c._children = [])).push(childCtx);
+    if (canLink) {
+      childCtx.parent = c;
+      (c._children || (c._children = [])).push(childCtx);
+    }
     // If the child landed in a live tree, fire its mount hooks now; otherwise a
     // later attach() on an ancestor drains them.
     if (isLive(root)) runMount(childCtx);
   }
+
+  let unmounted = false;
+  const unmount = () => {
+    if (unmounted) return;
+    unmounted = true;
+    if (childCtx) {
+      runDestroy(childCtx);
+      const kids = canLink ? c._children : null;
+      if (kids) {
+        const k = kids.indexOf(childCtx);
+        if (k >= 0) kids.splice(k, 1);
+      }
+    }
+    // Multi-root children remove every node of the group.
+    for (const n of nodes) n.remove();
+  };
+
+  // Tie the child's teardown to the enclosing control-flow scope (a `:for`/`:if`
+  // item), if any: when that item is removed, dropScope runs this and the child
+  // is unmounted (onDestroy fires, `_children` link cleared). A top-level mount
+  // has no open scope; the caller owns unmount via the returned handle.
+  addDisposer(c, unmount);
+
   return {
     root,
     ctx: childCtx,
@@ -390,18 +421,7 @@ export function mountChild(c, anchor, childFactory, props) {
       const b = boxes && boxes[name];
       if (b) b.v = value;
     },
-    unmount() {
-      if (childCtx) {
-        runDestroy(childCtx);
-        const kids = c._children;
-        if (kids) {
-          const k = kids.indexOf(childCtx);
-          if (k >= 0) kids.splice(k, 1);
-        }
-      }
-      // Multi-root children remove every node of the group.
-      for (const n of nodes) n.remove();
-    },
+    unmount,
   };
 }
 

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -116,10 +116,26 @@ export function unbind(c, s) {
 // ---------------------------------------------------------------------------
 
 export function beginScope(c) {
-  const scope = { subs: [], children: [], parent: c.scope };
+  // `disposers` hold extra teardown callbacks registered against this scope
+  // (e.g. a child component's `unmount`, added by mountChild). They run when
+  // the scope is dropped, so a `:for`/`:if` item that mounts a component
+  // unmounts it — firing onDestroy and unlinking it from the parent's
+  // `_children` — when the item is removed (for-diff-design.md §6).
+  const scope = { subs: [], children: [], disposers: null, parent: c.scope };
   if (c.scope) c.scope.children.push(scope);
   c.scope = scope;
   return scope;
+}
+
+// addDisposer(c, fn) — register `fn` on the currently-open scope (if any) to be
+// run when that scope is dropped. Returns true if it was registered, false when
+// no scope is open (the caller then owns teardown itself, e.g. a top-level
+// mountChild). Kept null-until-needed so scopes stay cheap.
+export function addDisposer(c, fn) {
+  const scope = c.scope;
+  if (!scope) return false;
+  (scope.disposers || (scope.disposers = [])).push(fn);
+  return true;
 }
 
 export function endScope(c) {
@@ -148,6 +164,14 @@ export function dropScope(c, scope) {
   for (const ch of scope.children) {
     ch.parent = null; // avoid double-splice below
     dropScope(c, ch);
+  }
+  // Run extra teardown (child-component unmounts) registered on this scope.
+  // Guarded to run once: null the list first so a disposer that re-enters
+  // (or a double dropScope) can't fire it twice.
+  const disposers = scope.disposers;
+  if (disposers) {
+    scope.disposers = null;
+    for (const fn of disposers) fn();
   }
   scope.subs.length = 0;
   scope.children.length = 0;

--- a/packages/lunas/test/dom.mountchild.test.mjs
+++ b/packages/lunas/test/dom.mountchild.test.mjs
@@ -8,7 +8,7 @@ import assert from "node:assert";
 import { installDom } from "./dom-shim.mjs";
 const document = installDom();
 
-import { createContext, bind } from "../src/core.mjs";
+import { createContext, bind, beginScope, endScope, dropScope } from "../src/core.mjs";
 import { box, prop } from "../src/boxes.mjs";
 import { anchorAppend, component, fragment } from "../src/dom.mjs";
 import { mountChild } from "../src/blocks.mjs";
@@ -172,6 +172,58 @@ await test("unmount recurses: a grandchild's onDestroy also fires", () => {
   assert.strictEqual(grandDestroyed, 0);
   m.unmount();
   assert.strictEqual(grandDestroyed, 1, "grandchild destroy fired via recursion");
+});
+
+// --- never-panic: a non-object `c` (a primitive :for item) must not throw -----
+
+await test("mountChild does not throw when `c` is a primitive (never sets _children on a number)", () => {
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  let destroyed = 0;
+  const Child = component("kid", {}, "<n></n>", (cc) => {
+    onDestroy(cc, () => destroyed++);
+  });
+  // Passing a primitive as `c` used to crash: "Cannot create property
+  // '_children' on number". It must mount cleanly and still drive teardown.
+  let m;
+  assert.doesNotThrow(() => {
+    m = mountChild(3, anchor, Child, {});
+  }, "primitive c must not throw");
+  assert.strictEqual(shape(host), "<kid> |", "child still mounted");
+  m.unmount();
+  assert.strictEqual(destroyed, 1, "onDestroy still fires via the handle");
+  assert.strictEqual(shape(host), "|", "child removed on unmount");
+});
+
+// --- scope-tied teardown: dropping the enclosing scope unmounts the child -----
+
+await test("dropping the enclosing scope unmounts a child mounted inside it (fires onDestroy, clears _children)", () => {
+  const c = createContext(null);
+  const host = document.createElement("div");
+  const anchor = anchorAppend(host);
+  let destroyed = 0;
+  const Child = component("kid", {}, "<x></x>", (cc) => {
+    onDestroy(cc, () => destroyed++);
+  });
+
+  // Simulate a :for/:if item: open a scope, mount the child inside it.
+  const scope = beginScope(c);
+  const m = mountChild(c, anchor, Child, {});
+  endScope(c);
+
+  assert.strictEqual(shape(host), "<kid> |", "child mounted inside the item scope");
+  assert.ok(c._children.includes(m.ctx), "child linked under parent _children");
+  assert.strictEqual(destroyed, 0, "alive while the item is present");
+
+  // Item removed: dropScope must tear the child down.
+  dropScope(c, scope);
+  assert.strictEqual(destroyed, 1, "onDestroy fired when the item scope dropped");
+  assert.ok(!c._children.includes(m.ctx), "child de-registered from _children");
+  assert.strictEqual(shape(host), "|", "child DOM removed");
+
+  // Idempotent: a later explicit unmount (or a second drop) is a no-op.
+  m.unmount();
+  assert.strictEqual(destroyed, 1, "no double onDestroy");
 });
 
 console.log("\ndom.mountchild.test.mjs: " + passed + " passed.");


### PR DESCRIPTION
## Problem

A `:for` whose body mounts a child component (`<Child :x=\"n\"/>`) over
**primitive** items leaked child contexts, and had a latent runtime crash
surface. When a `:for`/`:if` item that mounts a `<Child/>` was **removed**, the
runtime dropped the item's binds and DOM but never unmounted the child:

- the child's `onDestroy` never fired, and
- the child context stayed on the parent's `_children` list forever (leak; a
  later parent teardown would then fire a stale child's `onDestroy`).

The reported `TypeError: Cannot create property '_children' on number` is the
worst-case shape of the same fragility — `mountChild` assumed its first arg was
always an object context.

## Where the bug was — runtime, not codegen

The emitted code already passes the **real component context** `c` to
`mountChild` inside the `:for` item's `wire(root, d, i)` function (verified by
compiling the repro), so `emit.rs` needed no change. The wrong assumption lived
in the runtime's per-item teardown.

## Fix

- **`core.mjs`**: scopes gain an optional `disposers` list; `dropScope` runs
  them once, after unbinding. New `addDisposer(c, fn)` registers teardown on the
  currently-open scope (no-op when none is open).
- **`blocks.mjs` `mountChild`**: registers the child's (now idempotent)
  `unmount` as a disposer on the enclosing item scope, so removing the item
  unmounts the child (fires `onDestroy`, clears the `_children` link). Also
  guards the `_children` write so a non-object `c` can never throw
  (never-panic).

## Tests

- `codegen_exec.rs`: `:for` over number and string primitives each rendering a
  `<Child>`; asserts initial render, push/remove/reorder, and that removed
  items de-register from `c._children` (fails pre-fix: `KIDS2:4` leak vs `3`).
- Runtime samples: `for/component_over_primitive_numbers` (with mutation) and
  `component/for_over_primitive_strings`.
- `packages/lunas/test/dom.mountchild.test.mjs`: primitive-`c` no-throw guard +
  scope-drop-unmounts-child (`onDestroy` + `_children` cleanup).
- Doc: `for-diff-design.md` §6 documents scope disposers + the guard.

## Quality gates
`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo test --workspace`, and `node packages/lunas/test/run-all.mjs` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)