### PR TITLE
fix(runtime): deepBox reactivity for Map/Set

### DIFF
--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -27,6 +27,11 @@ export function box(c, i, v) {
 // wrappers are cached per underlying object so identity is stable.
 // Mutating array methods (push/splice/…) work through the set trap because
 // they run with the proxy as `this`.
+// Map/Set (and WeakMap/WeakSet) values are collection-aware: reads and methods
+// run against the real collection (native internal slots reject a foreign
+// receiver), and mutating ops (Map set/delete/clear, Set add/delete/clear)
+// mark the variable dirty. Values stored inside a collection are not deeply
+// wrapped — reassign an entry to make a change reactive.
 export function deepBox(c, i, v) {
   const notify = () => markVar(c, i);
   const wrap = makeWrap(notify);
@@ -49,6 +54,20 @@ export function deepBox(c, i, v) {
 // `notify` on any nested set/delete. Exported so other modules that need the
 // same "deeply-mutated value" semantics (e.g. store.mjs's per-field deep
 // mutation support) don't have to reimplement the Proxy handler.
+//
+// Collections (Map/Set) get a dedicated get-trap path: their accessors and
+// methods have internal slots ([[MapData]]/[[SetData]]) that reject a foreign
+// receiver, so we must run them against the REAL target rather than the proxy.
+// Mutating collection methods (Map set/delete/clear, Set add/delete/clear) are
+// wrapped to perform the op then `notify()`, so bindings that read the
+// collection (`.size`, `.get`, iteration, `.has`, …) re-run. Reads never mark.
+//
+// Values stored inside a Map/Set are NOT deeply wrapped: only collection-level
+// membership mutations are reactive. Mutating an object retrieved from a
+// collection (`map.get(k).field = …`) does not mark the box — reassign the
+// entry (`map.set(k, next)`) to trigger reactivity. Keeping values raw avoids
+// proxy-identity hazards with `has`/`get`/key lookups and keeps semantics
+// honest and simple.
 export function makeWrap(notify) {
   const cache = new WeakMap(); // raw object -> proxy
   const handler = {
@@ -70,16 +89,56 @@ export function makeWrap(notify) {
       return ok;
     },
   };
+  // Collection handler: bind everything to the real target so native internal
+  // slots accept the receiver; wrap mutators to notify after the op.
+  const collectionHandler = {
+    get(t, k) {
+      const val = Reflect.get(t, k, t);
+      if (typeof val !== "function") return val;
+      if (MUTATORS.has(k) && MUTATORS.get(k)(t)) {
+        return function (...args) {
+          const ret = val.apply(t, args);
+          notify();
+          return ret;
+        };
+      }
+      // Non-mutating method (get/has/forEach/keys/values/entries/…): bind so
+      // the native internal-slot check sees the real collection as receiver.
+      return val.bind(t);
+    },
+  };
   const wrap = (val) => {
     if (val === null || typeof val !== "object") return val;
     let px = cache.get(val);
     if (!px) {
-      px = new Proxy(val, handler);
+      px = new Proxy(val, isCollection(val) ? collectionHandler : handler);
       cache.set(val, px);
     }
     return px;
   };
   return wrap;
+}
+
+// Mutating collection method names -> predicate that reports whether the method
+// is truly mutating on THIS target. `delete` and `clear` are shared names
+// across Map/Set (both mutate); `set` mutates on Map but is a WeakSet non-op /
+// absent elsewhere, and `add` mutates on Set/WeakSet. The predicate guards
+// against, e.g., a `set` key on an unrelated wrapped object slipping through —
+// though collectionHandler only ever wraps real Map/Set/WeakMap/WeakSet.
+const MUTATORS = new Map([
+  ["set", (t) => t instanceof Map || t instanceof WeakMap],
+  ["add", (t) => t instanceof Set || t instanceof WeakSet],
+  ["delete", () => true],
+  ["clear", () => true],
+]);
+
+function isCollection(v) {
+  return (
+    v instanceof Map ||
+    v instanceof Set ||
+    v instanceof WeakMap ||
+    v instanceof WeakSet
+  );
 }
 
 // prop(c, i, raw, def) — adopt an `@input` prop as a reactive variable at

--- a/packages/lunas/test/boxes.collections.test.mjs
+++ b/packages/lunas/test/boxes.collections.test.mjs
@@ -1,0 +1,256 @@
+// boxes.collections.test.mjs — deepBox reactivity for native Map/Set (and
+// no-throw handling of WeakMap/WeakSet). Covers the MED-severity fix where the
+// generic deepBox Proxy handler threw "incompatible receiver" on Map/Set
+// accessors, and makes membership mutations (set/add/delete/clear) reactive.
+// Run: node packages/lunas/test/boxes.collections.test.mjs
+
+import assert from "node:assert";
+import { createContext, bind } from "../src/core.mjs";
+import { deepBox } from "../src/boxes.mjs";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// ---------------------------------------------------------------------------
+// Map: reads work, mutations are reactive.
+// ---------------------------------------------------------------------------
+
+await test("Map: size/get/has/keys/values/entries/forEach read without throwing", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1], ["b", 2]]));
+  const m = d.v;
+  assert.strictEqual(m.size, 2);
+  assert.strictEqual(m.get("a"), 1);
+  assert.strictEqual(m.has("b"), true);
+  assert.strictEqual(m.has("z"), false);
+  assert.deepStrictEqual([...m.keys()], ["a", "b"]);
+  assert.deepStrictEqual([...m.values()], [1, 2]);
+  assert.deepStrictEqual([...m.entries()], [["a", 1], ["b", 2]]);
+  const seen = [];
+  m.forEach((v, k) => seen.push(k + "=" + v));
+  assert.deepStrictEqual(seen, ["a=1", "b=2"]);
+});
+
+await test("Map: iteration (for..of and spread) works through the proxy", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1]]));
+  const out = [];
+  for (const [k, v] of d.v) out.push(k + v);
+  assert.deepStrictEqual(out, ["a1"]);
+  assert.deepStrictEqual([...d.v], [["a", 1]]);
+});
+
+await test("Map: set() is reactive — a bind reading .size re-runs", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map());
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.size));
+  assert.deepStrictEqual(sizes, [0], "initial bind run");
+  d.v.set("a", 1);
+  await tick();
+  assert.deepStrictEqual(sizes, [0, 1], "set marks the var dirty");
+});
+
+await test("Map: set() to an existing key still notifies (value may have changed)", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1]]));
+  const values = [];
+  bind(c, [0], () => values.push(d.v.get("a")));
+  d.v.set("a", 2);
+  await tick();
+  assert.deepStrictEqual(values, [1, 2], "re-set of a key re-runs the bind");
+});
+
+await test("Map: delete() is reactive", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1]]));
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.size));
+  const removed = d.v.delete("a");
+  assert.strictEqual(removed, true, "delete returns the native boolean");
+  await tick();
+  assert.deepStrictEqual(sizes, [1, 0]);
+});
+
+await test("Map: clear() is reactive", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map([["a", 1], ["b", 2]]));
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.size));
+  d.v.clear();
+  await tick();
+  assert.deepStrictEqual(sizes, [2, 0]);
+});
+
+await test("Map: chained set() returns the Map (native contract preserved)", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Map());
+  const ret = d.v.set("a", 1);
+  // Native Map.set returns the map itself; our wrapper returns the raw target.
+  assert.strictEqual(ret.get("a"), 1);
+  assert.strictEqual(ret.size, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Set: reads work, mutations are reactive.
+// ---------------------------------------------------------------------------
+
+await test("Set: size/has/values/entries/forEach read without throwing", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Set([1, 2, 3]));
+  const s = d.v;
+  assert.strictEqual(s.size, 3);
+  assert.strictEqual(s.has(2), true);
+  assert.strictEqual(s.has(9), false);
+  assert.deepStrictEqual([...s.values()], [1, 2, 3]);
+  assert.deepStrictEqual([...s], [1, 2, 3]);
+  const seen = [];
+  s.forEach((v) => seen.push(v));
+  assert.deepStrictEqual(seen, [1, 2, 3]);
+});
+
+await test("Set: add() is reactive", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Set());
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.size));
+  d.v.add(1);
+  await tick();
+  assert.deepStrictEqual(sizes, [0, 1]);
+});
+
+await test("Set: delete() and clear() are reactive", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Set([1, 2]));
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.size));
+  d.v.delete(1);
+  await tick();
+  assert.deepStrictEqual(sizes, [2, 1]);
+  d.v.clear();
+  await tick();
+  assert.deepStrictEqual(sizes, [2, 1, 0]);
+});
+
+await test("Set: add() returns the Set (native contract preserved)", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, new Set());
+  const ret = d.v.add(1);
+  assert.strictEqual(ret.has(1), true);
+});
+
+// ---------------------------------------------------------------------------
+// Collections nested inside a deepBox'd object.
+// ---------------------------------------------------------------------------
+
+await test("Map nested in a deepBox'd object: reads work and mutations mark dirty", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { tags: new Map([["x", 1]]) });
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.tags.size));
+  assert.deepStrictEqual(sizes, [1], "nested Map .size reads without throwing");
+  d.v.tags.set("y", 2);
+  await tick();
+  assert.deepStrictEqual(sizes, [1, 2], "nested Map mutation marks the outer var");
+});
+
+await test("Set nested in a deepBox'd object: mutations mark dirty", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { ids: new Set([1]) });
+  const sizes = [];
+  bind(c, [0], () => sizes.push(d.v.ids.size));
+  d.v.ids.add(2);
+  await tick();
+  assert.deepStrictEqual(sizes, [1, 2]);
+});
+
+await test("nested Map wrapper identity is stable across property reads", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { m: new Map() });
+  assert.strictEqual(d.v.m, d.v.m, "same underlying Map -> same proxy");
+});
+
+// ---------------------------------------------------------------------------
+// WeakMap/WeakSet: not deeply reactive, but must not throw.
+// ---------------------------------------------------------------------------
+
+await test("WeakMap: get/set/has/delete work without throwing (not deeply reactive)", () => {
+  const c = createContext(null);
+  const key = {};
+  const d = deepBox(c, 0, new WeakMap([[key, 1]]));
+  const wm = d.v;
+  assert.strictEqual(wm.get(key), 1);
+  assert.strictEqual(wm.has(key), true);
+  wm.set(key, 2);
+  assert.strictEqual(wm.get(key), 2);
+  assert.strictEqual(wm.delete(key), true);
+  assert.strictEqual(wm.has(key), false);
+});
+
+await test("WeakSet: add/has/delete work without throwing", () => {
+  const c = createContext(null);
+  const a = {};
+  const d = deepBox(c, 0, new WeakSet([a]));
+  const ws = d.v;
+  assert.strictEqual(ws.has(a), true);
+  const b = {};
+  ws.add(b);
+  assert.strictEqual(ws.has(b), true);
+  assert.strictEqual(ws.delete(a), true);
+  assert.strictEqual(ws.has(a), false);
+});
+
+await test("WeakMap mutation still notifies (collection-level, best-effort)", async () => {
+  // WeakMap has no size/iteration, but membership mutations still mark the var
+  // so a bind reading `.has(key)` can react. This is best-effort — WeakMaps are
+  // documented as not deeply reactive, but the mutators do notify.
+  const c = createContext(null);
+  const key = {};
+  const d = deepBox(c, 0, new WeakMap());
+  const seen = [];
+  bind(c, [0], () => seen.push(d.v.has(key)));
+  d.v.set(key, 1);
+  await tick();
+  assert.deepStrictEqual(seen, [false, true]);
+});
+
+// ---------------------------------------------------------------------------
+// Regression: object/array deepBox behavior is unchanged.
+// ---------------------------------------------------------------------------
+
+await test("regression: object property set through deepBox still marks dirty", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { a: 1 });
+  const seen = [];
+  bind(c, [0], () => seen.push(d.v.a));
+  d.v.a = 2;
+  await tick();
+  assert.deepStrictEqual(seen, [1, 2]);
+});
+
+await test("regression: array push/splice through deepBox still marks dirty", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [1, 2]);
+  const lens = [];
+  bind(c, [0], () => lens.push(d.v.length));
+  d.v.push(3);
+  await tick();
+  assert.deepStrictEqual(lens, [2, 3]);
+  d.v.splice(0, 1);
+  await tick();
+  assert.deepStrictEqual(lens, [2, 3, 2]);
+});
+
+await test("regression: nested object wrapper identity stays stable", () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, { user: { name: "a" } });
+  assert.strictEqual(d.v.user, d.v.user);
+});
+
+console.log("boxes.collections.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/boxes.deep.test.mjs
+++ b/packages/lunas/test/boxes.deep.test.mjs
@@ -312,21 +312,15 @@ await test("deepBox: two different deepBox instances wrapping equal-shaped objec
   assert.notStrictEqual(d1.v, d2.v, "distinct underlying objects -> distinct proxies");
 });
 
-await test("deepBox: Map/Set values are NOT safely deep-reactive -- accessing native accessors through the plain Proxy throws (TODO: needs a dedicated collection handler, cross-module change, not fixed here)", () => {
+await test("deepBox: Map accessors/methods work through the collection-aware handler (no more incompatible-receiver throw)", () => {
   const c = createContext(null);
   const d = deepBox(c, 0, new Map([["a", 1]]));
-  // Reading `.size` (an accessor with internal slots) through the generic
-  // get-trap's Reflect.get(target, key, receiver=proxy) fails because Map's
-  // internal [[MapData]] slot isn't on the proxy receiver. This documents a
-  // real limitation of the current Proxy-based deep wrap rather than a
-  // regression: fixing it needs a collection-aware handler (unwrap-and-bind
-  // methods, or special-case Map/Set in makeWrap), which is a cross-module
-  // design change out of scope for this test-only pass.
-  assert.throws(
-    () => d.v.size,
-    /incompatible receiver/,
-    "Map accessors break through the generic Proxy handler"
-  );
+  // `.size` (an accessor with internal slots) and `.get`/`.has` (methods) now
+  // run against the real Map, so the native internal-slot check passes.
+  assert.strictEqual(d.v.size, 1, ".size reads without throwing");
+  assert.strictEqual(d.v.get("a"), 1, ".get returns the entry");
+  assert.strictEqual(d.v.has("a"), true, ".has works");
+  assert.strictEqual(d.v.has("z"), false);
 });
 
 console.log("boxes.deep.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/types/boxes.d.ts
+++ b/packages/lunas/types/boxes.d.ts
@@ -19,6 +19,13 @@ export function box<T>(c: Context, i: number, v: T): Box<T>;
  * Reads through `.v` return a Proxy that marks the variable dirty on any
  * nested set/delete. Nested objects are wrapped lazily on property access;
  * wrappers are cached per underlying object so identity is stable.
+ *
+ * Map/Set (and WeakMap/WeakSet) are collection-aware: accessors and methods
+ * run against the real collection so native internal slots accept the
+ * receiver, and mutating operations (Map `set`/`delete`/`clear`, Set
+ * `add`/`delete`/`clear`) mark the variable dirty. Values stored inside a
+ * collection are NOT deeply wrapped — reassign an entry to make a nested
+ * change reactive. WeakMap/WeakSet do not throw but are not deeply reactive.
  */
 export function deepBox<T>(c: Context, i: number, v: T): Box<T>;
 


### PR DESCRIPTION
## Problem

`deepBox(c, i, new Map())` (or a Map/Set nested inside a deepBox'd object) threw
when reading an accessor like `.size` or calling a method: the generic Proxy
`get` trap did `Reflect.get(target, key, receiver /* = proxy */)`, and native
Map/Set internals reject a foreign receiver — *"Method Map.prototype.size called
on incompatible receiver"*. A reactivity test previously documented this as an
expected-throw.

## Fix

`makeWrap` now detects `Map`/`Set`/`WeakMap`/`WeakSet` and uses a
collection-aware Proxy handler:

- **Reads work.** Accessors and methods (`size`, `get`, `has`, `keys`,
  `values`, `entries`, `forEach`, iteration) run **bound to the real
  collection**, so native internal slots (`[[MapData]]`/`[[SetData]]`) accept
  the receiver. No more throw.
- **Mutations are reactive.** Mutating methods — Map `set`/`delete`/`clear`,
  Set `add`/`delete`/`clear` (and WeakMap/WeakSet `set`/`add`/`delete`) — are
  wrapped to perform the op then call `markVar(c, i)`, so bindings reading the
  collection re-run. Reads never mark.
- **Object/array behavior unchanged** (array-method reactivity + nested lazy
  wrapping preserved).
- Dependency-free ES2015+ (Map/Set/Proxy are all ES2015).

## Reactivity semantics chosen

- **Collection-level membership mutations are reactive** (add/set/delete/clear
  mark the box). `set` on an existing key still notifies (value may differ).
- **Values stored inside a Map/Set are NOT deeply wrapped.** Mutating an object
  retrieved from a collection (`map.get(k).field = …`) does not mark the box —
  reassign the entry (`map.set(k, next)`) to trigger reactivity. This keeps
  key/`has`/`get` identity clean and semantics honest; documented in
  `src/boxes.mjs` and `types/boxes.d.ts`.
- **WeakMap/WeakSet** do not throw and their mutators best-effort notify; they
  are not deeply reactive (no size/iteration).

## Tests

- Replaced the expected-throw test in `boxes.deep.test.mjs` with
  working-behavior assertions.
- New `boxes.collections.test.mjs` — **20 tests**: Map size/get/set/delete/
  clear/has/iteration/forEach reactivity; Set add/delete/clear/has/size/
  iteration reactivity; Map/Set nested in a deepBox'd object; no-throw
  WeakMap/WeakSet; object/array deepBox regression.
- Full runtime suite green: **37/37 test files pass**
  (`node packages/lunas/test/run-all.mjs`).

Scope limited to `packages/lunas/src/boxes.mjs` + its types + tests. No other
runtime module, no crates/, no roadmap.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)