### PR TITLE
feat(wasm): add `analyze` binding for language-server navigation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -710,6 +710,8 @@ name = "lunas_wasm"
 version = "0.1.0"
 dependencies = [
  "lunas_compiler",
+ "lunas_parser",
+ "lunas_script",
  "lunas_span",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/lunas_wasm/Cargo.toml
+++ b/crates/lunas_wasm/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 lunas_compiler = { path = "../lunas_compiler" }
+lunas_parser = { path = "../lunas_parser" }
+lunas_script = { path = "../lunas_script" }
 lunas_span = { path = "../lunas_span" }
 serde = { version = "1", features = ["derive"] }
 wasm-bindgen = "0.2"

--- a/crates/lunas_wasm/src/lib.rs
+++ b/crates/lunas_wasm/src/lib.rs
@@ -24,6 +24,8 @@
 //! line/column with its own line index (the offsets are UTF-8 byte offsets,
 //! matching the compiler's spans).
 
+use lunas_parser::parse;
+use lunas_script::{declared_bindings_with_spans, free_identifiers_with_spans};
 use lunas_span::{Diagnostic, Severity};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
@@ -78,6 +80,92 @@ pub fn compile(source: &str) -> Result<JsValue, JsValue> {
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
+/// One named symbol occurrence flattened for JavaScript: a `name` plus its
+/// file-absolute UTF-8 byte range.
+#[derive(Serialize)]
+struct JsSymbol {
+    name: String,
+    start: u32,
+    end: u32,
+}
+
+/// The result of an [`analyze`] call: the navigation data a language server
+/// needs for a `.lunas` source.
+///
+/// - `bindings` — each binding declared in the `script:` block, at its
+///   declaration site.
+/// - `references` — each identifier used in a template expression (`${ … }`,
+///   `:if`/`:for` headers, event handlers, attribute bindings). Template uses
+///   that shadow a local of the same name are excluded (free identifiers only),
+///   so a reference matched to a binding by name is a genuine use of it.
+///
+/// A JS consumer wires these into go-to-definition, find-references, highlight,
+/// rename and semantic tokens by matching `references` to `bindings` by name.
+#[derive(Serialize)]
+struct AnalyzeResult {
+    bindings: Vec<JsSymbol>,
+    references: Vec<JsSymbol>,
+}
+
+/// Pure analysis over a `.lunas` source, split out so it is unit-testable on the
+/// host target without the wasm-bindgen `JsValue` bridge.
+///
+/// Never panics: parse problems yield an empty file, and per-block script parse
+/// errors are skipped rather than propagated (mirrors the never-panic contract
+/// of the public compiler entry points).
+fn analyze_source(source: &str) -> AnalyzeResult {
+    let (file, _diags) = parse(source);
+
+    let mut bindings = Vec::new();
+    if let Some(script) = &file.script {
+        if let Ok(decls) = declared_bindings_with_spans(&script.source.text) {
+            let base = script.source.range.start();
+            for (name, local) in decls {
+                let r = local.shifted(base);
+                bindings.push(JsSymbol {
+                    name,
+                    start: r.start().raw(),
+                    end: r.end().raw(),
+                });
+            }
+        }
+    }
+
+    let mut references = Vec::new();
+    if let Some(html) = &file.html {
+        html.template.for_each_expression(|text, expr_range| {
+            if let Ok(refs) = free_identifiers_with_spans(text) {
+                let base = expr_range.start();
+                for (name, local) in refs {
+                    let r = local.shifted(base);
+                    references.push(JsSymbol {
+                        name,
+                        start: r.start().raw(),
+                        end: r.end().raw(),
+                    });
+                }
+            }
+        });
+    }
+
+    AnalyzeResult {
+        bindings,
+        references,
+    }
+}
+
+/// Analyzes a `.lunas` source for language-server navigation.
+///
+/// Never throws: returns `{ bindings, references }` (see [`AnalyzeResult`]) with
+/// file-absolute UTF-8 byte offsets, which a JS consumer maps to line/column
+/// with its own line index. This is only the serialization shim over
+/// [`analyze_source`]; all analysis lives in `lunas_parser` / `lunas_script`.
+#[wasm_bindgen]
+pub fn analyze(source: &str) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(&analyze_source(source))
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// The compiler package version (the `lunas_wasm` crate version). Useful for a
 /// plugin to log which compiler build is loaded.
 #[wasm_bindgen]
@@ -120,5 +208,56 @@ mod tests {
         // Whatever the outcome, the adapter must serialize cleanly.
         let dtos: Vec<JsDiagnostic> = diags.iter().map(JsDiagnostic::from).collect();
         assert_eq!(dtos.len(), diags.len());
+    }
+
+    #[test]
+    fn analyze_finds_script_bindings_and_template_references() {
+        let src = "\
+html:
+    <div :class=\"count > 0 ? 'on' : 'off'\">${ count }</div>
+script:
+    let count = 0
+";
+        let result = analyze_source(src);
+
+        // The `let count` binding is reported at its declaration site.
+        let count_bind = result
+            .bindings
+            .iter()
+            .find(|b| b.name == "count")
+            .expect("count binding should be found");
+        assert_eq!(
+            &src[count_bind.start as usize..count_bind.end as usize],
+            "count"
+        );
+
+        // `count` is referenced in the template (the `:class` expression and the
+        // `${ count }` interpolation), each span slicing back to the name.
+        let refs: Vec<_> = result
+            .references
+            .iter()
+            .filter(|r| r.name == "count")
+            .collect();
+        assert!(
+            refs.len() >= 2,
+            "expected >= 2 template references, got {}",
+            refs.len()
+        );
+        for r in refs {
+            assert_eq!(&src[r.start as usize..r.end as usize], "count");
+        }
+    }
+
+    #[test]
+    fn analyze_never_panics_on_garbage() {
+        // Malformed / empty inputs must analyze cleanly with no panic.
+        for src in [
+            "",
+            "not a lunas file",
+            "script:\n    let = =",
+            "html:\n    ${",
+        ] {
+            let _ = analyze_source(src);
+        }
     }
 }


### PR DESCRIPTION
## What
Adds a second wasm binding, **`analyze(source)`**, alongside `compile`, exposing the parser's existing LS-navigation foundation to JavaScript.

```ts
analyze(source) => {
  bindings:   [{ name, start, end }],  // `script:` declarations
  references: [{ name, start, end }],  // identifier uses in template expressions
}
```
Offsets are **file-absolute UTF-8 byte offsets** (same convention as `compile`'s diagnostics), so a JS consumer maps them with its own line index.

## Why
The Lunas language server lives in a separate repo (`lunasrun/tools`) and, per that repo's design, borrows only the parse from this wasm boundary. Until now the boundary exposed only `compile` → `{ code, diagnostics }`, so the LS could do diagnostics but **not** go-to-definition / find-references / highlight / rename / semantic tokens — even though `lunas_parser`/`lunas_script` already compute exactly that (`declared_bindings_with_spans`, `free_identifiers_with_spans`, `Template::for_each_expression`; see `examples/lsp_demo.rs`). This binding surfaces it.

## How
A thin serialization shim over the existing analysis — **no compiler logic added**. `analyze_source` (host-testable, no `JsValue`) runs `parse`, collects script bindings shifted to file coordinates, and walks template expressions collecting free identifiers (free, not referenced, so a shadowing local isn't reported as a use of the binding). Never panics: parse errors yield an empty file and per-block script-parse errors are skipped.

## Tests / gate
- Host-target unit tests: binding + reference discovery (spans slice back to the name) and never-panic on malformed/empty input.
- `cargo fmt --check`, `cargo clippy -p lunas_wasm -- -D warnings`, `cargo test -p lunas_wasm` green; builds for `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)