### PR TITLE
perf(:for): fine-grained item-field updates

### DIFF
--- a/crates/lunas_compiler/docs/for-diff-design.md
+++ b/crates/lunas_compiler/docs/for-diff-design.md
@@ -259,6 +259,37 @@ index-dirty; the compiler only wires index-reactive binds when the template
 actually reads the index, so templates that ignore the index pay nothing on
 reorder.
 
+### Fine-grained item-field updates (avoiding reconcile on a property change)
+
+A property change on one item (`rows[i].label = x`, a `deepBox` nested write)
+would, naively, mark the whole `rows` box dirty and re-run the reconciler over
+all N items (extractKeys + LIS + patch every kept item) — O(N) work for an
+O(1) change. When the `:for` source is exactly one `deepBox` variable, the
+compiler emits `box: rows` and `forBlock` opts that box into **element
+tracking**:
+
+- The box distinguishes a **structural** mutation (a write on the array itself:
+  reassign / `push` / `splice` / `length` / `rows[i] = obj`) from a pure
+  **element-field** write (a nested mutation of an object that is a direct
+  element of the array, or anything under it). Attribution uses a single shared
+  Proxy handler plus a WeakMap (raw subtree object → owning array element),
+  populated as reads traverse the tree, so the hot get/set traps stay
+  monomorphic.
+- On flush `forBlock` checks the box: **structural → full reconcile** (the
+  algorithm above, unchanged); **field-only → patch only the touched items**
+  (their patch closure + `runScope`), looked up via a raw-element → handle map.
+  Any field write it can't attribute to a live handle falls back to a full
+  reconcile, so no update is ever missed.
+- Both mutation kinds still `markVar`, so every OTHER dependent of the array
+  (computeds, a `${rows.length}` bind elsewhere) stays correct — only the
+  forBlock's own reaction is specialized.
+- The reconciler iterates the box's **raw** array, so keying / patching / item
+  binds never read through element proxies on the hot path.
+
+This makes update-every-Kth and single-field edits O(changes) instead of O(N),
+while structural changes keep the provably-minimal keyed diff. Correctness is
+preserved by always reconciling whenever anything structural changed.
+
 ---
 
 ## 7. Duplicate keys — defined fallback

--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -217,7 +217,9 @@ export function forBlock(c, into, deps, items, opts) { /* keyed list at a text a
                                                           builder), or mount { mount } — the
                                                           `:for`-over-a-component mode where
                                                           opts.mount(d,key,i) → { node, patch }
-                                                          mounts one child per item. keyOf optional */ }
+                                                          mounts one child per item. keyOf optional.
+                                                          opts.box (a deepBox) enables fine-grained
+                                                          item-field updates (§8) */ }
 export function mountChild(c, before, Child, props) { /* Child(props) inserted at a text anchor;
                                                           returns { root, ctx, setProp(name,value),
                                                           unmount() } — setProp drives a reactive
@@ -495,6 +497,19 @@ a unit (§8).
 - **`:for`**: initial render builds **all items as one `innerHTML` string** (the
   fast path), then wires each item. Updates use a keyed diff (insert / remove /
   move individual items); items are **not** re-`innerHTML`ed wholesale.
+- **Fine-grained item-field updates**: when the iterable is exactly one
+  `deepBox` variable (`item of rows`), the compiler additionally emits
+  `box: rows` in the `forBlock` opts. `forBlock` then opts that box into element
+  tracking (`box.observeElems()`), which lets the box distinguish a **structural**
+  change (reassign / `push` / `splice` / `length` / `rows[i] = obj`) from a pure
+  **element-field** write (`rows[i].label = x`, at any depth under an element).
+  A structural change runs the full keyed reconcile as before; a field-only
+  flush **patches just the touched items** — no `extractKeys` / LIS / whole-list
+  patch — so an item-property change is O(changes), not O(N). Both cases still
+  `markVar`, so every other dependent (computeds, `${rows.length}`, …) stays
+  correct. Derived iterables (`rows.filter(…)`, a computed) get no `box:` and
+  keep the coarse reconcile-on-change path. The reconciler iterates the box's
+  **raw** array so the hot path never reads through element proxies.
 - **Multi-root blocks** (a branch/item with several top-level nodes): track the
   node list, or delimit with a start/end anchor pair, so removal/move affects the
   whole group. Single-root blocks use the cheap one-node path (compiler picks).

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -1954,6 +1954,26 @@ impl<'a> Emitter<'a> {
             frag.shadowed,
         );
 
+        // Fine-grained item-field updates: when the iterable is exactly a single
+        // deepBox variable read (`item of rows`), pass the box so `forBlock` can
+        // observe element-field mutations (`rows[i].label = x`) and patch just the
+        // touched item instead of running a full reconcile. Only a bare, unshadowed
+        // reactive var qualifies; anything derived (`rows.filter(...)`, a computed)
+        // keeps the coarse reconcile-on-change path.
+        let fine_box: Option<String> = {
+            let it = parsed.iterable.trim();
+            if is_plain_identifier(it) && !frag.shadowed.iter().any(|n| n == it) {
+                self.component
+                    .reactive_vars
+                    .iter()
+                    .find(|v| v.name == it)
+                    .filter(|_| is_deeply_mutated(&self.deep_hint, it))
+                    .map(|_| it.to_string())
+            } else {
+                None
+            }
+        };
+
         // `:for` over a component tag: mount-mode forBlock (one child per item).
         if let Some(comp) = for_component {
             self.emit_for_component(
@@ -2001,6 +2021,12 @@ impl<'a> Emitter<'a> {
         b.push_str("html: ");
         b.push_str(&html_name);
         b.push_str(",\n");
+        if let Some(box_name) = &fine_box {
+            push_indent(b, frag.indent + 1);
+            b.push_str("box: ");
+            b.push_str(box_name);
+            b.push_str(",\n");
+        }
         push_indent(b, frag.indent + 1);
         b.push_str("wire: (");
         b.push_str(&root);
@@ -2771,6 +2797,19 @@ fn binding_names(pattern: &str) -> Vec<String> {
     // Object patterns parse as blocks when bare; parenthesize.
     let as_expr = format!("({p})");
     lunas_script::free_identifiers(&as_expr).unwrap_or_default()
+}
+
+/// Whether `s` is a single plain JS identifier (`[A-Za-z_$][A-Za-z0-9_$]*`) with
+/// no member access, call, or other expression syntax. Used to detect a `:for`
+/// iterable that is exactly one variable read, eligible for the fine-grained
+/// element-field update fast path.
+fn is_plain_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
 }
 
 /// Whether a user name would collide with the single-letter positional generated

--- a/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/App.lunas
@@ -1,0 +1,16 @@
+html:
+    <div>
+        <button class="bump" @click="bump()">bump</button>
+        <button class="add" @click="add()">add</button>
+        <ul>
+            <li :for="row of rows" :key="row.id">
+                <span class="lbl">${row.info.text}</span>
+                <input class="edit" />
+            </li>
+        </ul>
+    </div>
+script:
+    let rows = [{id:1,info:{text:"a"}},{id:2,info:{text:"b"}},{id:3,info:{text:"c"}}]
+    let seq = 4
+    function bump(){ rows[1].info.text = rows[1].info.text + "!" }
+    function add(){ rows = rows.concat([{id:seq,info:{text:"z"}}]); seq = seq + 1 }

--- a/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="bump">bump</button><button class="add">add</button><ul><li><span class="lbl">a</span><input class="edit"></li><li><span class="lbl">b</span><input class="edit"></li><li><span class="lbl">c</span><input class="edit"></li></ul></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/for/item_field_finegrained_sibling_state/steps.mjs
@@ -1,0 +1,19 @@
+export default async ({ $$, click, equal }) => {
+  const L = () => $$("span.lbl").map((n) => n.innerHTMLString()).join(",");
+  // Give each input a distinct value to detect any node re-creation.
+  const inputs = $$("input.edit");
+  inputs.forEach((el, i) => (el.value = "v" + i));
+  // A deep field write on row 1 must patch ONLY that item's text bind.
+  await click("button.bump");
+  equal(L(), "a,b!,c");
+  // Sibling input nodes must be the SAME nodes (state preserved -> field patch
+  // never re-ran the reconciler / rebuilt items).
+  const after = $$("input.edit");
+  equal(after.map((el) => el.value).join(","), "v0,v1,v2");
+  // A structural change (append) still reconciles correctly after field writes,
+  // and preserves the existing items' input state.
+  await click("button.add");
+  equal(L(), "a,b!,c,z");
+  const grown = $$("input.edit");
+  equal(grown.map((el) => el.value).join(","), "v0,v1,v2,");
+};

--- a/crates/lunas_compiler/tests/snapshots/app_App.js
+++ b/crates/lunas_compiler/tests/snapshots/app_App.js
@@ -76,6 +76,7 @@ export default component("div", {}, HTML, (c, props) => {
   const a3 = anchorAppend(g3);
   forBlock(c, a3, [1], () => Array.from((tags.v) || []), {
     html: HTML_7,
+    box: tags,
     wire: (r6, d0) => {
       let tag = d0;
       const [g9] = refs(r6, [[]]);

--- a/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
+++ b/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
@@ -19,6 +19,7 @@ export default component("div", {}, HTML, (c, props) => {
   const a0 = anchorAppend(g0);
   forBlock(c, a0, [0], () => Array.from((groups.v) || []), {
     html: HTML_1,
+    box: groups,
     wire: (r0, d0) => {
       let group = d0;
       const [g1, g2, g3] = refs(r0, [[0], [1], [1]]);

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -22,7 +22,6 @@ import {
   addDisposer,
 } from "./core.mjs";
 import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
-import { rawOf } from "./boxes.mjs";
 import { isLive, runMount, runDestroy, onDestroy } from "./lifecycle.mjs";
 
 const toNodes = (h) => (Array.isArray(h) ? h : [h]);
@@ -241,6 +240,10 @@ export function forBlock(c, anchor, deps, items, opts) {
     fineBox.observeElems();
     rawToHandle = new Map();
   }
+  // In fine mode the reconciler iterates the RAW array (no per-element proxy
+  // reads on the hot path); field-write detection still fires when user code
+  // mutates through `box.v`. Outside fine mode, use the compiled `items()`.
+  const readItems = fineBox ? () => fineBox._raw() : items;
 
   let seeded = false;
   if (opts.seed) {
@@ -250,7 +253,7 @@ export function forBlock(c, anchor, deps, items, opts) {
     // Bulk initial render (design doc §2a): ONE innerHTML parse of every
     // item's skeleton concatenated, then per-item wiring, then seed the
     // reconciler. No later update ever re-runs this.
-    const arr = items();
+    const arr = readItems();
     const n = arr.length;
     if (n > 0) {
       const scr = anchor.ownerDocument.createElement("div");
@@ -274,12 +277,13 @@ export function forBlock(c, anchor, deps, items, opts) {
     seeded = true;
   }
 
-  const run = () => reconcile(state, host, items(), makeItem, ropts);
+  const run = () => reconcile(state, host, readItems(), makeItem, ropts);
 
-  // Seed the raw->handle map from the initial render's state (if any).
+  // Seed the raw->handle map from the initial render's state (if any). In fine
+  // mode state.data already holds raw elements (readItems yields raw).
   if (fineBox) {
     for (let k = 0; k < state.data.length; k++) {
-      rawToHandle.set(rawOf(state.data[k]), state.nodes[k]);
+      rawToHandle.set(state.data[k], state.nodes[k]);
     }
   }
 
@@ -338,9 +342,9 @@ export function forBlock(c, anchor, deps, items, opts) {
   }
   function rebuildRawMap() {
     rawToHandle.clear();
-    const data = state.data;
+    const data = state.data; // raw elements in fine mode
     const nodes = state.nodes;
-    for (let k = 0; k < data.length; k++) rawToHandle.set(rawOf(data[k]), nodes[k]);
+    for (let k = 0; k < data.length; k++) rawToHandle.set(data[k], nodes[k]);
   }
 
   const s = bind(c, deps, () => {

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -22,6 +22,7 @@ import {
   addDisposer,
 } from "./core.mjs";
 import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
+import { rawOf } from "./boxes.mjs";
 import { isLive, runMount, runDestroy, onDestroy } from "./lifecycle.mjs";
 
 const toNodes = (h) => (Array.isArray(h) ? h : [h]);
@@ -225,6 +226,22 @@ export function forBlock(c, anchor, deps, items, opts) {
     onWarn: opts.onWarn,
   };
 
+  // Fine-grained item-field updates (output-design.md §8, for-diff-design.md §6):
+  // when the `:for` source is a single deepBox (opts.box), opting into element
+  // tracking lets us tell a pure field mutation (`rows[i].label = x`) apart from
+  // a structural change. On a field-only flush we patch just the touched items —
+  // no extractKeys / LIS / whole-list patch — falling back to a full reconcile
+  // whenever anything structural changed (reassign / length / reorder). This is
+  // the only behavioral change; correctness is preserved by always reconciling
+  // on structural change. Element tracking must be enabled BEFORE the initial
+  // `items()` read so `state.data` already holds trackable element proxies.
+  const fineBox = opts.box && typeof opts.box.observeElems === "function" ? opts.box : null;
+  let rawToHandle = null; // raw element -> handle, rebuilt after each reconcile
+  if (fineBox) {
+    fineBox.observeElems();
+    rawToHandle = new Map();
+  }
+
   let seeded = false;
   if (opts.seed) {
     seedForState(state, opts.seed.keys, opts.seed.handles, opts.seed.data);
@@ -258,13 +275,82 @@ export function forBlock(c, anchor, deps, items, opts) {
   }
 
   const run = () => reconcile(state, host, items(), makeItem, ropts);
+
+  // Seed the raw->handle map from the initial render's state (if any).
+  if (fineBox) {
+    for (let k = 0; k < state.data.length; k++) {
+      rawToHandle.set(rawOf(state.data[k]), state.nodes[k]);
+    }
+  }
+
+  // When the initial render already ran (seeded), incremental tracking is live
+  // from the start; otherwise the first fire renders via a full reconcile.
+  let fineInited = seeded;
+  const fineRun = () => {
+    // First fire without a seeded initial render (e.g. make-mode): render via a
+    // full reconcile so the list actually mounts, then track incrementally.
+    if (!fineInited) {
+      fineInited = true;
+      fineBox._clear();
+      run();
+      rebuildRawMap();
+      return;
+    }
+    // A structural change (or a datum with no live handle) forces a full
+    // reconcile; that rebuilds rawToHandle from the fresh state below.
+    if (fineBox._struct) {
+      fineBox._clear();
+      run();
+      rebuildRawMap();
+      return;
+    }
+    // Snapshot the dirty elements before clearing (`_clear` empties the live
+    // Set, which is the same object).
+    const dirty = fineBox._elems && fineBox._elems.size ? Array.from(fineBox._elems) : null;
+    fineBox._clear();
+    if (!dirty) return;
+    let missed = false;
+    // Patch only the touched items. Index is looked up from state so patchItem
+    // gets the right position (patchItem re-runs the item scope with new data).
+    const idxOf = indexMap();
+    for (let k = 0; k < dirty.length; k++) {
+      const h = rawToHandle.get(dirty[k]);
+      const pos = h !== undefined ? idxOf.get(h) : undefined;
+      if (h === undefined || pos === undefined) {
+        missed = true;
+        continue;
+      }
+      ropts.patchItem(h, state.data[pos], pos);
+    }
+    if (missed) {
+      // A field write landed on an element we don't track (shouldn't happen for
+      // in-place edits of mounted items, but never miss an update): reconcile.
+      run();
+      rebuildRawMap();
+    }
+  };
+
+  function indexMap() {
+    const m = new Map();
+    const nodes = state.nodes;
+    for (let k = 0; k < nodes.length; k++) m.set(nodes[k], k);
+    return m;
+  }
+  function rebuildRawMap() {
+    rawToHandle.clear();
+    const data = state.data;
+    const nodes = state.nodes;
+    for (let k = 0; k < data.length; k++) rawToHandle.set(rawOf(data[k]), nodes[k]);
+  }
+
   const s = bind(c, deps, () => {
     if (seeded) {
       // the initial render already mounted the items; skip the first run
       seeded = false;
       return;
     }
-    run();
+    if (fineBox) fineRun();
+    else run();
   });
 
   return {

--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -5,20 +5,11 @@
 
 import { markVar } from "./core.mjs";
 
-// Marker used to unwrap a fine-grained `:for` element proxy back to its raw
-// target. Reading `proxy[RAW]` returns the underlying object; on any non-proxy
-// (or a plain value) it is `undefined`. Lets forBlock key its raw->handle map by
-// stable raw identity even though `items()` yields element proxies.
+// Marker to unwrap a fine-grained `:for` element proxy back to its raw target:
+// reading `proxy[RAW]` returns the underlying object. Kept for callers that hold
+// an element proxy and need stable raw identity (the forBlock itself iterates
+// the box's raw array directly and does not need it on the hot path).
 export const RAW = Symbol("lunas.raw");
-
-// rawOf(x) — the raw object behind a fine-grained element proxy, or x itself.
-export function rawOf(x) {
-  if (x !== null && typeof x === "object") {
-    const r = x[RAW];
-    if (r !== undefined) return r;
-  }
-  return x;
-}
 
 // box(c, i, v) — reassign-only variable at reactive index i.
 // Lightest path: plain getter/setter, no Proxy. Same-value writes are no-ops.
@@ -67,8 +58,11 @@ export function deepBox(c, i, v) {
     set v(x) {
       if (x !== v) {
         v = x;
+        if (self._track) {
+          self._struct = true; // whole-value reassign is structural
+          wrap.markRoot(x);
+        }
         px = wrap(x);
-        if (self._track) self._struct = true; // whole-value reassign is structural
         notify();
       }
     },
@@ -79,9 +73,11 @@ export function deepBox(c, i, v) {
     observeElems() {
       if (!this._track) {
         this._track = true;
+        fineHooks.active = true;
         this._elems = new Set();
-        // Re-wrap so the root array's proxy uses the tracking handler and
-        // remembers which nested objects are direct array elements.
+        // Register the current root array so its own mutations are structural,
+        // then re-wrap so reads populate owner attribution.
+        wrap.markRoot(v);
         px = wrap(v);
       }
       return this;
@@ -90,20 +86,26 @@ export function deepBox(c, i, v) {
       this._struct = false;
       if (this._elems) this._elems.clear();
     },
+    // The underlying RAW current value (the unwrapped array). forBlock iterates
+    // this for keying/patching so the hot reconcile path never reads through the
+    // element proxies; field-write detection still runs when USER code mutates
+    // via `.v` (the proxy).
+    _raw() {
+      return v;
+    },
   };
-  const onStruct = () => {
-    if (self._track) self._struct = true;
-    notify();
+  const fineHooks = {
+    active: false,
+    onStruct() {
+      self._struct = true;
+      notify();
+    },
+    onElem(rawEl) {
+      if (self._elems) self._elems.add(rawEl);
+      notify();
+    },
   };
-  const onElem = (rawEl) => {
-    if (self._elems) self._elems.add(rawEl);
-    notify();
-  };
-  const wrap = makeWrap(notify, {
-    isRoot: () => self._track,
-    onStruct,
-    onElem,
-  });
+  const wrap = makeWrap(notify, fineHooks);
   let px = wrap(v);
   return self;
 }
@@ -128,69 +130,50 @@ export function deepBox(c, i, v) {
 // honest and simple.
 export function makeWrap(notify, fine) {
   const cache = new WeakMap(); // raw object -> proxy
-  // Fine-grained :for hooks (optional). When active (fine.isRoot() true), the
-  // ROOT array's own mutations route to fine.onStruct(); each direct element of
-  // the array, and the whole subtree beneath it, routes nested field writes to
-  // fine.onElem(rawTopLevelElement). This lets a forBlock patch only the touched
-  // items on a field-only update instead of running a full reconcile.
-  const fineActive = () => fine != null && fine.isRoot();
-
-  // Element-subtree handler: mutations attribute to `owner` (the direct array
-  // element at the root of this subtree). Reads keep the same owner so deeper
-  // objects (`arr[i].sub.field = x`) still mark `arr[i]`.
-  const elemHandler = (owner) => ({
-    get(t, k, r) {
-      if (k === RAW) return t;
-      const val = Reflect.get(t, k, r);
-      return val !== null && typeof val === "object" ? wrapElem(val, owner) : val;
-    },
-    set(t, k, x, r) {
-      const had = k in t;
-      const old = t[k];
-      const ok = Reflect.set(t, k, x, r);
-      if (ok && (!had || old !== x)) fine.onElem(owner);
-      return ok;
-    },
-    deleteProperty(t, k) {
-      const had = k in t;
-      const ok = Reflect.deleteProperty(t, k);
-      if (ok && had) fine.onElem(owner);
-      return ok;
-    },
-  });
-  const wrapElem = (val, owner) => {
-    if (val === null || typeof val !== "object") return val;
-    if (isCollection(val)) return wrap(val); // collections keep coarse semantics
-    let px = elemCache.get(val);
-    if (!px) {
-      px = new Proxy(val, elemHandler(owner));
-      elemCache.set(val, px);
-    }
-    return px;
-  };
-  const elemCache = new WeakMap(); // raw element-subtree object -> elem proxy
+  // Fine-grained :for tracking (optional, `fine` present). When active, the
+  // ROOT array proxy's own mutations route to fine.onStruct() (structural), and
+  // a nested field write attributes to the direct array element it lives under,
+  // via fine.onElem(rawElement). Owner attribution uses a single WeakMap
+  // (raw subtree object -> owning array element), populated on read, so the
+  // hot get/set traps stay MONOMORPHIC (one shared handler, no per-element
+  // handler allocation) — matching the non-fine cost as closely as possible.
+  // `fine` is a live hooks object with a mutable `active` flag (false until a
+  // forBlock calls observeElems). While inactive the traps behave exactly like
+  // the non-fine path — one boolean read of overhead — so deepBoxes not used as
+  // a fine `:for` source pay essentially nothing.
+  const owners = fine ? new WeakMap() : null; // raw obj -> raw owning element
+  const roots = fine ? new WeakSet() : null; // the diffed root array(s)
 
   const handler = {
     get(t, k, r) {
-      const val = Reflect.get(t, k, r);
-      if (val === null || typeof val !== "object") return val;
-      // Root array element read under fine-grained tracking: wrap so its nested
-      // field writes attribute to that element (owner = the raw element itself).
-      if (fineActive() && Array.isArray(t) && typeof k !== "symbol") {
-        return wrapElem(val, val);
+      if (fine && fine.active) {
+        if (k === RAW) return t;
+        const val = Reflect.get(t, k, r);
+        if (val === null || typeof val !== "object") return val;
+        if (roots.has(t)) {
+          if (typeof k !== "symbol") owners.set(val, val); // direct element owns itself
+        } else {
+          const o = owners.get(t);
+          if (o !== undefined && !owners.has(val)) owners.set(val, o);
+        }
+        return wrap(val);
       }
-      return wrap(val);
+      const val = Reflect.get(t, k, r);
+      return val !== null && typeof val === "object" ? wrap(val) : val;
     },
     set(t, k, x, r) {
       const had = k in t;
       const old = t[k];
       const ok = Reflect.set(t, k, x, r);
       if (ok && (!had || old !== x)) {
-        // A write on the root array itself (index assignment, length, push/…)
-        // is structural. Deeper objects use elemHandler, so this handler's
-        // target `t` under fine mode is only ever the root array.
-        if (fineActive() && Array.isArray(t)) fine.onStruct();
-        else notify();
+        if (fine && fine.active) {
+          if (roots.has(t)) fine.onStruct();
+          else {
+            const o = owners.get(t);
+            if (o !== undefined) fine.onElem(o);
+            else notify();
+          }
+        } else notify();
       }
       return ok;
     },
@@ -198,8 +181,14 @@ export function makeWrap(notify, fine) {
       const had = k in t;
       const ok = Reflect.deleteProperty(t, k);
       if (ok && had) {
-        if (fineActive() && Array.isArray(t)) fine.onStruct();
-        else notify();
+        if (fine && fine.active) {
+          if (roots.has(t)) fine.onStruct();
+          else {
+            const o = owners.get(t);
+            if (o !== undefined) fine.onElem(o);
+            else notify();
+          }
+        } else notify();
       }
       return ok;
     },
@@ -230,6 +219,11 @@ export function makeWrap(notify, fine) {
       cache.set(val, px);
     }
     return px;
+  };
+  // markRoot(rawArray) — register the diffed root array so its own mutations are
+  // structural. Called by the box for the current `.v` value (fine mode only).
+  wrap.markRoot = (val) => {
+    if (roots && val !== null && typeof val === "object") roots.add(val);
   };
   return wrap;
 }

--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -5,6 +5,21 @@
 
 import { markVar } from "./core.mjs";
 
+// Marker used to unwrap a fine-grained `:for` element proxy back to its raw
+// target. Reading `proxy[RAW]` returns the underlying object; on any non-proxy
+// (or a plain value) it is `undefined`. Lets forBlock key its raw->handle map by
+// stable raw identity even though `items()` yields element proxies.
+export const RAW = Symbol("lunas.raw");
+
+// rawOf(x) — the raw object behind a fine-grained element proxy, or x itself.
+export function rawOf(x) {
+  if (x !== null && typeof x === "object") {
+    const r = x[RAW];
+    if (r !== undefined) return r;
+  }
+  return x;
+}
+
 // box(c, i, v) — reassign-only variable at reactive index i.
 // Lightest path: plain getter/setter, no Proxy. Same-value writes are no-ops.
 export function box(c, i, v) {
@@ -32,11 +47,20 @@ export function box(c, i, v) {
 // receiver), and mutating ops (Map set/delete/clear, Set add/delete/clear)
 // mark the variable dirty. Values stored inside a collection are not deeply
 // wrapped — reassign an entry to make a change reactive.
+//
+// Fine-grained `:for` tracking (opt-in): a deepBox used as a `:for` source can
+// have a `forBlock` attach itself via `box.observeElems()`. Once observed, the
+// box records — between flushes — whether the mutation was STRUCTURAL (a write
+// on the array itself: `arr[i] = x`, `arr.length = n`, `push`/`splice`/…, or a
+// whole-value reassign `box.v = x`) or a pure ELEMENT-FIELD write (a nested
+// mutation of an object that is a direct element of the array, e.g.
+// `arr[i].label = x`). Both still `markVar` so every dependent flushes; the
+// forBlock consults `box._struct` / `box._elems` to patch just the touched
+// items instead of running a full reconcile when nothing structural changed.
 export function deepBox(c, i, v) {
   const notify = () => markVar(c, i);
-  const wrap = makeWrap(notify);
-  let px = wrap(v);
-  return {
+  // Fine-grained state (null until a forBlock opts in via observeElems()).
+  const self = {
     get v() {
       return px;
     },
@@ -44,10 +68,44 @@ export function deepBox(c, i, v) {
       if (x !== v) {
         v = x;
         px = wrap(x);
+        if (self._track) self._struct = true; // whole-value reassign is structural
         notify();
       }
     },
+    // --- fine-grained :for support (all no-cost until observeElems runs) ---
+    _track: false, // observing element-field vs structural changes
+    _struct: false, // a structural change occurred since last clear
+    _elems: null, // Set<rawElement> field-mutated since last clear
+    observeElems() {
+      if (!this._track) {
+        this._track = true;
+        this._elems = new Set();
+        // Re-wrap so the root array's proxy uses the tracking handler and
+        // remembers which nested objects are direct array elements.
+        px = wrap(v);
+      }
+      return this;
+    },
+    _clear() {
+      this._struct = false;
+      if (this._elems) this._elems.clear();
+    },
   };
+  const onStruct = () => {
+    if (self._track) self._struct = true;
+    notify();
+  };
+  const onElem = (rawEl) => {
+    if (self._elems) self._elems.add(rawEl);
+    notify();
+  };
+  const wrap = makeWrap(notify, {
+    isRoot: () => self._track,
+    onStruct,
+    onElem,
+  });
+  let px = wrap(v);
+  return self;
 }
 
 // makeWrap(notify) — build a lazy, cached deep-Proxy wrapper that calls
@@ -68,24 +126,81 @@ export function deepBox(c, i, v) {
 // entry (`map.set(k, next)`) to trigger reactivity. Keeping values raw avoids
 // proxy-identity hazards with `has`/`get`/key lookups and keeps semantics
 // honest and simple.
-export function makeWrap(notify) {
+export function makeWrap(notify, fine) {
   const cache = new WeakMap(); // raw object -> proxy
-  const handler = {
+  // Fine-grained :for hooks (optional). When active (fine.isRoot() true), the
+  // ROOT array's own mutations route to fine.onStruct(); each direct element of
+  // the array, and the whole subtree beneath it, routes nested field writes to
+  // fine.onElem(rawTopLevelElement). This lets a forBlock patch only the touched
+  // items on a field-only update instead of running a full reconcile.
+  const fineActive = () => fine != null && fine.isRoot();
+
+  // Element-subtree handler: mutations attribute to `owner` (the direct array
+  // element at the root of this subtree). Reads keep the same owner so deeper
+  // objects (`arr[i].sub.field = x`) still mark `arr[i]`.
+  const elemHandler = (owner) => ({
     get(t, k, r) {
+      if (k === RAW) return t;
       const val = Reflect.get(t, k, r);
-      return val !== null && typeof val === "object" ? wrap(val) : val;
+      return val !== null && typeof val === "object" ? wrapElem(val, owner) : val;
     },
     set(t, k, x, r) {
       const had = k in t;
       const old = t[k];
       const ok = Reflect.set(t, k, x, r);
-      if (ok && (!had || old !== x)) notify();
+      if (ok && (!had || old !== x)) fine.onElem(owner);
       return ok;
     },
     deleteProperty(t, k) {
       const had = k in t;
       const ok = Reflect.deleteProperty(t, k);
-      if (ok && had) notify();
+      if (ok && had) fine.onElem(owner);
+      return ok;
+    },
+  });
+  const wrapElem = (val, owner) => {
+    if (val === null || typeof val !== "object") return val;
+    if (isCollection(val)) return wrap(val); // collections keep coarse semantics
+    let px = elemCache.get(val);
+    if (!px) {
+      px = new Proxy(val, elemHandler(owner));
+      elemCache.set(val, px);
+    }
+    return px;
+  };
+  const elemCache = new WeakMap(); // raw element-subtree object -> elem proxy
+
+  const handler = {
+    get(t, k, r) {
+      const val = Reflect.get(t, k, r);
+      if (val === null || typeof val !== "object") return val;
+      // Root array element read under fine-grained tracking: wrap so its nested
+      // field writes attribute to that element (owner = the raw element itself).
+      if (fineActive() && Array.isArray(t) && typeof k !== "symbol") {
+        return wrapElem(val, val);
+      }
+      return wrap(val);
+    },
+    set(t, k, x, r) {
+      const had = k in t;
+      const old = t[k];
+      const ok = Reflect.set(t, k, x, r);
+      if (ok && (!had || old !== x)) {
+        // A write on the root array itself (index assignment, length, push/…)
+        // is structural. Deeper objects use elemHandler, so this handler's
+        // target `t` under fine mode is only ever the root array.
+        if (fineActive() && Array.isArray(t)) fine.onStruct();
+        else notify();
+      }
+      return ok;
+    },
+    deleteProperty(t, k) {
+      const had = k in t;
+      const ok = Reflect.deleteProperty(t, k);
+      if (ok && had) {
+        if (fineActive() && Array.isArray(t)) fine.onStruct();
+        else notify();
+      }
       return ok;
     },
   };


### PR DESCRIPTION
## Root cause

In `forBlock`, a single reconcile closure is bound against the `:for` source's deps (the whole `rows` box). An item-field mutation `rows[i].label = x` (deepBox nested write) marks the `rows` index dirty -> the for-bind fires -> `reconcile()` runs `extractKeys` over ALL N items + LIS + `patchItem`/`runScope` on every matched item, even though only one field of one item changed. This is the 2-4x gap vs Svelte/Solid on keyed update-every-Nth.

Confirmed via the compiled output: inner item binds like `bind(c, [], () => { t.data = \`${row.label}\`; })` have empty deps and are driven only by the item patch path; the only dep on the array index is the forBlock's reconcile.

## Fix (staged, correctness-first)

Separate **structural** changes from **element-field** changes at the box level:

- `deepBox` used as a `:for` source opts into element tracking. The proxy routes root-array mutations (reassign / `push` / `splice` / `length` / `arr[i] = obj`) to a structural-dirty flag, and nested field writes (`arr[i].field = x`, at any depth under an element) to an element-dirty set keyed by the raw element. Both still `markVar` so every other dependent (computeds, `.length` binds) stays correct.
- `forBlock` consults the box on each flush: **structural -> full reconcile** (unchanged path); **field-only -> patch just the touched items** (O(changes)) via a raw-element -> handle map, skipping extractKeys/LIS/whole-list patch. Any un-mapped write falls back to a reconcile, so nothing is ever missed.
- Compiler passes `box: <var>` only when the iterable is exactly one bare, unshadowed deepBox variable. Derived iterables (`rows.filter(...)`, computeds) keep the coarse reconcile path.

## Correctness

- Structural change always reconciles -> add/remove/reorder/swap/empty transitions/duplicate-key fallback are untouched.
- All existing tests green: `cargo test --workspace` (1061 runtime samples incl. `for/*`), `node packages/lunas/test/run-all.mjs` (38 files), `cargo fmt`, `cargo clippy -D warnings`.
- New behavior is exercised by the existing `for/react_field_update` sample (field write patches only that item).

## Benchmarks

Before/after numbers to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)