### PR TITLE
feat(codegen): wire child-side emits (c-emits)

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -339,7 +339,7 @@ export function attach(root, host) { /* append a detached component root to a li
 // calling a bare `emit("name", payload)` in its script; the codegen detects that
 // free `emit` reference and injects, at the top of the child's setup:
 //   registerEmits(c, props);
-//   const emit = (name, payload) => emit$rt(c, name, payload);   // emit$rt = aliased runtime emit
+//   const emit = (name, payload) => $emit(c, name, payload);   // $emit = aliased runtime emit
 // so the child's `emit("name", payload)` routes through registerEmits'd props to
 // the parent's on<Name> handler. (The runtime emit is imported under an alias
 // because the bare `emit` name is reserved for that injected closure; a child
@@ -400,7 +400,7 @@ No signal-tracking stack, no VDOM, no per-node effect objects.
 | `:for="n of items"` | `forBlock`; **initial render = one `innerHTML` of the concatenated items**, updates = keyed diff. A **component** body (`<Child :for=…/>`) uses forBlock *mount mode*: one `mountChild` per item (props from the item) instead of a static item skeleton; the item `make` returns `{ node, patch }` and the child teardown rides the item scope |
 | `<Child :p="e"/>` | `mountChild(c, anchor, Child, { p: () => e, static: "x" })` at an anchor; reactive props are getters, static props are values (see below) |
 | `<Child @save="h($event)"/>` (parent) | an `onSave: ($event) => h($event)` entry on the mountChild props object; the child raises it with `emit("save", payload)` (§5, c-emits). `@save-all` → `onSaveAll` (camel-cased). Handler runs in the parent; it does not auto-mark the parent dirty |
-| `emit("save", payload)` in a child `script` | the compiler detects the free `emit` call and injects, at the top of the child's `setup`, `registerEmits(c, props)` + `const emit = (name, payload) => emit$rt(c, name, payload)` (runtime `emit` imported as an alias). The child's `emit("save", …)` then routes to the parent's `onSave` prop. A child that declares its own top-level `emit` opts out (no injection) |
+| `emit("save", payload)` in a child `script` | the compiler detects the free `emit` call and injects, at the top of the child's `setup`, `registerEmits(c, props)` + `const emit = (name, payload) => $emit(c, name, payload)` (runtime `emit` imported as the `$emit` alias). The child's `emit("save", …)` then routes to the parent's `onSave` prop. A child that declares its own top-level `emit` opts out (no injection) |
 | `@input name:type = v` | `const name = prop(c, "name", i, props.name, v)` at the top of `setup` — every prop is a reactive box (see below) |
 | `:class="e"` | `setClass(el, "<static class>", e)` — `e` is `string \| { cls: bool } \| array` (nested), normalized and merged with the static `class` attr (`normClass`) |
 | `:style="e"` | `setStyle(el, "<static style>", e)` — `e` is `string \| { camelCaseProp: v }` (arrays merge), camelCase → kebab, merged with the static `style` attr (`normStyle`) |

--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -335,13 +335,21 @@ export function attach(root, host) { /* append a detached component root to a li
 
 // --- emits: child → parent events (c-emits) ---------------------------------
 // A `@name` listener on a component tag compiles to an `on<Name>` prop on the
-// mountChild props object (see §6). The child calls emit(c, "name", payload),
-// which looks up on<Name> in the props it was constructed with and calls it.
+// mountChild props object (the PARENT half, see §6). The CHILD raises events by
+// calling a bare `emit("name", payload)` in its script; the codegen detects that
+// free `emit` reference and injects, at the top of the child's setup:
+//   registerEmits(c, props);
+//   const emit = (name, payload) => emit$rt(c, name, payload);   // emit$rt = aliased runtime emit
+// so the child's `emit("name", payload)` routes through registerEmits'd props to
+// the parent's on<Name> handler. (The runtime emit is imported under an alias
+// because the bare `emit` name is reserved for that injected closure; a child
+// that declares its OWN top-level `emit` opts out — no plumbing is injected.)
 // emit does NOT mark the parent dirty — the handler decides (a box setter in the
 // handler marks the parent as usual). Names camel-case: `save-all` → `onSaveAll`.
 export function registerEmits(c, props, declared) { /* at the top of a child setup: stash props so
                                                        emit can find on<Name> handlers; optional
-                                                       declared[] enables warn-only validation */ }
+                                                       declared[] enables warn-only validation
+                                                       (no `.lunas` syntax for declared[] yet) */ }
 export function emit(c, name, payload) { /* invoke the parent's on<Name> handler if present; returns
                                             whether one ran; no-op (false) when no listener/parent */ }
 export function eventPropName(name) { /* "save" → "onSave"; the codegen's @name→onName mapping */ }
@@ -391,7 +399,8 @@ No signal-tracking stack, no VDOM, no per-node effect objects.
 | `:if` / `:elseif` / `:else` | one `ifBlock` chain per cascade, anchored; branch built by its own `innerHTML` when shown. A branch body that is a **component tag** (`<Child :if=…/>`) mounts the child via `mountChild` inside the branch `make` (teardown rides the branch scope); a bare multi-child `<template :if>` unwraps into a multi-root branch (no literal `<template>`) |
 | `:for="n of items"` | `forBlock`; **initial render = one `innerHTML` of the concatenated items**, updates = keyed diff. A **component** body (`<Child :for=…/>`) uses forBlock *mount mode*: one `mountChild` per item (props from the item) instead of a static item skeleton; the item `make` returns `{ node, patch }` and the child teardown rides the item scope |
 | `<Child :p="e"/>` | `mountChild(c, anchor, Child, { p: () => e, static: "x" })` at an anchor; reactive props are getters, static props are values (see below) |
-| `<Child @save="h($event)"/>` | an `onSave: ($event) => h($event)` entry on the mountChild props object; the child raises it with `emit(c, "save", payload)` (§5, c-emits). `@save-all` → `onSaveAll` (camel-cased). Handler runs in the parent; it does not auto-mark the parent dirty |
+| `<Child @save="h($event)"/>` (parent) | an `onSave: ($event) => h($event)` entry on the mountChild props object; the child raises it with `emit("save", payload)` (§5, c-emits). `@save-all` → `onSaveAll` (camel-cased). Handler runs in the parent; it does not auto-mark the parent dirty |
+| `emit("save", payload)` in a child `script` | the compiler detects the free `emit` call and injects, at the top of the child's `setup`, `registerEmits(c, props)` + `const emit = (name, payload) => emit$rt(c, name, payload)` (runtime `emit` imported as an alias). The child's `emit("save", …)` then routes to the parent's `onSave` prop. A child that declares its own top-level `emit` opts out (no injection) |
 | `@input name:type = v` | `const name = prop(c, "name", i, props.name, v)` at the top of `setup` — every prop is a reactive box (see below) |
 | `:class="e"` | `setClass(el, "<static class>", e)` — `e` is `string \| { cls: bool } \| array` (nested), normalized and merged with the static `class` attr (`normClass`) |
 | `:style="e"` | `setStyle(el, "<static style>", e)` — `e` is `string \| { camelCaseProp: v }` (arrays merge), camelCase → kebab, merged with the static `style` attr (`normStyle`) |

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -67,6 +67,8 @@ const ALL_HELPERS: &[&str] = &[
     "slotContent",
     "setClass",
     "setStyle",
+    "registerEmits",
+    "emit",
     // `component` is intentionally excluded: it is only referenced at module
     // scope (the default export), where user bindings — emitted inside the
     // setup closure — cannot shadow it.
@@ -255,6 +257,14 @@ struct Emitter<'a> {
     /// assignment per two-way member/index lvalue (`::value="o.k"` deep-writes
     /// `o`, so `o` needs a `deepBox` even if the script never mutates it).
     deep_hint: String,
+    /// Whether the child script raises events via a free `emit(...)` call
+    /// (output-design.md §5, c-emits). When set, `setup_body` injects a
+    /// `registerEmits(c, props)` call plus a `const emit = (name, payload) =>`
+    /// closure that binds `c`, so the child's `emit("save", payload)` routes to
+    /// the parent's `onSave` handler prop. The runtime `emit` helper is imported
+    /// under an alias (`$emit`) because the bare `emit` name is reserved for that
+    /// closure.
+    emits_used: bool,
     /// The name of the injected runtime-context setup parameter. Defaults to
     /// `c`; mangled to a reserved form when a user binding would shadow it (a
     /// component that declares `let c` in script, which otherwise emits
@@ -328,6 +338,22 @@ impl<'a> Emitter<'a> {
         }
         for p in &component.props {
             reserved.insert(p.name.clone());
+        }
+        // Child-side emits (c-emits): the script raises events by calling a bare
+        // `emit(name, payload)` — a FREE identifier (not a user-declared binding
+        // and not a prop). When present, the setup body injects a local `const
+        // emit` closure that binds `c`; reserve the `emit` name here so the
+        // runtime `emit` helper is imported under an alias (`$emit`) and the bare
+        // name is free for that closure. A user who declares their own `emit`
+        // (a top-level function/const — already in `reserved`) opts out: their
+        // name wins and no plumbing is injected.
+        let emits_used = !reserved.contains("emit")
+            && !script_text.trim().is_empty()
+            && lunas_script::free_identifiers_with_spans_program(script_text)
+                .map(|ids| ids.iter().any(|(name, _)| name == "emit"))
+                .unwrap_or(false);
+        if emits_used {
+            reserved.insert("emit".to_string());
         }
         let mut aliases = std::collections::BTreeMap::new();
         for &h in ALL_HELPERS {
@@ -420,6 +446,7 @@ impl<'a> Emitter<'a> {
             hoisted: Vec::new(),
             child_imports,
             deep_hint,
+            emits_used,
             ctx,
             props_param,
             local_prefix,
@@ -533,6 +560,7 @@ impl<'a> Emitter<'a> {
     fn setup_body(&mut self, skeleton: &Skeleton, diags: &mut Vec<Diagnostic>) -> String {
         let mut b = String::new();
 
+        self.emit_emits(&mut b);
         self.emit_props(&mut b);
         self.emit_boxes(&mut b);
         let root_base = format!("{}.root", self.ctx());
@@ -546,6 +574,46 @@ impl<'a> Emitter<'a> {
         self.emit_fragment(&mut b, skeleton, &frag, diags);
 
         b
+    }
+
+    // --- emits (child → parent events) ------------------------------------
+
+    /// Injects the child-side emit plumbing (output-design.md §5, c-emits) when
+    /// the script raises events via a bare `emit(name, payload)` call:
+    ///
+    /// ```js
+    /// registerEmits(c, props);
+    /// const emit = (name, payload) => $emit(c, name, payload);
+    /// ```
+    ///
+    /// `registerEmits` stashes the props so the runtime `emit` can look up the
+    /// parent's `on<Name>` handler; the injected `emit` closure binds `c` so the
+    /// child's `emit("save", payload)` needs only the name + payload. The runtime
+    /// helper is referenced under its alias (`$emit`) because the bare `emit`
+    /// name is reserved for this closure (see `new`). Emitted before props/boxes
+    /// so the `const emit` is initialized before any script body runs.
+    fn emit_emits(&mut self, b: &mut String) {
+        if !self.emits_used {
+            return;
+        }
+        self.use_helper("registerEmits");
+        self.use_helper("emit");
+        let register = self.helper("registerEmits").to_string();
+        let emit_rt = self.helper("emit").to_string();
+        let ctx = self.ctx().to_string();
+        let props = self.props().to_string();
+        b.push_str("  ");
+        b.push_str(&register);
+        b.push('(');
+        b.push_str(&ctx);
+        b.push_str(", ");
+        b.push_str(&props);
+        b.push_str(");\n");
+        b.push_str("  const emit = (name, payload) => ");
+        b.push_str(&emit_rt);
+        b.push('(');
+        b.push_str(&ctx);
+        b.push_str(", name, payload);\n");
     }
 
     // --- props ------------------------------------------------------------

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -853,6 +853,64 @@ fn dynamic_component_event_and_ref() {
 }
 
 #[test]
+fn child_emit_call_injects_register_and_closure() {
+    // A child that raises an event with a bare `emit("saved", payload)` call
+    // gets `registerEmits(c, props)` + a `const emit` closure binding `c`, and
+    // the runtime `emit` helper is imported under the `$emit` alias so it does
+    // not clash with the injected local (output-design.md §5, c-emits).
+    let js = emit(
+        "html:\n    <button @click=\"save()\">x</button>\nscript:\n    let n = 0\n    function save(){ n++; emit(\"saved\", n) }\n",
+    );
+    assert!(
+        js.contains("emit as $emit"),
+        "runtime emit imported under alias: {js}"
+    );
+    assert!(
+        js.contains("registerEmits(c, props);"),
+        "registerEmits stashes props: {js}"
+    );
+    assert!(
+        js.contains("const emit = (name, payload) => $emit(c, name, payload);"),
+        "emit closure binds c: {js}"
+    );
+    // The payload expression is `.v`-rewritten like any reactive read.
+    assert!(
+        js.contains("emit(\"saved\", n.v)"),
+        "reactive payload read goes through the box: {js}"
+    );
+}
+
+#[test]
+fn child_without_emit_has_no_emit_plumbing() {
+    // A child that never calls `emit` must not import/inject the emit helpers.
+    let js = emit(
+        "html:\n    <button @click=\"inc()\">x</button>\nscript:\n    let n = 0\n    function inc(){ n++ }\n",
+    );
+    assert!(!js.contains("registerEmits"), "no registerEmits: {js}");
+    assert!(
+        !js.contains("emit as $emit") && !js.contains("const emit ="),
+        "no emit plumbing: {js}"
+    );
+}
+
+#[test]
+fn user_declared_emit_is_not_treated_as_c_emits() {
+    // A user who declares their own top-level `emit` opts out: no plumbing is
+    // injected and their `emit` is emitted verbatim (a plain box mutation here).
+    let js = emit(
+        "html:\n    <button @click=\"go()\">x</button>\nscript:\n    let n = 0\n    function emit(){ n++ }\n    function go(){ emit() }\n",
+    );
+    assert!(
+        !js.contains("registerEmits") && !js.contains("emit as $emit"),
+        "user-declared emit opts out of c-emits: {js}"
+    );
+    assert!(
+        js.contains("function emit(){ n.v++ }"),
+        "user emit emitted verbatim: {js}"
+    );
+}
+
+#[test]
 fn dynamic_component_without_is_is_voided() {
     let (js, diags) = compile("html:\n    <component/>\n");
     assert!(js.is_some());

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -409,6 +409,96 @@ fn child_renders_and_receives_reactive_props() {
 }
 
 #[test]
+fn child_emit_drives_parent_state() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Child raises `emit("changed", 1)` from a click. The parent listens with
+    // `@changed="onChanged($event)"`, whose handler mutates parent state — that
+    // write (a parent box setter) is what re-renders the parent text. This is
+    // the full child → parent event round-trip (output-design.md §5, c-emits).
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div><Child @changed=\"onChanged($event)\"/><p>total: ${total}</p></div>\n\
+        script:\n\
+        \x20   let total = 0\n\
+        \x20   function onChanged(n){ total = total + n }\n";
+    let child = "html:\n\
+        \x20   <button @click=\"bump()\">c</button>\n\
+        script:\n\
+        \x20   function bump(){ emit(\"changed\", 1) }\n";
+
+    // Layout: outer div (root) > inner div > [childRoot(button), anchor, p].
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const cBtn = div.childNodes[0].childNodes[0];\n\
+        const p = div.childNodes[2];\n\
+        console.log('INITIAL:' + p.innerHTMLString());\n\
+        cBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER_EMIT:' + p.innerHTMLString());\n\
+        cBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER_EMIT2:' + p.innerHTMLString());\n";
+
+    let out = run_parent_child("child_emit", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:total: 0"),
+        "parent renders initial state: {out}"
+    );
+    assert!(
+        out.contains("AFTER_EMIT:total: 1"),
+        "child emit runs the parent handler, which mutates parent state: {out}"
+    );
+    assert!(
+        out.contains("AFTER_EMIT2:total: 2"),
+        "the emit channel stays live across repeated events: {out}"
+    );
+}
+
+#[test]
+fn child_emit_payload_and_no_listener_are_safe() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // Two facets in one round-trip: (1) an object payload is delivered intact to
+    // the parent handler as `$event`; (2) a second event the parent does NOT
+    // listen for is a no-op (emit returns false, nothing throws).
+    let parent = "@use Child from \"./Child.lunas\"\n\
+        html:\n\
+        \x20   <div><Child @save=\"onSave($event)\"/><p>${label}:${count}</p></div>\n\
+        script:\n\
+        \x20   let label = \"none\"\n\
+        \x20   let count = 0\n\
+        \x20   function onSave(e){ label = e.name; count = e.n }\n";
+    let child = "html:\n\
+        \x20   <button @click=\"go()\">c</button>\n\
+        script:\n\
+        \x20   function go(){ emit(\"save\", { name: \"a\", n: 7 }); emit(\"unheard\", 1) }\n";
+
+    // Layout: outer div (root) > inner div > [childRoot(button), anchor, p].
+    let driver = "\
+        const root = factory({});\n\
+        const div = root.childNodes[0];\n\
+        const cBtn = div.childNodes[0].childNodes[0];\n\
+        const p = div.childNodes[2];\n\
+        console.log('INITIAL:' + p.innerHTMLString());\n\
+        cBtn.dispatch('click'); await tick();\n\
+        console.log('AFTER:' + p.innerHTMLString());\n";
+
+    let out = run_parent_child("child_emit_payload", parent, child, "./Child.lunas", driver);
+    assert!(
+        out.contains("INITIAL:none:0"),
+        "initial parent render: {out}"
+    );
+    assert!(
+        out.contains("AFTER:a:7"),
+        "object payload delivered as $event and an unlistened event is a no-op: {out}"
+    );
+}
+
+#[test]
 fn child_uses_default_when_prop_omitted() {
     if !node_available() {
         eprintln!("skipping codegen_exec: node not found at {NODE}");

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/App.lunas
@@ -1,0 +1,6 @@
+@use Child from "./Child.lunas"
+html:
+    <div><Child @changed="onChanged($event)"/><p>total: ${total}</p></div>
+script:
+    let total = 0
+    function onChanged(n){ total = total + n }

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/Child.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/Child.lunas
@@ -1,0 +1,4 @@
+html:
+    <button @click="add()">+1</button>
+script:
+    function add(){ emit("changed", 1) }

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/_config.json
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/_config.json
@@ -1,0 +1,1 @@
+{ "description": "a child emits an event whose parent handler mutates parent state; the parent DOM updates" }

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><div><button>+1</button></div><p>total: 3</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/expected.html
@@ -1,0 +1,1 @@
+<div><div><div><button>+1</button></div><p>total: 0</p></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/emit/child_emit_updates_parent_total/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ click, expect }) => {
+  // Child emit("changed", 1) runs the parent's onChanged, which mutates parent
+  // state — that write is what re-renders the parent's total text.
+  expect("p").text("total: 0");
+  await click("button");
+  expect("p").text("total: 1");
+  await click("button");
+  await click("button");
+  expect("p").text("total: 3");
+};

--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -61,18 +61,32 @@ mountChild(c, anchor, SaveButton, {
 });
 ```
 
-At the top of the child's `setup`, `registerEmits` stashes the props so `emit`
-can find handlers; then `emit(c, "saved", payload)` looks up `onSaved` and calls
-it:
+On the child side, the compiler detects the bare `emit(...)` call in your script
+and injects two lines at the top of the child's `setup`: `registerEmits` stashes
+the props so `emit` can find handlers, and a small `emit` closure binds the
+component context `c` so your script only passes the name and payload:
 
 ```js
-// child setup
-registerEmits(c, props /*, ["saved"] optional declared list */);
-// …later…
-emit(c, "saved", { at: Date.now() });   // → props.onSaved({ at: … })
+// child setup (compiler-injected preamble)
+registerEmits(c, props);
+const emit = (name, payload) => emit$rt(c, name, payload);  // emit$rt = runtime emit
+// …your script, verbatim…
+function save() {
+  emit("saved", { at: Date.now() });   // → runtime emit → props.onSaved({ at: … })
+}
 ```
 
+So in `.lunas` you write `emit("saved", payload)` — the context argument is
+supplied for you. The runtime `emit` is imported under an alias (`emit$rt`
+above) so it never clashes with the injected `emit` closure your script calls.
+
 `eventPropName` is the exact mapping the compiler uses: `"save"` → `"onSave"`.
+
+> **The `emit` name is reserved when you use it.** If your child script calls
+> `emit(...)`, the compiler owns the `emit` identifier (the injected closure).
+> If instead you declare your *own* top-level `emit` (a `function emit` or
+> `const emit`), you opt out: no plumbing is injected and your `emit` is emitted
+> verbatim. Pick one — don't both declare `emit` and expect the c-emits closure.
 
 > **Component tag vs. DOM element.** `@click` on a `<button>` is a DOM listener;
 > `@saved` on a `<SaveButton/>` is an emit handler. The compiler distinguishes
@@ -163,6 +177,11 @@ emit(c, "delete", …);   // warns: emitted undeclared event "delete"; handler s
 ```
 
 This is a lean, warn-only guard — useful in development, never fatal.
+
+> **Not yet surfaced in `.lunas`.** There is no authoring syntax for the
+> declared-events list today, so the compiler emits `registerEmits(c, props)`
+> without it. The runtime parameter exists so a future `@emits`-style
+> declaration can pass it through without a runtime change.
 
 ## Gotchas
 

--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -69,7 +69,7 @@ component context `c` so your script only passes the name and payload:
 ```js
 // child setup (compiler-injected preamble)
 registerEmits(c, props);
-const emit = (name, payload) => emit$rt(c, name, payload);  // emit$rt = runtime emit
+const emit = (name, payload) => $emit(c, name, payload);  // $emit = runtime emit
 // …your script, verbatim…
 function save() {
   emit("saved", { at: Date.now() });   // → runtime emit → props.onSaved({ at: … })
@@ -77,7 +77,7 @@ function save() {
 ```
 
 So in `.lunas` you write `emit("saved", payload)` — the context argument is
-supplied for you. The runtime `emit` is imported under an alias (`emit$rt`
+supplied for you. The runtime `emit` is imported under an alias (`$emit`
 above) so it never clashes with the injected `emit` closure your script calls.
 
 `eventPropName` is the exact mapping the compiler uses: `"save"` → `"onSave"`.


### PR DESCRIPTION
## Summary

Completes the child half of component events (c-emits). The parent side —
`@save="…"` on a component tag → an `onSave` handler prop — landed in #181.
This PR wires the **child** side: a child raises events with a bare
`emit("name", payload)` call in its script, and codegen routes it to the
parent's `on<Name>` prop.

## Authoring surface

In a child `script`, call `emit("name", payload)` — the component context
`c` is supplied for you (matches what `docs/components/events.md` already
promised). No new declaration keyword.

## How it compiles

The emitter detects a **free** `emit` reference in the child script and
injects, at the top of `setup` (before props/boxes):

```js
registerEmits(c, props);
const emit = (name, payload) => $emit(c, name, payload);   // $emit = aliased runtime emit
```

- `registerEmits` stashes the props so the runtime `emit` can find the
  parent's `on<Name>` handler.
- The runtime `emit` is imported as `emit as $emit` because the bare `emit`
  name is reserved for the injected closure.
- A child that declares its **own** top-level `emit` opts out — no plumbing
  is injected, its `emit` is emitted verbatim.
- `emit` does not mark the parent dirty; the parent handler's box setters do
  (unchanged semantics).

## Tests

- **codegen_emit** (3): closure/registerEmits/alias injection; no plumbing
  when `emit` is unused; user-declared-`emit` opt-out.
- **codegen_exec** (2): child emit runs the parent handler that mutates
  parent state and re-renders the parent DOM (repeatable); object payload
  delivered as `$event` + an unlistened event is a safe no-op.
- **runtime sample** `emit/child_emit_updates_parent_total/`: a child `+1`
  button emits `changed`; the parent's `onChanged` bumps `total`; the parent
  `<p>` updates 0→1→3.

## Docs

- `crates/lunas_compiler/docs/output-design.md` §5 emits block + §6 mapping
  table (new child-side `emit(...)` row).
- `docs/components/events.md`: the injected preamble, the `emit`-name
  reservation / opt-out rule, and that `declared[]` validation has no
  `.lunas` syntax yet.

## Quality gate

- `cargo fmt --check` ✓
- `cargo clippy --workspace -D warnings` ✓
- `cargo test --workspace` ✓ (incl. 1062 runtime samples)
- `node packages/lunas/test/run-all.mjs` (node v22.18.0) → all 38 files pass

The roadmap `c-emits` item was already `done`, so no roadmap edit is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)