### PR TITLE
fix(runtime): keyed :for / :if / fragments inside <table> (context-correct fragment parsing)

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -482,9 +482,24 @@ template are imported; a colliding tag name (e.g. a component literally named
 6. Return `root`; the caller attaches it to the live DOM **once**.
 
 **Multi-root component**: skip the wrapper element — parse the interior into a
-throwaway `<div>` (or the mount host), take its child nodes as the roots, and
-track the set (or a start/end anchor pair) so the block can be removed/moved as
-a unit (§8).
+throwaway container (a `<template>`; see the table-context note below), take its
+child nodes as the roots, and track the set (or a start/end anchor pair) so the
+block can be removed/moved as a unit (§8).
+
+**Fragment parsing goes through a `<template>` (table-context safety).** Every
+detached fragment parse the runtime does — a `:for` item / bulk-item skeleton, an
+`:if`/`ifChain` branch (`fromHTML`), and a multi-root `fragment(...)` — parses the
+HTML as the content of a `<template>` element (`t.innerHTML = html; …t.content`),
+not the `innerHTML` of a `<div>`. A `<template>`'s content fragment is a valid
+insertion context for **any** element, whereas a `<div>` is not a valid table or
+select insertion context: assigning `"<tr>…</tr>"` (or `<td>`/`<tbody>`/`<option>`
+/`<col>`/…) as a `<div>`'s `innerHTML` makes the HTML parser **DROP** the
+table/select tags, leaving an empty container whose `childNodes[0]` is `undefined`
+— which crashed a keyed `:for`/`:if`/fragment whose item is a `<tr>` (etc.). The
+shared `parseFragment(html, doc)` helper (dom.mjs) implements this, falling back to
+a `<div>` only when `<template>`/`.content` is unavailable. The component **root**
+build is unaffected (its static skeleton is the `innerHTML` of the `div` wrapper /
+the component's own root tag, both valid contexts for table markup).
 
 ---
 

--- a/crates/lunas_compiler/tests/codegen_exec.rs
+++ b/crates/lunas_compiler/tests/codegen_exec.rs
@@ -1271,3 +1271,58 @@ fn inline_and_function_call_handlers_mix() {
         "function-call handler still works: {out}"
     );
 }
+
+#[test]
+fn keyed_for_inside_table_tbody_renders_and_reacts() {
+    if !node_available() {
+        eprintln!("skipping codegen_exec: node not found at {NODE}");
+        return;
+    }
+    // A keyed `:for` whose item skeleton is a `<tr>` (table context). Parsing
+    // `<tr>` as the innerHTML of a `<div>` DROPS it in a real browser, which was
+    // the table-context crash (`childNodes[0]` undefined). The runtime now parses
+    // fragment skeletons through a `<template>` so the row survives. This test
+    // mounts the table, asserts the initial rows, then removes one via its own
+    // button (structural change through the keyed reconciler).
+    let source = "html:\n\
+        \x20   <table><tbody><tr :for=\"row of rows\" :key=\"row.id\"><td class=\"cell\">${row.label}</td><td><button class=\"del\" @click=\"del(row.id)\">x</button></td></tr></tbody></table>\n\
+        script:\n\
+        \x20   let rows = [{id:1,label:\"a\"},{id:2,label:\"b\"},{id:3,label:\"c\"}]\n\
+        \x20   function del(id){ rows = rows.filter(r => r.id !== id) }\n";
+
+    // Walk the whole tree collecting `td.cell` text, in document order.
+    let driver = "\
+        const root = factory({});\n\
+        const cells = () => {\n\
+          const out = [];\n\
+          const walk = (n) => {\n\
+            for (const c of n.childNodes) {\n\
+              if (c.tag === 'td' && (c.getAttribute('class') || '') === 'cell') out.push(c.innerHTMLString());\n\
+              walk(c);\n\
+            }\n\
+          };\n\
+          walk(root);\n\
+          return out.join(',');\n\
+        };\n\
+        const dels = () => {\n\
+          const out = [];\n\
+          const walk = (n) => {\n\
+            for (const c of n.childNodes) {\n\
+              if (c.tag === 'button' && (c.getAttribute('class') || '') === 'del') out.push(c);\n\
+              walk(c);\n\
+            }\n\
+          };\n\
+          walk(root);\n\
+          return out;\n\
+        };\n\
+        console.log('INITIAL:' + cells());\n\
+        dels()[1].dispatch('click'); await tick();\n\
+        console.log('MID:' + cells());\n\
+        dels()[0].dispatch('click'); await tick();\n\
+        console.log('AFTER:' + cells());\n";
+
+    let out = run_component("table_for", source, driver);
+    assert!(out.contains("INITIAL:a,b,c"), "initial table render: {out}");
+    assert!(out.contains("MID:a,c"), "remove middle row: {out}");
+    assert!(out.contains("AFTER:c"), "remove first row: {out}");
+}

--- a/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <select><option :for="o of opts" :key="o.id" class="opt">${o.label}</option></select>
+script:
+    let opts = [{id:1,label:"one"},{id:2,label:"two"}]
+    function add(){ opts = [...opts, {id:3,label:"three"}] }

--- a/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/expected.after.html
@@ -1,0 +1,1 @@
+<div><select><option class="opt">one</option><option class="opt">two</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/expected.html
@@ -1,0 +1,1 @@
+<div><select><option class="opt">one</option><option class="opt">two</option></select></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/for/select_option_keyed/steps.mjs
@@ -1,0 +1,4 @@
+export default async ({ $$, equal }) => {
+  const L = () => $$("option.opt").map(n => n.innerHTMLString()).join(",");
+  equal(L(), "one,two");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <table><tbody><tr :for="row of rows" :key="row.id"><td class="cell">${row.label}</td><td><button class="up" @click="bump(row.id)">+</button></td></tr></tbody></table>
+script:
+    let rows = [{id:1,label:"a"},{id:2,label:"b"}]
+    function bump(id){ rows = rows.map(r => r.id === id ? {...r, label: r.label + "!"} : r) }

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/expected.after.html
@@ -1,0 +1,1 @@
+<div><table><tbody><tr><td class="cell">a!</td><td><button class="up">+</button></td></tr><tr><td class="cell">b!</td><td><button class="up">+</button></td></tr></tbody></table></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/expected.html
@@ -1,0 +1,1 @@
+<div><table><tbody><tr><td class="cell">a</td><td><button class="up">+</button></td></tr><tr><td class="cell">b</td><td><button class="up">+</button></td></tr></tbody></table></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_field_update/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $$, click, equal }) => {
+  const L = () => $$("td.cell").map(n => n.innerHTMLString()).join(",");
+  equal(L(), "a,b");
+  await click($$("button.up")[0]);
+  equal(L(), "a!,b");
+  await click($$("button.up")[1]);
+  equal(L(), "a!,b!");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/App.lunas
@@ -1,0 +1,8 @@
+html:
+    <table><tbody><tr :for="row of rows" :key="row.id"><td class="cell">${row.label}</td><td><button class="del" @click="removeRow(row.id)">x</button></td></tr></tbody></table>
+script:
+    let rows = [{id:1,label:"a"},{id:2,label:"b"},{id:3,label:"c"}]
+    function rename(id, label){ rows = rows.map(r => r.id === id ? {...r, label} : r) }
+    function add(){ rows = [...rows, {id:4,label:"d"}] }
+    function removeRow(id){ rows = rows.filter(r => r.id !== id) }
+    function reorder(){ rows = [rows[2], rows[0], rows[1]] }

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/expected.after.html
@@ -1,0 +1,1 @@
+<div><table><tbody><tr><td class="cell">c</td><td><button class="del">x</button></td></tr></tbody></table></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/expected.html
@@ -1,0 +1,1 @@
+<div><table><tbody><tr><td class="cell">a</td><td><button class="del">x</button></td></tr><tr><td class="cell">b</td><td><button class="del">x</button></td></tr><tr><td class="cell">c</td><td><button class="del">x</button></td></tr></tbody></table></div>

--- a/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/for/table_tbody_keyed/steps.mjs
@@ -1,0 +1,10 @@
+export default async ({ $$, click, equal }) => {
+  const L = () => $$("td.cell").map(n => n.innerHTMLString()).join(",");
+  // initial render already asserted via expected.html
+  equal(L(), "a,b,c");
+  // structural change: remove the middle row via its own button
+  await click($$("button.del")[1]);
+  equal(L(), "a,c");
+  await click($$("button.del")[0]);
+  equal(L(), "c");
+};

--- a/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/App.lunas
+++ b/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/App.lunas
@@ -1,0 +1,5 @@
+html:
+    <div><button class="tog" @click="toggle()">t</button><table><tbody><tr class="r1"><td>always</td></tr><tr :if="show" class="r2"><td class="opt">optional</td></tr></tbody></table></div>
+script:
+    let show = false
+    function toggle(){ show = !show }

--- a/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/expected.after.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/expected.after.html
@@ -1,0 +1,1 @@
+<div><div><button class="tog">t</button><table><tbody><tr class="r1"><td>always</td></tr></tbody></table></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/expected.html
+++ b/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/expected.html
@@ -1,0 +1,1 @@
+<div><div><button class="tog">t</button><table><tbody><tr class="r1"><td>always</td></tr></tbody></table></div></div>

--- a/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/steps.mjs
+++ b/crates/lunas_compiler/tests/runtime/samples/if/table_row_toggle/steps.mjs
@@ -1,0 +1,8 @@
+export default async ({ $$, click, expect }) => {
+  expect("td.opt").count(0);
+  await click($$("button.tog")[0]);
+  expect("td.opt").count(1);
+  expect("td.opt").text("optional");
+  await click($$("button.tog")[0]);
+  expect("td.opt").count(0);
+};

--- a/packages/lunas/src/blocks.mjs
+++ b/packages/lunas/src/blocks.mjs
@@ -22,6 +22,7 @@ import {
   addDisposer,
 } from "./core.mjs";
 import { createForState, seedForState, reconcile, extractKeys } from "./for_diff.mjs";
+import { parseFragment } from "./dom.mjs";
 import { isLive, runMount, runDestroy, onDestroy } from "./lifecycle.mjs";
 
 const toNodes = (h) => (Array.isArray(h) ? h : [h]);
@@ -184,8 +185,10 @@ export function forBlock(c, anchor, deps, items, opts) {
 
   // Build one item in compiled mode: parse its own skeleton copy, wire it.
   const buildOne = (d, i) => {
-    const scr = anchor.ownerDocument.createElement("div");
-    scr.innerHTML = opts.html;
+    // Parse through parseFragment (a <template>) so a table-context item
+    // skeleton (`<tr>`, `<td>`, …) survives — a plain <div> parse would drop it
+    // and `childNodes[0]` would be undefined (the table-context crash).
+    const scr = parseFragment(opts.html, anchor.ownerDocument);
     const root = scr.childNodes[0];
     const p = opts.wire(root, d, i);
     if (p) patches.set(root, p);
@@ -256,10 +259,11 @@ export function forBlock(c, anchor, deps, items, opts) {
     const arr = readItems();
     const n = arr.length;
     if (n > 0) {
-      const scr = anchor.ownerDocument.createElement("div");
       let html = "";
       for (let i = 0; i < n; i++) html += opts.html;
-      scr.innerHTML = html;
+      // Parse through parseFragment (a <template>) so table-context item
+      // skeletons (`<tr>`, …) survive the bulk parse instead of being dropped.
+      const scr = parseFragment(html, anchor.ownerDocument);
       // Snapshot roots before moving anything (childNodes is live).
       const nodes = new Array(n);
       for (let i = 0; i < n; i++) nodes[i] = scr.childNodes[i];

--- a/packages/lunas/src/dom.mjs
+++ b/packages/lunas/src/dom.mjs
@@ -48,8 +48,11 @@ export const on = (el, ev, fn) => el.addEventListener(ev, fn);
 // against the whole child list.
 export function fragment(attrs, HTML, setup) {
   return (props) => {
-    const host = document.createElement("div"); // throwaway wiring host
-    host.innerHTML = HTML; // ★ one native parse, detached
+    // ★ one native parse, detached. Parse through a <template> (via
+    // parseFragment) so a multi-root fragment whose top-level nodes are
+    // table-context elements (`<tr>`, `<td>`, …) survives instead of being
+    // dropped by a <div> parse context.
+    const host = parseFragment(HTML, document);
     const c = createContext(host); // `c.root` = host: positional refs navigate it
     // Wire while the nodes are still attached to the host, so refs(c.root, …)
     // captured in setup resolve against the parsed tree (like a single-root
@@ -67,19 +70,51 @@ export function fragment(attrs, HTML, setup) {
   };
 }
 
+// parseFragment(html, doc) — parse a bulk skeleton string into a detached
+// container and return that container. The caller reads the parsed roots off
+// the container's `.childNodes` (`childNodes[0]` for a single root, or
+// `Array.from(childNodes)` for a multi-root group), so the container's identity
+// never escapes.
+//
+// A `<template>` element is used rather than a throwaway `<div>`: a
+// `<template>`'s `.content` fragment accepts ANY element — including
+// table-context elements (`<tr>`, `<td>`, `<tbody>`, `<thead>`, `<col>`,
+// `<colgroup>`) and `<option>` — which the HTML parser would otherwise DROP when
+// assigned as the innerHTML of a `<div>` (a `<div>` is not a valid table/select
+// insertion context). Without this, a `:for`/`:if` item whose skeleton is a
+// `<tr>` parses to an empty `<div>` and `childNodes[0]` is `undefined`, crashing
+// on `.childNodes` reads (the table-context bug). `<template>.content` is a
+// DocumentFragment, and `.childNodes` on it is the same list the caller expects.
+//
+// Falls back to a `<div>` when `<template>` / `.content` is unavailable (e.g. a
+// minimal test DOM without template support) so parsing of non-table skeletons
+// keeps working everywhere.
+export function parseFragment(html, doc) {
+  if (typeof doc.createElement === "function") {
+    const t = doc.createElement("template");
+    // `.content` exists only on a real (or shim-supported) <template>.
+    if (t && t.content) {
+      t.innerHTML = html;
+      return t.content;
+    }
+  }
+  const el = doc.createElement("div");
+  el.innerHTML = html;
+  return el;
+}
+
 // fromHTML(html, near) — parse a static block skeleton (an :if branch, a :for
-// item, …) into a detached scratch element via one bulk innerHTML, exactly like
-// the component root build (§8: branches are built by their own innerHTML when
-// shown). `near` is any node used to reach the owner document, so blocks built
-// inside a detached component still resolve a document (and tests can pass a
-// fake-DOM node).
+// item, …) into a detached container via one bulk parse, exactly like the
+// component root build (§8: branches are built by their own parse when shown).
+// `near` is any node used to reach the owner document, so blocks built inside a
+// detached component still resolve a document (and tests can pass a fake-DOM
+// node). Table-context skeletons (`<tr>`, `<td>`, …) survive because the parse
+// goes through a `<template>` — see parseFragment.
 export function fromHTML(html, near) {
   const doc =
     (near && near.ownerDocument) ||
     (typeof document !== "undefined" ? document : null);
-  const el = doc.createElement("div");
-  el.innerHTML = html;
-  return el;
+  return parseFragment(html, doc);
 }
 
 // --- anchors -----------------------------------------------------------------

--- a/packages/lunas/test/dom-shim.mjs
+++ b/packages/lunas/test/dom-shim.mjs
@@ -133,9 +133,15 @@ class FakeNode {
     this._props.disabled = v;
   }
   set innerHTML(html) {
-    this.childNodes.length = 0;
-    for (const n of parseHTML(html, this.ownerDocument)) {
-      this.appendChild(n);
+    // A <template> parses into its `.content` DocumentFragment, mirroring the
+    // real DOM: `template.innerHTML = …` populates `template.content`, and the
+    // <template> element itself has no direct children. This is what lets the
+    // runtime's parseFragment survive table-context skeletons (<tr>, <td>, …)
+    // which a plain element parse would drop.
+    const target = this.tag === "template" && this.content ? this.content : this;
+    target.childNodes.length = 0;
+    for (const n of parseHTML(html, target.ownerDocument, target.tag)) {
+      target.appendChild(n);
     }
   }
   get innerHTML() {
@@ -175,11 +181,46 @@ const VOID = new Set([
   "param", "source", "track", "wbr",
 ]);
 
-// Tiny recursive-descent parser for the skeleton subset.
-function parseHTML(html, doc) {
+// Table-context elements: the HTML parser only produces these inside a valid
+// table insertion context. A real browser DROPS a `<tr>`/`<td>`/`<tbody>`/…
+// parsed as the innerHTML of a non-table container (e.g. a `<div>`), which is
+// the table-context bug the runtime's <template> fix addresses. The shim models
+// that drop so a `<div>`-context parse of table content matches the browser and
+// the buggy path fails loudly (the fix routes through a <template>, whose
+// content fragment is a valid insertion context and keeps these elements).
+//
+// Maps a table-only tag to the set of parent tags it may legally appear under.
+// A `<template>` content fragment (and the top-level `null` document context)
+// is treated as permissive — the browser's template content is a valid parse
+// context for any table-context element.
+const TABLE_CONTEXT = {
+  tr: new Set(["tbody", "thead", "tfoot", "table"]),
+  td: new Set(["tr"]),
+  th: new Set(["tr"]),
+  tbody: new Set(["table"]),
+  thead: new Set(["table"]),
+  tfoot: new Set(["table"]),
+  caption: new Set(["table"]),
+  colgroup: new Set(["table"]),
+  col: new Set(["colgroup", "table"]),
+};
+
+// Tiny recursive-descent parser for the skeleton subset. `containerTag` is the
+// tag of the element whose innerHTML is being set (undefined/`"template"`/`null`
+// = permissive context where any element survives, matching a <template>'s
+// content fragment and document-level parsing in this shim).
+function parseHTML(html, doc, containerTag) {
   let i = 0;
   const roots = [];
   const stack = [];
+  const permissive =
+    containerTag === undefined ||
+    containerTag === null ||
+    containerTag === "template";
+  // The current parse context tag: the innermost open element, or (at the top
+  // level) `null` when permissive (<template>/document) else the container tag.
+  const contextTag = () =>
+    stack.length ? stack[stack.length - 1].tag : permissive ? null : containerTag;
   const push = (node) => {
     if (stack.length) stack[stack.length - 1].appendChild(node);
     else roots.push(node);
@@ -195,6 +236,15 @@ function parseHTML(html, doc) {
         const end = html.indexOf(">", i);
         const raw = html.slice(i + 1, end);
         const { tag, attrs } = parseTag(raw);
+        // Drop a table-context element whose parent context can't legally hold
+        // it (browser parity). `null` context (permissive top level) allows it.
+        const allowed = TABLE_CONTEXT[tag];
+        const ctx = contextTag();
+        if (allowed && ctx !== null && !allowed.has(ctx)) {
+          // Skip this element AND its subtree: advance past the whole element.
+          i = skipElement(html, i, tag);
+          continue;
+        }
         const el = doc.createElement(tag);
         for (const [k, v] of attrs) el.setAttribute(k, v);
         push(el);
@@ -210,6 +260,32 @@ function parseHTML(html, doc) {
     }
   }
   return roots;
+}
+
+// skipElement(html, start, tag) — advance the parse index past a whole element
+// (its open tag, subtree, and matching close tag) starting at `start` (the `<`
+// of the open tag). Used to drop a mis-nested table-context element and its
+// content, approximating the browser dropping table tags parsed out of context.
+// Void elements have no close tag. Handles simple nesting of the same tag.
+function skipElement(html, start, tag) {
+  const openEnd = html.indexOf(">", start);
+  let i = openEnd + 1;
+  if (VOID.has(tag)) return i;
+  let depth = 1;
+  const openRe = new RegExp("<" + tag + "(?:[\\s/>])", "i");
+  const closeStr = "</" + tag;
+  while (i < html.length && depth > 0) {
+    const nextClose = html.toLowerCase().indexOf(closeStr, i);
+    if (nextClose === -1) return html.length;
+    // Count same-tag opens between i and nextClose to balance nesting.
+    const between = html.slice(i, nextClose);
+    let m;
+    const re = new RegExp("<" + tag + "(?:[\\s/>])", "gi");
+    while ((m = re.exec(between))) depth++;
+    depth--; // consume this close
+    i = html.indexOf(">", nextClose) + 1;
+  }
+  return i;
 }
 
 function parseTag(raw) {
@@ -256,7 +332,22 @@ export function installDom() {
     createElement(tag) {
       const n = new FakeNode(doc, "element", "");
       n.tag = tag;
+      // A <template> owns a `.content` DocumentFragment (kind "fragment"),
+      // mirroring the real DOM. Its innerHTML setter populates `.content`, and
+      // that fragment is a permissive parse context (table-context elements
+      // survive) — see FakeNode.innerHTML and parseHTML. The fragment carries a
+      // `null` tag so it reads as the permissive top-level parse context.
+      if (tag === "template") {
+        const frag = new FakeNode(doc, "fragment", "");
+        frag.tag = null;
+        n.content = frag;
+      }
       return n;
+    },
+    createDocumentFragment() {
+      const frag = new FakeNode(doc, "fragment", "");
+      frag.tag = null;
+      return frag;
     },
     // A document-level root so teleport targets attached here are reachable via
     // document.querySelector. Tests append their portal container to `body`.

--- a/packages/lunas/test/dom.table-context.test.mjs
+++ b/packages/lunas/test/dom.table-context.test.mjs
@@ -1,0 +1,97 @@
+// dom.table-context.test.mjs — the table-context fragment-parsing fix.
+//
+// A `:for` item / `:if` branch / fragment whose skeleton is a table-context
+// element (`<tr>`, `<td>`, `<tbody>`, `<option>`, …) must survive being parsed
+// as a detached fragment. Parsing such HTML as the innerHTML of a `<div>` makes
+// a real browser DROP the table tags (a `<div>` is not a valid table insertion
+// context), so the parsed container is empty and `childNodes[0]` is undefined —
+// the crash this fix addresses. parseFragment / fromHTML now parse through a
+// `<template>`, whose content fragment is a valid insertion context for any
+// element, so the row survives.
+//
+// The dom-shim models the browser's drop: a `<div>`-context parse of `<tr>`
+// drops it, a `<template>`-context parse keeps it. These tests assert both the
+// shim's fidelity (a plain `<div>` parse drops table tags) and the runtime fix
+// (parseFragment/fromHTML/forBlock keep them).
+// Run: node packages/lunas/test/dom.table-context.test.mjs
+
+import assert from "node:assert";
+import { installDom } from "./dom-shim.mjs";
+import { parseFragment, fromHTML } from "../src/dom.mjs";
+
+installDom();
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log("  ok  " + name);
+}
+
+// --- shim fidelity: a <div> parse drops table-context elements ---------------
+
+await test("shim: <tr> assigned as <div> innerHTML is dropped (browser parity)", () => {
+  const div = document.createElement("div");
+  div.innerHTML = "<tr><td>x</td></tr>";
+  // Real browser drops the row (and its subtree) -> empty container.
+  assert.strictEqual(div.childNodes.length, 0);
+  assert.strictEqual(div.childNodes[0], undefined);
+});
+
+await test("shim: <tr> is kept inside a valid table context", () => {
+  const table = document.createElement("table");
+  table.innerHTML = "<tbody><tr><td>x</td></tr></tbody>";
+  const tbody = table.childNodes[0];
+  assert.strictEqual(tbody.tag, "tbody");
+  assert.strictEqual(tbody.childNodes[0].tag, "tr");
+});
+
+// --- shim: <template> content is a permissive parse context ------------------
+
+await test("shim: <template>.content keeps a bare <tr>", () => {
+  const t = document.createElement("template");
+  assert.ok(t.content, "template exposes .content");
+  t.innerHTML = "<tr><td>x</td></tr>";
+  // The <template> element itself stays empty; content holds the row.
+  assert.strictEqual(t.childNodes.length, 0);
+  assert.strictEqual(t.content.childNodes[0].tag, "tr");
+  assert.strictEqual(t.content.childNodes[0].childNodes[0].tag, "td");
+});
+
+// --- the fix: parseFragment / fromHTML keep table-context content ------------
+
+await test("parseFragment: bare <tr> skeleton survives -> childNodes[0] is the row", () => {
+  const scr = parseFragment("<tr><td class=\"c\">a</td></tr>", document);
+  const root = scr.childNodes[0];
+  assert.ok(root, "root is defined (no table-context drop)");
+  assert.strictEqual(root.tag, "tr");
+  assert.strictEqual(root.childNodes[0].tag, "td");
+  assert.strictEqual(root.childNodes[0].getAttribute("class"), "c");
+});
+
+await test("parseFragment: bulk (multi-row) skeleton keeps every row", () => {
+  const scr = parseFragment("<tr><td>a</td></tr><tr><td>b</td></tr>", document);
+  assert.strictEqual(scr.childNodes.length, 2);
+  assert.strictEqual(scr.childNodes[0].tag, "tr");
+  assert.strictEqual(scr.childNodes[1].tag, "tr");
+});
+
+await test("parseFragment: <option> (select context) survives too", () => {
+  const scr = parseFragment("<option value=\"1\">one</option>", document);
+  assert.strictEqual(scr.childNodes[0].tag, "option");
+  assert.strictEqual(scr.childNodes[0].getAttribute("value"), "1");
+});
+
+await test("fromHTML: table-context branch skeleton survives (:if / :for path)", () => {
+  const near = document.createElement("table");
+  const scr = fromHTML("<tr><td>x</td></tr>", near);
+  assert.strictEqual(scr.childNodes[0].tag, "tr");
+});
+
+await test("parseFragment: non-table skeleton still parses normally", () => {
+  const scr = parseFragment("<li><span>a</span></li>", document);
+  assert.strictEqual(scr.childNodes[0].tag, "li");
+  assert.strictEqual(scr.childNodes[0].childNodes[0].tag, "span");
+});
+
+console.log("dom.table-context.test.mjs: all " + passed + " tests passed");


### PR DESCRIPTION
## Problem

A keyed `:for` list whose item is a `<tr>` inside `<table><tbody>` **crashed on initial construction** with:

```
TypeError: Cannot read properties of undefined (reading 'childNodes')
```

The same latent bug affected `:if`/`ifChain` branches and multi-root `fragment(...)` components whose content is table-context (`<tr>`/`<td>`/`<tbody>`/`<thead>`/`<col>`/…) or `<option>`. It works fine in a `<div>` structure, which is why it went unnoticed.

## Root cause

Every detached fragment parse the runtime does built the nodes by assigning the skeleton HTML as the `innerHTML` of a throwaway `<div>`, then reading `scr.childNodes[0]`:

- `blocks.mjs` `forBlock` — bulk initial render **and** per-item `buildOne`
- `dom.mjs` `fromHTML` — `:if`/`ifChain`/`ifBlock` branch building
- `dom.mjs` `fragment` — multi-root component building

A `<div>` is **not a valid table/select insertion context**, so the HTML parser **drops** the table/select tags. The container is then empty, `childNodes[0]` is `undefined`, and the compiled `refs(root, …)` immediately reads `.childNodes` off `undefined` → crash.

## Fix

Parse fragment HTML through a **`<template>`** element instead of a `<div>`. A `<template>`'s `.content` fragment is a valid insertion context for **any** element, so table/select content survives. A shared `parseFragment(html, doc)` helper (dom.mjs) implements this and falls back to a `<div>` only when `<template>`/`.content` is unavailable. All four parse sites above route through it. Node identity / anchor / positional-ref logic is unchanged (the `.childNodes[0]` / `Array.from(.childNodes)` contract holds — a `DocumentFragment` exposes `childNodes` identically).

**No codegen change was needed.** The component root build is unaffected (its static skeleton is the `innerHTML` of the `div` wrapper — a valid context for table markup), and the emitted item/branch skeletons already contain the correct `<tr>` HTML. Verified empirically: the runtime `<template>` fix fully resolves it.

## Tests

- **dom-shim** now (a) models the browser's table-context drop — a `<div>`-context parse of `<tr>` drops it — so the buggy path fails loudly, and (b) supports `<template>`/`.content`. New `packages/lunas/test/dom.table-context.test.mjs` (8 cases) locks the shim fidelity + the `parseFragment`/`fromHTML` fix.
- New runtime samples: `for/table_tbody_keyed` (initial + structural remove), `for/table_tbody_field_update`, `for/select_option_keyed`, `if/table_row_toggle` (an `:if` `<tr>` branch through `fromHTML`).
- New `codegen_exec` test mounting a table keyed-`:for`, asserting initial rows and structural removals.

## Gates (all green)

- `cargo test --workspace` — pass (runtime samples now **1066**, codegen_exec **35**)
- `node packages/lunas/test/run-all.mjs` — **39** files pass
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean

The fine-grained `:for` update path (recently merged) is untouched and still green.

`crates/lunas_compiler/docs/output-design.md` documents the `<template>` fragment-parse contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)