### PR TITLE
perf(runtime): fix super-linear :for swap (idempotent deepBox proxy wrap)

### DIFF
--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -146,8 +146,15 @@ export function makeWrap(notify, fine) {
 
   const handler = {
     get(t, k, r) {
+      // `proxy[RAW]` unwraps to the raw target in every mode. This is also what
+      // keeps `wrap` idempotent: a value that is already one of our proxies is
+      // detected via its RAW marker and returned as-is instead of being wrapped
+      // again. Without this, code that reads elements out through the proxy and
+      // stores them back (e.g. a `:for` swap doing `r = arr.slice(); arr = r`)
+      // would grow a fresh proxy layer on every update — an O(depth) read cost
+      // that compounds into super-linear churn.
+      if (k === RAW) return t;
       if (fine && fine.active) {
-        if (k === RAW) return t;
         const val = Reflect.get(t, k, r);
         if (val === null || typeof val !== "object") return val;
         if (roots.has(t)) {
@@ -197,6 +204,7 @@ export function makeWrap(notify, fine) {
   // slots accept the receiver; wrap mutators to notify after the op.
   const collectionHandler = {
     get(t, k) {
+      if (k === RAW) return t; // keep wrap idempotent for collection proxies too
       const val = Reflect.get(t, k, t);
       if (typeof val !== "function") return val;
       if (MUTATORS.has(k) && MUTATORS.get(k)(t)) {
@@ -213,6 +221,13 @@ export function makeWrap(notify, fine) {
   };
   const wrap = (val) => {
     if (val === null || typeof val !== "object") return val;
+    // Idempotence: if `val` is already one of OUR proxies, `val[RAW]` returns
+    // its raw target (the get trap intercepts RAW). Re-wrapping would stack a
+    // new proxy layer every time, so wrap the underlying raw object instead —
+    // it's already cached under that key, so this collapses back to the
+    // canonical single-layer proxy for the object.
+    const raw = val[RAW];
+    if (raw !== undefined) val = raw;
     let px = cache.get(val);
     if (!px) {
       px = new Proxy(val, isCollection(val) ? collectionHandler : handler);

--- a/packages/lunas/test/boxes.deep.test.mjs
+++ b/packages/lunas/test/boxes.deep.test.mjs
@@ -6,7 +6,7 @@
 
 import assert from "node:assert";
 import { createContext, bind } from "../src/core.mjs";
-import { box, deepBox, shared } from "../src/boxes.mjs";
+import { box, deepBox, shared, RAW } from "../src/boxes.mjs";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -321,6 +321,64 @@ await test("deepBox: Map accessors/methods work through the collection-aware han
   assert.strictEqual(d.v.get("a"), 1, ".get returns the entry");
   assert.strictEqual(d.v.has("a"), true, ".has works");
   assert.strictEqual(d.v.has("z"), false);
+});
+
+// ---------------------------------------------------------------------------
+// wrap idempotence: reading elements out through the proxy and storing them
+// back (the keyed `:for` swap: r = arr.slice(); reorder; arr = r) must NOT
+// stack a new proxy layer per update. Without idempotence this compounded into
+// super-linear read cost. Guard: RAW always unwraps one layer to the SAME raw
+// object no matter how many read/store cycles happened, and element proxy
+// identity stays stable across cycles.
+// ---------------------------------------------------------------------------
+await test("deepBox: proxy wrap is idempotent across read-and-store cycles (no proxy stacking)", async () => {
+  const c = createContext(null);
+  const raw0 = { id: 1 };
+  const d = deepBox(c, 0, [raw0, { id: 2 }, { id: 3 }]);
+  d.observeElems(); // fine mode — the path that used to stack proxies
+
+  // First read: element proxy over the raw object. RAW unwraps to the raw
+  // object (a plain object, which has no RAW of its own).
+  const e1 = d.v[0];
+  assert.strictEqual(e1[RAW], raw0, "element proxy unwraps to its raw object");
+  assert.strictEqual(e1[RAW][RAW], undefined, "the unwrapped raw object is not itself a proxy");
+
+  // Simulate several swap cycles: slice (holds element proxies), reorder,
+  // reassign the whole value back through .v.
+  for (let cycle = 0; cycle < 5; cycle++) {
+    const r = d.v.slice();
+    const t = r[0];
+    r[0] = r[2];
+    r[2] = t;
+    d.v = r; // store an array whose elements are proxies
+  }
+
+  // After 5 cycles the element for raw0 must still unwrap to raw0 in ONE step —
+  // no accumulated proxy layers.
+  const eAfter = d.v.slice().find((e) => e[RAW] === raw0);
+  assert.ok(eAfter, "raw0's element survives the reorder cycles");
+  assert.strictEqual(eAfter[RAW], raw0, "still unwraps to the same raw object in one step");
+  assert.strictEqual(eAfter[RAW][RAW], undefined, "unwrapped value is the raw object, not a stacked proxy");
+  // Element proxy identity is stable (cached), so reads are cheap and consistent.
+  assert.strictEqual(d.v.find((e) => e[RAW] === raw0), eAfter, "element proxy identity is stable");
+});
+
+// A field write through a stored element proxy still marks the box (fine mode),
+// proving idempotent unwrapping did not break write attribution.
+await test("deepBox: field write through a re-stored element proxy still triggers reactivity", async () => {
+  const c = createContext(null);
+  const d = deepBox(c, 0, [{ id: 1, label: "a" }, { id: 2, label: "b" }]);
+  d.observeElems();
+  let runs = 0;
+  bind(c, [0], () => { void d.v.length; runs++; });
+  // A read-store cycle (like a swap) then a nested field write on a stored elem.
+  const r = d.v.slice();
+  d.v = r;
+  await tick();
+  const before = runs;
+  d.v[0].label = "changed"; // nested write through the (re-stored) element proxy
+  await tick();
+  assert.ok(runs > before, "nested field write on a re-stored element still flushes dependents");
 });
 
 console.log("boxes.deep.test.mjs: all " + passed + " tests passed");


### PR DESCRIPTION
## Problem

Profiling the js-framework-benchmark **swap** op on current `main` (60 iters, CDP sampler) showed **82% of self-time in the deepBox proxy `get` trap** (`boxes.mjs`), plus ~4% in `isCollection`. The keyed reconciler itself (`for_diff.mjs`), LIS, and `extractKeys` were all <0.3%.

Root cause: the fine-grained deepBox `get` trap wraps every object it returns, cached by the value passed in. The canonical keyed swap reads elements out through the proxy and stores them back:

```js
const r = rows.v.slice();   // slice() returns element *proxies*
const t = r[1]; r[1] = r[998]; r[998] = t;
rows.v = r;                 // stores an array whose elements are proxies
```

`slice()` yields the wrapped element proxies, so the array reassigned into the box holds proxies. On the next swap those proxies get wrapped **again** (cache keys are raw objects, so a proxy misses the cache and a new proxy-of-proxy is minted). Each update stacks another layer; reading `.id`/`.label` costs O(layers) and layers grow every swap → **super-linear** swap cost.

Isolated micro-repro (N=1000, per-batch avg): `1.5ms → 4.7 → 10.1 → 12.5 ms/iter` and climbing.

## Fix

Make `wrap` **idempotent**. `RAW` (the existing unwrap marker) is now intercepted in *every* mode and in the collection handler, so a value that is already one of our proxies is detected via `val[RAW]` and unwrapped to its raw target before wrapping — collapsing back to the single canonical proxy instead of nesting. Hot path gains one symbol-key comparison; no behavior change.

After: **flat ~0.11 ms/iter, no growth.**

Scope: only `packages/lunas/src/boxes.mjs`. `for_diff.mjs` and `blocks.mjs` untouched.

## Correctness

- `node packages/lunas/test/run-all.mjs` — all 38 files green
- `cargo test --workspace` — 0 failures (incl. the ~1000 runtime `:for/*` samples: add/remove/reorder/swap/dup-key)
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings` — clean

## Bench (this machine; hotter than the 2.15ms reference box — read the ratio)

Filled in on the PR after the before/after `bench-ops` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)