### PR TITLE
fix(ci): make browser_smoke opt-in to stop check-job Chrome flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,4 +202,8 @@ jobs:
         working-directory: crates
         env:
           CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+          # Opt-in: browser_smoke skips unless this is set, so a plain
+          # `cargo test --all` (e.g. the check job, which may pick up an
+          # unpinned/flaky Chrome) never runs it — only this pinned-Chrome job does.
+          LUNAS_BROWSER_SMOKE: "1"
         run: cargo test -p lunas_compiler --test browser_smoke -- --nocapture

--- a/crates/lunas_compiler/tests/browser_smoke.rs
+++ b/crates/lunas_compiler/tests/browser_smoke.rs
@@ -426,6 +426,21 @@ struct SmokeEnv {
 }
 
 fn preflight() -> Option<SmokeEnv> {
+    // Opt-in gate. The browser smoke layer is environment-sensitive: it drives a
+    // real headless Chrome via `--dump-dom`, which is unreliable on arbitrary
+    // Chrome/Chromium builds (some emit no serialized DOM). It is meant to run
+    // ONLY in the dedicated CI job that pins Chrome stable (which sets this env),
+    // NOT in a plain `cargo test --all` that would otherwise pick up whatever
+    // Chrome happens to be on PATH (e.g. the ubuntu runner's default in the
+    // `fmt · clippy · test` job) and flake. Without the env var we skip cleanly;
+    // the deterministic node integration layer already covers these scenarios.
+    if std::env::var_os("LUNAS_BROWSER_SMOKE").is_none() {
+        eprintln!(
+            "SKIP browser_smoke: set LUNAS_BROWSER_SMOKE=1 to run (only the dedicated \
+             pinned-Chrome CI job does; `cargo test --all` skips this layer)."
+        );
+        return None;
+    }
     let Some(node) = node_bin() else {
         eprintln!(
             "SKIP browser_smoke: no node found (pinned NVM path, LUNAS_NODE, or PATH `node`)."


### PR DESCRIPTION
## Problem
`browser_smoke` (real headless Chrome via `--dump-dom`) ran in **two** places: the dedicated smoke job (Chrome pinned to `stable` — correct) **and** the plain `cargo test --all` inside `fmt · clippy · test`, which picks up the ubuntu runner's **default** Chrome. That default Chrome sometimes emits an empty `--dump-dom`; `assert_done` skips on empty DOM, but the later per-test assertions still ran against the empty DOM and **panicked** — a flaky red unrelated to the change under test (it passed on `main` only because that run's Chrome happened to produce output). This just red-flagged PR #193 (an unrelated, correct perf fix).

## Fix
Gate the whole suite behind `LUNAS_BROWSER_SMOKE=1`, set **only** in the dedicated pinned-Chrome job. Effect:
- `cargo test --all` (check job + local dev) now **skips** the browser layer cleanly — no flaky double-run.
- The dedicated job (pinned stable Chrome + the env var) still runs the real-browser assertions.
- The deterministic node integration layer (dom-shim) already covers the same scenarios in the check job.

Verified locally: `cargo test --test browser_smoke` without the env → all 4 skip cleanly, no panic. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)