### PR TITLE
perf(reactivity): make deep reactivity proxy-free (drop the Proxy that was losing to Svelte)

### DIFF
--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -61,9 +61,9 @@ export default component("div", { class: "counter" }, HTML, (c, props) => {
   // Only mutated bindings are boxed. The compiler picks the box kind per var,
   // and gives each a reactive index (0, 1, …):
   const count   = box(c, 0, props.start ?? 0);  // index 0: reassigned only
-  const history = deepBox(c, 1, []);             // index 1: array .push() -> Proxy
+  const history = deepBox(c, 1, []);             // index 1: array .push() -> touch()
 
-  function inc() { count.v++; history.v.push(count.v); }
+  function inc() { count.v++; (history.touch(), history.v.push(count.v)); }
 
   // Positional nav to the dynamic elements (detached, no ids).
   const [btn, p, ul] = refs(c.root, [[0], [1], [2]]);
@@ -108,12 +108,42 @@ auto-tracking signals.
 
 | Var classification (from analysis) | Box | Cost |
 |---|---|---|
-| Reassigned only (`x = …`) | `box` — plain getter/setter that sets the bit | lightest, no Proxy |
-| Deeply mutated (`arr.push`, `obj.k = …`) | `deepBox` — Proxy that sets the bit on mutation | Proxy only where needed |
+| Reassigned only (`x = …`) | `box` — plain getter/setter that sets the bit | lightest |
+| Deeply mutated (`arr.push`, `obj.k = …`) | `deepBox` — raw value + compiler-injected `touch()`/`touchElem()` invalidation | no Proxy; a deep mutation costs one bit-set, same as a reassign |
 | Shared across components (passed as prop and mutated) | `shared` — sets the dirty bit in *every* dependent component | cross-component without signals |
 
 This resolves the classic weaknesses of pure static wiring (deep mutation,
 cross-component flow) **at compile time**, avoiding a runtime hybrid.
+
+#### Deep mutation is compiler-instrumented, not Proxy-intercepted
+
+`deepBox.v` returns the **raw** value — reads are as cheap as a plain `box`, and
+the reconciler hot path reads it directly. A deep mutation is made reactive by an
+explicit invalidation the compiler emits right after the mutating statement (the
+Svelte-family model), never a runtime Proxy:
+
+```
+arr.push(x)        ->  (arr.touch(), arr.v.push(x))
+obj.k = v          ->  (obj.touch(), obj.v.k = v)
+rows[i].label = x  ->  (rows.touchElem(rows.v[i]), rows.v[i].label = x)
+```
+
+`touch()` marks the variable dirty (structural change); `touchElem(el)` marks it
+and records the mutated array element so a `:for` can patch just that item
+(fine-grained item updates) without a Proxy attributing the write. `markVar`
+defers the flush to a microtask, so it is irrelevant that the injected call runs
+before the mutation completes within the statement. The compiler finds mutation
+sites over the real AST (`lunas_script::deep_mutation_sites`); element-field
+attribution is used only for the side-effect-free `X[idx].field` shape, and a
+plain structural `touch()` is the always-correct fallback for everything else.
+
+Why not a Proxy: a Proxy makes every nested get/set a trap dispatch plus (for
+`:for` element attribution) WeakMap bookkeeping, which measured **~10× the cost
+of a raw write** on the deep-mutation hot path (`js-framework-benchmark`'s
+"partial update" / "swap" rows) — precisely where a Proxy-based Lunas gave up its
+structural lead to Svelte, which compiles mutations to direct writes. Removing it
+roughly **halves** the wall-clock of those operations while keeping identical
+semantics.
 
 ### Dispatch representation (no BigInt)
 
@@ -132,10 +162,12 @@ a `Uint32Array` of 32-bit chunks — **never `BigInt`**.
 
 `BigInt` is rejected on two grounds: it is markedly slower than `number`
 (heap-allocated, non-primitive) **and** it is the least compatible option (ES2020
-/ Safari 14+, no efficient polyfill). Lunas's compatibility floor is set by
-`Proxy` (ES2015 / Safari 10+, used by `deepBox` for deep mutation) — the same
-floor as Vue 3 / Svelte 5 / Solid. Adjacency, `number`, and `Uint32Array` all
-stay at or below that floor; `BigInt` would raise it above the competition.
+/ Safari 14+, no efficient polyfill). With deep mutation now compiler-instrumented
+(above), the runtime uses **no `Proxy`** either, so the reactive core is plain
+ES2015 (`getter`/`setter`, arrays, `Map`/`Set`) — its floor is below Vue 3 /
+Svelte 5 / Solid, which all rely on `Proxy`. Adjacency, `number`, and
+`Uint32Array` all stay at or below that floor; `BigInt` would raise it above the
+competition.
 
 `handlers[].writes` is used at compile time for validation / dead-code
 elimination; at runtime the box setter already enqueues dependents, so the write
@@ -167,7 +199,7 @@ function flush(c) {
 export function box(c, i, v) {               // reassign-only var at reactive index i
   return { get v() { return v; }, set v(x) { if (x !== v) { v = x; markVar(c, i); } } };
 }
-export function deepBox(c, i, v) { /* Proxy wrapping arrays/objects; markVar(c,i) on mutation */ }
+export function deepBox(c, i, v) { /* raw value; touch()/touchElem(el) -> markVar(c,i), compiler-injected */ }
 export function prop(c, name, i, raw, def, deep) { /* adopt an @input prop as a reactive box at index
                                                       i; seed from raw (getter or value) or def;
                                                       register under c._props[name] for the parent's
@@ -262,9 +294,9 @@ export function teleportBlock(c, before, targetOf, build) { /* `<teleport to>` �
 // --- module-level stores (state outside any component; §4's "shared" concept
 //     generalized to N components importing the same module, instead of one
 //     value passed down as a prop) ---
-export function createStore(initial) { /* named fields, each its own subs list + deep-mutation
-                                           proxy (reuses boxes.mjs's Proxy handler); returns
-                                           { get(key), set(key,v), subscribe(key,fn) } */ }
+export function createStore(initial) { /* named fields, each its own subs list; deep mutation via
+                                           compiler-injected store.touch(key) (no Proxy); returns
+                                           { get(key), set(key,v), touch(key), subscribe(key,fn) } */ }
 export function useStore(c, i, store, key) { /* adopt field `key` at c's reactive index i;
                                                  writes to `key` markVar(c,i), batched as usual;
                                                  scope-aware: dropScope tears the adoption down */ }

--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -150,20 +150,26 @@ mutations over the AST (`lunas_script::deep_mutation_sites`): direct member/inde
 writes (`x.k = v`, `x[i] = v`, `x[i].f = v`, `x.f++`, `delete x.k`), mutating
 method calls (`push`/`splice`/`sort`/… and Map/Set `set`/`add`/`delete`/`clear`),
 destructuring targets (`[x[0], x[1]] = …`), `Object.assign`/`defineProperty` on a
-tracked value, and an iteration-callback that mutates elements
-(`x.forEach(e => e.f = …)`, `x.map(e => (e.n = …, e))`) — the last recovered by a
-conservative structural `touch()` when the callback body actually contains a
-mutation, so a pure `filter`/`map` never over-notifies. **Known limitation
-(Svelte-family):** a mutation reached *only* through a cross-function alias —
-passing the value to a helper that mutates a differently-named parameter — is not
-auto-instrumented; reassign the value or call `box.touch()` to make it reactive.
+tracked value, and an iteration-callback that mutates its **element parameter**
+(`x.forEach(e => e.f = …)`, `x.map(e => (e.n = …, e))`, `x.forEach(e =>
+Object.assign(e, …))`). The iteration case is scoped to writes on the element
+binding specifically: a callback-local accumulator (`x.forEach(e => { total +=
+e.n })`, `x.some(e => { found = true })`) is *not* a mutation of `x`, so a pure or
+folding `map`/`filter`/`some`/`reduce` — the shape of an ordinary computed — never
+gets a spurious `touch()`. **Known limitation (Svelte-family):** a mutation
+reached *only* through an alias the syntax can't follow — a cross-function helper
+that mutates a differently-named parameter, or an element captured under a local
+name — is not auto-instrumented; reassign the value or call `box.touch()`.
 
 **Runaway-loop guard.** Because `touch()` is unconditional (no `old === new`
 short-circuit — the compiler cannot cheaply prove a write was a no-op), a reactive
 effect that mutates a dependency it reads no longer self-limits at value
-convergence. The flush loop therefore bounds consecutive self-triggered passes
-(`MAX_FLUSH_DEPTH`, aborting with a dev warning) — the same safeguard Vue applies
-— so such an effect degrades to a bounded stop instead of hanging the page.
+convergence. The flush loop therefore bounds how many times a **single effect**
+may re-run within one flush burst (`MAX_FLUSH_DEPTH`), counted per effect so a
+long legitimate cascade of *distinct* effects is never falsely aborted. On abort
+it clears the queued records' dirty flags and any pending post-callbacks so the
+loop stops cleanly without wedging innocent effects that shared the burst — the
+same class of safeguard Vue applies (its "Maximum recursive updates" limit).
 
 ### Dispatch representation (no BigInt)
 

--- a/crates/lunas_compiler/docs/output-design.md
+++ b/crates/lunas_compiler/docs/output-design.md
@@ -145,6 +145,26 @@ structural lead to Svelte, which compiles mutations to direct writes. Removing i
 roughly **halves** the wall-clock of those operations while keeping identical
 semantics.
 
+**Which mutation forms are instrumented.** The compiler recognizes deep
+mutations over the AST (`lunas_script::deep_mutation_sites`): direct member/index
+writes (`x.k = v`, `x[i] = v`, `x[i].f = v`, `x.f++`, `delete x.k`), mutating
+method calls (`push`/`splice`/`sort`/… and Map/Set `set`/`add`/`delete`/`clear`),
+destructuring targets (`[x[0], x[1]] = …`), `Object.assign`/`defineProperty` on a
+tracked value, and an iteration-callback that mutates elements
+(`x.forEach(e => e.f = …)`, `x.map(e => (e.n = …, e))`) — the last recovered by a
+conservative structural `touch()` when the callback body actually contains a
+mutation, so a pure `filter`/`map` never over-notifies. **Known limitation
+(Svelte-family):** a mutation reached *only* through a cross-function alias —
+passing the value to a helper that mutates a differently-named parameter — is not
+auto-instrumented; reassign the value or call `box.touch()` to make it reactive.
+
+**Runaway-loop guard.** Because `touch()` is unconditional (no `old === new`
+short-circuit — the compiler cannot cheaply prove a write was a no-op), a reactive
+effect that mutates a dependency it reads no longer self-limits at value
+convergence. The flush loop therefore bounds consecutive self-triggered passes
+(`MAX_FLUSH_DEPTH`, aborting with a dev warning) — the same safeguard Vue applies
+— so such an effect degrades to a bounded stop instead of hanging the page.
+
 ### Dispatch representation (no BigInt)
 
 The graph is stored as **adjacency** by default: each reactive variable holds the

--- a/crates/lunas_compiler/src/codegen/emit.rs
+++ b/crates/lunas_compiler/src/codegen/emit.rs
@@ -1033,10 +1033,13 @@ impl<'a> Emitter<'a> {
                     // The handler body is `.v`-rewritten like an element handler;
                     // `$event` is the payload parameter. Names camel-case:
                     // `save-all` → `onSaveAll`.
+                    let deep_targets =
+                        deep_var_names(&self.deep_hint, &self.component.reactive_vars);
                     let body = rewrite_handler(
                         &handler.text,
                         &self.component.reactive_vars,
                         frag.shadowed,
+                        &deep_targets,
                     );
                     let key = event_prop_name(event);
                     members.push(format!("{}: ($event) => {{ {body}; }}", prop_key(&key)));
@@ -2450,7 +2453,13 @@ impl<'a> Emitter<'a> {
         // assignments (`n = n + 1`, `count++`, `a++; b++`, `obj.k = v`) compile
         // to the `.v` box-setter path so the write marks the var and the DOM
         // updates. Function-call handlers (`inc()`) are unaffected.
-        let body = rewrite_handler(handler, &self.component.reactive_vars, frag.shadowed);
+        let deep_targets = deep_var_names(&self.deep_hint, &self.component.reactive_vars);
+        let body = rewrite_handler(
+            handler,
+            &self.component.reactive_vars,
+            frag.shadowed,
+            &deep_targets,
+        );
         push_indent(b, frag.indent);
         b.push_str(self.helper("on"));
         b.push('(');
@@ -2473,8 +2482,19 @@ impl<'a> Emitter<'a> {
         let set = attr_set_statement(node, attr, &value);
         self.emit_update(b, frag, &deps, reads_any(lvalue, frag.shadowed), &set);
 
-        // Write side: element state flows back into the lvalue.
+        // Write side: element state flows back into the lvalue. Build the write
+        // as an assignment statement and route it through the handler rewrite so
+        // a deep lvalue (`obj.field`, `items[i].done`) gets both its `.v` and the
+        // proxy-free deep-mutation invalidation injected — a plain-var lvalue
+        // (`count`) just becomes `count.v = …`, whose setter marks on its own.
         let (event, read) = two_way_read(node, attr);
+        let deep_targets = deep_var_names(&self.deep_hint, &self.component.reactive_vars);
+        let write = rewrite_handler(
+            &format!("{lvalue} = {read}"),
+            &self.component.reactive_vars,
+            frag.shadowed,
+            &deep_targets,
+        );
         self.use_helper("on");
         push_indent(b, frag.indent);
         b.push_str(self.helper("on"));
@@ -2483,9 +2503,7 @@ impl<'a> Emitter<'a> {
         b.push_str(", ");
         push_js_string(b, event);
         b.push_str(", () => { ");
-        b.push_str(&value);
-        b.push_str(" = ");
-        b.push_str(&read);
+        b.push_str(&write);
         b.push_str("; });\n");
     }
 
@@ -3244,6 +3262,21 @@ fn rewrite_script(
         decl_ranges.push(d.stmt_range);
     }
 
+    // (1b) Proxy-free deep reactivity: after each deep mutation of a deepBox var,
+    // inject an explicit invalidation. `arr.push(x)` -> `(arr.touch(), arr.push(x))`
+    // and `rows[i].label = x` -> `(rows.touchElem(rows.v[i]), rows[i].label = x)`.
+    // The `.v` that step (2) appends to the reactive references INSIDE the wrapped
+    // expression still lands (the injected wrapper is zero-width text around it).
+    // These edits are pushed BEFORE step (2) so that, at a shared end offset (a
+    // mutation whose last token is itself a reactive read), the `.v` is applied
+    // to the LEFT of the closing `)` — see apply_edits' stable ordering.
+    let deep_targets = deep_var_names(hint, vars);
+    let reactive_names: std::collections::HashSet<&str> =
+        vars.iter().map(|v| v.name.as_str()).collect();
+    for site in touch_sites(script, &deep_targets, &reactive_names, &decl_ranges) {
+        edits.push(site);
+    }
+
     // (2) Every reactive reference becomes `name.v`. Skip references inside a
     // rewritten declaration statement — its init was already rewritten in (1).
     for r in &refs {
@@ -3312,12 +3345,14 @@ fn apply_edits(src: &str, mut edits: Vec<(u32, u32, String)>) -> String {
 /// Rewrites a standalone JS expression so reactive references become `name.v`.
 /// Uses scope-aware [`free_identifiers_with_spans`] so shadowed locals (e.g. an
 /// arrow parameter of the same name) are left alone. `shadowed` names (loop
-/// bindings of enclosing `:for` items) are excluded from rewriting.
+/// bindings of enclosing `:for` items) are excluded from rewriting. A bind
+/// expression is READ-only, so no deep-mutation invalidation is injected.
 fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String {
     rewrite_with(
         expr,
         vars,
         shadowed,
+        &[],
         lunas_script::free_identifiers_with_spans,
     )
 }
@@ -3329,23 +3364,33 @@ fn rewrite_expr(expr: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String
 /// `.v` rewrite is silently skipped (assignments would not reach the box setter
 /// and the DOM would never update). A handler that only *calls* a function is
 /// left untouched by the identifier rewrite except for its reactive arguments,
-/// which is exactly right.
-fn rewrite_handler(handler: &str, vars: &[ReactiveVar], shadowed: &[String]) -> String {
+/// which is exactly right. `deep_targets` are the deepBox vars a deep mutation
+/// in the handler must invalidate via an injected `touch()`/`touchElem()`.
+fn rewrite_handler(
+    handler: &str,
+    vars: &[ReactiveVar],
+    shadowed: &[String],
+    deep_targets: &[String],
+) -> String {
     rewrite_with(
         handler,
         vars,
         shadowed,
+        deep_targets,
         lunas_script::free_identifiers_with_spans_program,
     )
 }
 
 /// Shared body of the `.v`-rewrite: appends `.v` after every free occurrence of
 /// a (non-shadowed) reactive binding, using the supplied span analyzer to locate
-/// occurrences. On a parse error the source is returned unchanged (never-panic).
+/// occurrences. When `deep_targets` is non-empty, each deep mutation of one of
+/// those vars is ALSO wrapped with an injected invalidation (proxy-free deep
+/// reactivity). On a parse error the source is returned unchanged (never-panic).
 fn rewrite_with(
     src: &str,
     vars: &[ReactiveVar],
     shadowed: &[String],
+    deep_targets: &[String],
     spans_of: impl Fn(
         &str,
     )
@@ -3367,12 +3412,74 @@ fn rewrite_with(
         Err(_) => return src.trim().to_string(),
     };
     let mut edits: Vec<(u32, u32, String)> = Vec::new();
+    // Deep-mutation touch injections FIRST, so a `.v` sharing a mutation's end
+    // offset lands to the left of the closing `)` (apply_edits' stable ordering).
+    let deep_active: Vec<String> = deep_targets
+        .iter()
+        .filter(|n| reactive.contains(n.as_str()))
+        .cloned()
+        .collect();
+    for site in touch_sites(src, &deep_active, &reactive, &[]) {
+        edits.push(site);
+    }
     for (name, range) in spans {
         if reactive.contains(name.as_str()) {
             edits.push((range.end().raw(), range.end().raw(), ".v".to_string()));
         }
     }
     apply_edits(src, edits).trim().to_string()
+}
+
+/// Names of the reactive vars the component deeply mutates (so they are boxed
+/// with `deepBox` and need injected `touch()` invalidations).
+fn deep_var_names(hint: &str, vars: &[ReactiveVar]) -> Vec<String> {
+    vars.iter()
+        .filter(|v| is_deeply_mutated(hint, &v.name))
+        .map(|v| v.name.clone())
+        .collect()
+}
+
+/// Computes the invalidation-wrapper edits for every deep-mutation site of a
+/// `deep_targets` var in `code`: `(root.touch(), <expr>)` for a structural
+/// mutation, `(root.touchElem(root.v[idx]), <expr>)` for an element-field write.
+/// `reactive` is used to `.v`-qualify a reactive index identifier; sites falling
+/// inside a rewritten declaration statement (`skip`) are dropped to avoid
+/// overlapping that statement's replacement edit.
+fn touch_sites(
+    code: &str,
+    deep_targets: &[String],
+    reactive: &std::collections::HashSet<&str>,
+    skip: &[TextRange],
+) -> Vec<(u32, u32, String)> {
+    if deep_targets.is_empty() {
+        return Vec::new();
+    }
+    let sites = lunas_script::deep_mutation_sites(code, deep_targets).unwrap_or_default();
+    let mut edits: Vec<(u32, u32, String)> = Vec::new();
+    for s in sites {
+        let lo = s.expr.start().raw();
+        let hi = s.expr.end().raw();
+        if skip.iter().any(|dr| {
+            dr.end().raw() > dr.start().raw() && lo >= dr.start().raw() && hi <= dr.end().raw()
+        }) {
+            continue;
+        }
+        let prefix = match &s.elem_index {
+            Some(idx) => {
+                let raw = idx.slice(code).unwrap_or("0");
+                let idx_text = if reactive.contains(raw) {
+                    format!("{raw}.v")
+                } else {
+                    raw.to_string()
+                };
+                format!("({}.touchElem({}.v[{}]), ", s.root, s.root, idx_text)
+            }
+            None => format!("({}.touch(), ", s.root),
+        };
+        edits.push((lo, lo, prefix));
+        edits.push((hi, hi, ")".to_string()));
+    }
+    edits
 }
 
 // --- attribute set special cases -----------------------------------------

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -1523,3 +1523,62 @@ fn for_ordinary_item_omits_tablectx() {
     // And it still emits a forBlock with html (sanity: the fast path is active).
     assert!(js.contains("forBlock"), "expected forBlock:\n{js}");
 }
+
+// --- proxy-free deep reactivity: invalidation injection for alias mutations ---
+
+#[test]
+fn deep_mutation_direct_forms_inject_touch() {
+    // Structural method call and element-field write get their touch/touchElem.
+    let js = emit(
+        "html:\n    <ul><li :for=\"r of rows\" :key=\"r.id\">${r.n}</li></ul>\n    <button @click=\"rows.push({id:2,n:2})\">a</button>\n    <button @click=\"rows[0].n = 9\">b</button>\nscript:\n    let rows = [{id:1,n:1}]\n",
+    );
+    assert!(
+        js.contains("(rows.touch(), rows.v.push("),
+        "structural push must inject touch():\n{js}"
+    );
+    assert!(
+        js.contains("(rows.touchElem(rows.v[0]), rows.v[0].n = 9)"),
+        "element-field write must inject touchElem():\n{js}"
+    );
+}
+
+#[test]
+fn deep_mutation_via_iteration_callback_injects_touch() {
+    // A mutation reached through a forEach/map callback alias is recovered with a
+    // conservative structural touch of the receiver.
+    let js = emit(
+        "html:\n    <button @click=\"markAll()\">a</button>\n    <p :for=\"t of todos\" :key=\"t.id\">${t.done}</p>\nscript:\n    let todos = [{id:1,done:false}]\n    function seed(){ todos.push({id:2,done:false}) }\n    function markAll(){ todos.forEach(t => t.done = true) }\n",
+    );
+    assert!(
+        js.contains("(todos.touch(), todos.v.forEach("),
+        "forEach whose callback mutates elements must inject a structural touch:\n{js}"
+    );
+}
+
+#[test]
+fn pure_iteration_callback_does_not_inject_touch() {
+    // A pure filter/map (no mutation in the callback) must NOT over-notify.
+    let js = emit(
+        "html:\n    <p :for=\"o of xs\" :key=\"o.id\">${o.n}</p>\n    <button @click=\"seed()\">a</button>\n    <button @click=\"pick()\">b</button>\nscript:\n    let xs = [{id:1,n:1}]\n    function seed(){ xs.push({id:2,n:2}) }\n    function pick(){ const r = xs.filter(o => o.n > 0); return r }\n",
+    );
+    // The pick() handler wraps a pure filter -> no touch injected there.
+    assert!(
+        js.contains("xs.v.filter(") && !js.contains("(xs.touch(), xs.v.filter("),
+        "pure filter must not inject a touch:\n{js}"
+    );
+}
+
+#[test]
+fn object_assign_and_destructuring_inject_touch() {
+    let js = emit(
+        "html:\n    <button @click=\"upd()\">u</button>\n    <button @click=\"swap()\">s</button>\n    <p>${obj.a}</p>\n    <p :for=\"x of arr\" :key=\"x\">${x}</p>\nscript:\n    let obj = {a:1,b:2}\n    let arr = [1,2]\n    function seedO(){ obj.a = 0 }\n    function seedA(){ arr.push(3) }\n    function upd(){ Object.assign(obj, {a:9}) }\n    function swap(){ [arr[0], arr[1]] = [arr[1], arr[0]] }\n",
+    );
+    assert!(
+        js.contains("(obj.touch(), Object.assign(obj.v,"),
+        "Object.assign(target, ...) must inject a touch of target:\n{js}"
+    );
+    assert!(
+        js.contains("(arr.touch(), [arr.v[0], arr.v[1]] = [arr.v[1], arr.v[0]])"),
+        "destructuring assignment to element targets must inject a touch:\n{js}"
+    );
+}

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -1582,3 +1582,22 @@ fn object_assign_and_destructuring_inject_touch() {
         "destructuring assignment to element targets must inject a touch:\n{js}"
     );
 }
+
+#[test]
+fn iteration_callback_local_accumulator_does_not_touch() {
+    // A computed that uses forEach/some with a CALLBACK-LOCAL accumulator/flag
+    // (not an element mutation) must NOT get a touch injected — otherwise reading
+    // it in a bind would self-invalidate into a loop.
+    let js = emit(
+        "html:\n    <p>${sum()}</p>\n    <button @click=\"seed()\">a</button>\nscript:\n    let arr = [{n:1}]\n    function seed(){ arr.push({n:2}) }\n    function sum(){ let total = 0; arr.forEach(x => { total += x.n }); return total }\n",
+    );
+    assert!(
+        js.contains("arr.v.forEach(") && !js.contains("(arr.touch(), arr.v.forEach("),
+        "a local-accumulator forEach must NOT inject a touch (loop hazard):\n{js}"
+    );
+    // The genuine structural mutation (push) is still wrapped.
+    assert!(
+        js.contains("(arr.touch(), arr.v.push("),
+        "push is still instrumented:\n{js}"
+    );
+}

--- a/crates/lunas_compiler/tests/codegen_emit.rs
+++ b/crates/lunas_compiler/tests/codegen_emit.rs
@@ -1601,3 +1601,25 @@ fn iteration_callback_local_accumulator_does_not_touch() {
         "push is still instrumented:\n{js}"
     );
 }
+
+#[test]
+fn nested_same_name_callback_shadow_does_not_touch_outer() {
+    // A nested callback that reuses the element name must not attribute its inner
+    // mutation to the OUTER array (would be a spurious touch -> getter self-loop).
+    let js = emit(
+        "html:\n    <p>${total()}</p>\n    <button @click=\"seed()\">a</button>\nscript:\n    let data = [{children:[{done:false}]}]\n    function seed(){ data.push({children:[]}) }\n    function total(){ let n = 0; data.forEach(e => e.children.forEach(e => { if(e.done) n++ })); return n }\n",
+    );
+    assert!(
+        !js.contains("(data.touch(), data.v.forEach("),
+        "inner `e` shadows outer `e`: must NOT touch the outer array:\n{js}"
+    );
+    // But a nested callback with a DIFFERENT param that mutates the outer element
+    // by its real name still injects.
+    let js2 = emit(
+        "html:\n    <button @click=\"go()\">a</button>\n    <p :for=\"t of todos\" :key=\"t.id\">${t.done}</p>\nscript:\n    let todos = [{id:1,done:false,tags:[1]}]\n    function seed(){ todos.push({id:2,done:false,tags:[]}) }\n    function go(){ todos.forEach(e => { e.tags.forEach(x => { e.done = true }) }) }\n",
+    );
+    assert!(
+        js2.contains("(todos.touch(), todos.v.forEach("),
+        "outer element mutated under a non-shadowing inner param: must touch:\n{js2}"
+    );
+}

--- a/crates/lunas_compiler/tests/snapshots/app_App.js
+++ b/crates/lunas_compiler/tests/snapshots/app_App.js
@@ -23,7 +23,7 @@ export default component("div", {}, HTML, (c, props) => {
   ])
   function show(p) { page.v = p }
   function addTag() {
-      tags.v.push({ id: tags.v.length + 1, label: "extra" })
+      (tags.touch(), tags.v.push({ id: tags.v.length + 1, label: "extra" }))
   }
   const [e0, e1, e2] = refs(c.root, [[0, 1, 0], [0, 1, 1], [0, 1, 2]]);
   const [g0, g1, g2, g3, g4] = refs(c.root, [[0, 0], [0, 2], [0, 2], [0, 2], [0]]);

--- a/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
+++ b/crates/lunas_compiler/tests/snapshots/for_keyed_nested.js
@@ -11,9 +11,9 @@ export default component("div", {}, HTML, (c, props) => {
       { id: 2, name: "b", open: false, tags: ["z"] }
   ])
   function add() {
-      groups.v.push({ id: groups.v.length + 1, name: "n", open: false, tags: ["t"] })
+      (groups.touch(), groups.v.push({ id: groups.v.length + 1, name: "n", open: false, tags: ["t"] }))
   }
-  function toggleFirst() { groups.v[0].open = !groups.v[0].open }
+  function toggleFirst() { (groups.touchElem(groups.v[0]), groups.v[0].open = !groups.v[0].open) }
   const [e0, e1] = refs(c.root, [[0, 0], [0, 1]]);
   const [g0] = refs(c.root, [[0, 2]]);
   const a0 = anchorAppend(g0);

--- a/crates/lunas_compiler/tests/snapshots/ref_html.js
+++ b/crates/lunas_compiler/tests/snapshots/ref_html.js
@@ -6,7 +6,7 @@ export default component("div", {}, HTML, (c, props) => {
   const field = deepBox(c, 0, undefined)
   const markup = box(c, 1, "<b>bold</b>")
   function fill() {
-      field.v.value = "typed"
+      (field.touch(), field.v.value = "typed")
       markup.v = "<i>italic</i>"
   }
   const [e0, e1, e2] = refs(c.root, [[0, 0], [0, 1], [0, 2]]);

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -522,6 +522,80 @@ fn collect_pat_names(pat: &Pat, out: &mut std::collections::HashSet<String>) {
 /// assert_eq!(assigned_identifiers("count = count + 1; obj.x = 2; n++").unwrap(),
 ///            ["count", "obj", "n"]);
 /// ```
+/// A single deep-mutation site of one of the `targets` variables: the byte
+/// range of the whole mutation expression (so a caller can wrap it), the root
+/// variable name mutated, and — when the mutation is an element-field write on a
+/// direct array element (`X[idx].field = …`) — the byte range of the index
+/// expression `idx` (so the caller can attribute the change to `X[idx]` for
+/// fine-grained `:for` patching). `elem_index` is `None` for a STRUCTURAL
+/// mutation (`X.push(…)`, `X[i] = y`, `X.k = v`, `delete X.k`, `X.length = n`,
+/// Map/Set `set`/`add`/`delete`/`clear`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeepMutationSite {
+    /// Byte range of the whole mutation expression within `code`.
+    pub expr: lunas_span::TextRange,
+    /// Root variable being deep-mutated.
+    pub root: String,
+    /// For an element-field write, the byte range of the `[idx]` index expr.
+    pub elem_index: Option<lunas_span::TextRange>,
+}
+
+/// Finds every deep-mutation site of a variable in `targets`. This is what
+/// proxy-free deep reactivity needs: after each returned mutation the compiler
+/// injects `root.touch()` (structural) or `root.touchElem(root.v[idx])`
+/// (element-field), so a deep mutation still marks the variable dirty without a
+/// runtime Proxy. Parses `code` as a program (works for both a whole `script:`
+/// block and an inline `@event` handler). Never panics; a parse error yields an
+/// empty list (the caller falls back to no injection).
+///
+/// Element-field is detected only for the unambiguous, side-effect-free shape
+/// `X[idx].…` where `idx` is a bare identifier or number literal (so
+/// re-evaluating `X.v[idx]` in the injected call is safe); every other deep
+/// mutation is reported as structural (always correct, just coarser).
+///
+/// ```
+/// use lunas_script::deep_mutation_sites;
+///
+/// let sites = deep_mutation_sites("rows[i].label = x; rows.push(y)",
+///                                 &["rows".to_string()]).unwrap();
+/// assert_eq!(sites.len(), 2);
+/// assert!(sites[0].elem_index.is_some()); // rows[i].label = x  -> touchElem
+/// assert!(sites[1].elem_index.is_none());  // rows.push(y)       -> touch
+/// ```
+pub fn deep_mutation_sites(
+    code: &str,
+    targets: &[String],
+) -> Result<Vec<DeepMutationSite>, ScriptParseError> {
+    let (module, fm) = parse_source_with_fm(code.to_string())?;
+    let mut c = MutationSiteCollector {
+        targets: targets.iter().map(|s| s.as_str().to_string()).collect(),
+        sites: Vec::new(),
+    };
+    module.visit_with(&mut c);
+    let base = fm.start_pos.0;
+    let code_len = code.len() as u32;
+    let conv = |lo: u32, hi: u32| -> Option<lunas_span::TextRange> {
+        let lo = lo.checked_sub(base)?;
+        let hi = hi.checked_sub(base)?;
+        (hi <= code_len && lo <= hi).then(|| lunas_span::TextRange::at(lo, hi))
+    };
+    Ok(c.sites
+        .into_iter()
+        .filter_map(|s| {
+            let expr = conv(s.expr_lo, s.expr_hi)?;
+            let elem_index = match s.idx {
+                Some((lo, hi)) => Some(conv(lo, hi)?),
+                None => None,
+            };
+            Some(DeepMutationSite {
+                expr,
+                root: s.root,
+                elem_index,
+            })
+        })
+        .collect())
+}
+
 pub fn assigned_identifiers(code: &str) -> Result<Vec<String>, ScriptParseError> {
     let module = parse_program(code)?;
     let mut collector = AssignCollector { names: Vec::new() };
@@ -724,6 +798,125 @@ impl Visit for AssignCollector {
         // assignments / mutations.
         n.visit_children_with(self);
     }
+}
+
+// --- deep-mutation site collection (proxy-free reactivity) -------------------
+
+struct RawMutationSite {
+    expr_lo: u32,
+    expr_hi: u32,
+    root: String,
+    idx: Option<(u32, u32)>,
+}
+
+struct MutationSiteCollector {
+    targets: std::collections::HashSet<String>,
+    sites: Vec<RawMutationSite>,
+}
+
+impl MutationSiteCollector {
+    /// Record a member-target deep mutation (`X.f = …`, `X[i] = …`,
+    /// `X[i].f = …`, `X.f++`, `delete X.f`). `expr` is the whole mutation
+    /// expression's span (what the caller wraps).
+    fn record_member(&mut self, m: &swc_ecma_ast::MemberExpr, expr: swc_common::Span) {
+        let Some(root) = root_ident(&m.obj) else {
+            return;
+        };
+        let name = root.sym.to_string();
+        if !self.targets.contains(&name) {
+            return;
+        }
+        self.sites.push(RawMutationSite {
+            expr_lo: expr.lo.0,
+            expr_hi: expr.hi.0,
+            root: name,
+            idx: element_index_span(m),
+        });
+    }
+}
+
+impl Visit for MutationSiteCollector {
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
+        // Only member/index targets are deep mutations. A plain `X = …` reassign
+        // is not deep — the box's own `.v` setter marks it, so we skip it here.
+        if let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &n.left {
+            self.record_member(m, n.span);
+        }
+        n.visit_children_with(self);
+    }
+
+    fn visit_update_expr(&mut self, n: &UpdateExpr) {
+        if let Expr::Member(m) = &*n.arg {
+            self.record_member(m, n.span);
+        }
+        n.visit_children_with(self);
+    }
+
+    fn visit_unary_expr(&mut self, n: &swc_ecma_ast::UnaryExpr) {
+        if matches!(n.op, swc_ecma_ast::UnaryOp::Delete) {
+            if let Expr::Member(m) = &*n.arg {
+                self.record_member(m, n.span);
+            }
+        }
+        n.visit_children_with(self);
+    }
+
+    fn visit_call_expr(&mut self, n: &CallExpr) {
+        if let Callee::Expr(callee) = &n.callee {
+            if let Expr::Member(m) = &**callee {
+                if let MemberProp::Ident(method) = &m.prop {
+                    if is_mutating_method(&method.sym) {
+                        if let Some(id) = root_ident(&m.obj) {
+                            let name = id.sym.to_string();
+                            if self.targets.contains(&name) {
+                                self.sites.push(RawMutationSite {
+                                    expr_lo: n.span.lo.0,
+                                    expr_hi: n.span.hi.0,
+                                    root: name,
+                                    idx: None, // a mutating method is structural
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        n.visit_children_with(self);
+    }
+}
+
+/// For an LHS member expression, returns the index-expression span when the
+/// shape is `root[idx].…` (a field write on a direct array element) with `idx`
+/// a bare identifier or number literal; otherwise `None` (structural).
+fn element_index_span(m: &swc_ecma_ast::MemberExpr) -> Option<(u32, u32)> {
+    use swc_common::Spanned;
+    // Flatten the member chain from the root outward.
+    let mut chain: Vec<&swc_ecma_ast::MemberExpr> = Vec::new();
+    fn flatten<'a>(m: &'a swc_ecma_ast::MemberExpr, out: &mut Vec<&'a swc_ecma_ast::MemberExpr>) {
+        if let Expr::Member(inner) = &*m.obj {
+            flatten(inner, out);
+        }
+        out.push(m);
+    }
+    flatten(m, &mut chain);
+    // Element-field iff the FIRST access off the root is a computed index and at
+    // least one further member access sits above it (`root[idx].field`), so the
+    // mutated value is a field of the element `root[idx]`, not the root itself.
+    if chain.len() < 2 {
+        return None;
+    }
+    if let MemberProp::Computed(c) = &chain[0].prop {
+        // Only simple, side-effect-free indices: re-evaluating `root.v[idx]` in
+        // the injected `touchElem` must be safe.
+        if matches!(
+            &*c.expr,
+            Expr::Ident(_) | Expr::Lit(swc_ecma_ast::Lit::Num(_))
+        ) {
+            let sp = c.expr.span();
+            return Some((sp.lo.0, sp.hi.0));
+        }
+    }
+    None
 }
 
 /// Array / collection methods that mutate the receiver in place. A call to one

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -833,14 +833,82 @@ impl MutationSiteCollector {
             idx: element_index_span(m),
         });
     }
+
+    /// Record a STRUCTURAL touch of `root` over `span`, if `root` is a target and
+    /// not already recorded for this exact span (dedup keeps a destructuring swap
+    /// `[a[0], a[1]] = …` to a single `a.touch()`).
+    fn push_structural(&mut self, root: &str, span: swc_common::Span) {
+        if !self.targets.contains(root) {
+            return;
+        }
+        if self.sites.iter().any(|s| {
+            s.root == root && s.idx.is_none() && s.expr_lo == span.lo.0 && s.expr_hi == span.hi.0
+        }) {
+            return;
+        }
+        self.sites.push(RawMutationSite {
+            expr_lo: span.lo.0,
+            expr_hi: span.hi.0,
+            root: root.to_string(),
+            idx: None,
+        });
+    }
+
+    /// Walk a destructuring-assignment target pattern and record a structural
+    /// touch for every member/element target rooted at a deep var — e.g.
+    /// `[arr[0], arr[1]] = …` or `({ a: obj.k } = …)`. The old Proxy caught these
+    /// through the value; syntax-based tracking must find them in the pattern.
+    fn record_pat_targets(&mut self, pat: &Pat, span: swc_common::Span) {
+        match pat {
+            Pat::Expr(e) => {
+                if let Expr::Member(m) = &**e {
+                    if let Some(id) = root_ident(&m.obj) {
+                        self.push_structural(&id.sym, span);
+                    }
+                }
+            }
+            Pat::Array(a) => {
+                for el in a.elems.iter().flatten() {
+                    self.record_pat_targets(el, span);
+                }
+            }
+            Pat::Object(o) => {
+                for p in &o.props {
+                    match p {
+                        ObjectPatProp::KeyValue(kv) => self.record_pat_targets(&kv.value, span),
+                        ObjectPatProp::Rest(r) => self.record_pat_targets(&r.arg, span),
+                        ObjectPatProp::Assign(_) => {}
+                    }
+                }
+            }
+            Pat::Rest(r) => self.record_pat_targets(&r.arg, span),
+            Pat::Assign(a) => self.record_pat_targets(&a.left, span),
+            _ => {}
+        }
+    }
 }
 
 impl Visit for MutationSiteCollector {
     fn visit_assign_expr(&mut self, n: &AssignExpr) {
-        // Only member/index targets are deep mutations. A plain `X = …` reassign
-        // is not deep — the box's own `.v` setter marks it, so we skip it here.
-        if let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &n.left {
-            self.record_member(m, n.span);
+        match &n.left {
+            // Member/index target: `X.f = …`, `X[i] = …`, `X[i].f = …`.
+            AssignTarget::Simple(SimpleAssignTarget::Member(m)) => self.record_member(m, n.span),
+            // Destructuring target: `[X[0], X[1]] = …`, `({ a: X.k } = …)`.
+            AssignTarget::Pat(AssignTargetPat::Array(a)) => {
+                for el in a.elems.iter().flatten() {
+                    self.record_pat_targets(el, n.span);
+                }
+            }
+            AssignTarget::Pat(AssignTargetPat::Object(o)) => {
+                for p in &o.props {
+                    match p {
+                        ObjectPatProp::KeyValue(kv) => self.record_pat_targets(&kv.value, n.span),
+                        ObjectPatProp::Rest(r) => self.record_pat_targets(&r.arg, n.span),
+                        ObjectPatProp::Assign(_) => {}
+                    }
+                }
+            }
+            _ => {}
         }
         n.visit_children_with(self);
     }
@@ -865,18 +933,113 @@ impl Visit for MutationSiteCollector {
         if let Callee::Expr(callee) = &n.callee {
             if let Expr::Member(m) = &**callee {
                 if let MemberProp::Ident(method) = &m.prop {
-                    if is_mutating_method(&method.sym) {
+                    let mname = method.sym.as_ref();
+                    if is_mutating_method(mname) {
+                        // `X.push(…)`, `X.splice(…)`, Map/Set `set`/`add`/… — structural.
                         if let Some(id) = root_ident(&m.obj) {
-                            let name = id.sym.to_string();
-                            if self.targets.contains(&name) {
-                                self.sites.push(RawMutationSite {
-                                    expr_lo: n.span.lo.0,
-                                    expr_hi: n.span.hi.0,
-                                    root: name,
-                                    idx: None, // a mutating method is structural
-                                });
-                            }
+                            self.push_structural(&id.sym, n.span);
                         }
+                    } else if is_iteration_method(mname)
+                        && n.args.iter().any(|a| callback_mutates(&a.expr))
+                    {
+                        // `X.forEach(el => el.f = …)` / `X.map(el => (el.n = …, el))`:
+                        // the callback mutates elements through an alias the syntax
+                        // scan can't attribute, so conservatively force a structural
+                        // touch of the receiver (safe: at worst an extra reconcile).
+                        if let Some(id) = root_ident(&m.obj) {
+                            self.push_structural(&id.sym, n.span);
+                        }
+                    }
+                }
+                // `Object.assign(X, …)` / `Object.defineProperty(X, …)` mutate their
+                // first argument by reference — attribute the touch to that argument.
+                if is_object_mutator(m) {
+                    if let Some(arg) = n.args.first() {
+                        if let Some(id) = root_ident(&arg.expr) {
+                            self.push_structural(&id.sym, n.span);
+                        }
+                    }
+                }
+            }
+        }
+        n.visit_children_with(self);
+    }
+}
+
+/// Array iteration methods whose callback commonly mutates the elements. Only
+/// triggers a touch when the callback body actually contains a mutation (checked
+/// by [`callback_mutates`]) — a pure `filter`/`map` never spuriously touches.
+/// `reduce`/`reduceRight` are intentionally excluded: their callback usually
+/// mutates a separate accumulator, not the array.
+fn is_iteration_method(name: &str) -> bool {
+    matches!(
+        name,
+        "forEach"
+            | "map"
+            | "flatMap"
+            | "filter"
+            | "some"
+            | "every"
+            | "find"
+            | "findIndex"
+            | "findLast"
+            | "findLastIndex"
+    )
+}
+
+/// `Object.assign` / `Object.defineProperty` / `Object.defineProperties` /
+/// `Object.setPrototypeOf` — builtins that mutate the object passed as their
+/// first argument in place.
+fn is_object_mutator(m: &swc_ecma_ast::MemberExpr) -> bool {
+    let (Expr::Ident(obj), MemberProp::Ident(prop)) = (&*m.obj, &m.prop) else {
+        return false;
+    };
+    obj.sym.as_ref() == "Object"
+        && matches!(
+            prop.sym.as_ref(),
+            "assign" | "defineProperty" | "defineProperties" | "setPrototypeOf"
+        )
+}
+
+/// True when a callback expression (arrow or function) contains any mutation in
+/// its body: an assignment, an update (`++`/`--`), a `delete`, or a mutating
+/// method call. Over-approximate on purpose — a stray local write only causes a
+/// benign extra re-render, never a wrong one. A callback passed by reference
+/// (`arr.forEach(fn)`) is not a literal function here, so it returns false.
+fn callback_mutates(expr: &Expr) -> bool {
+    if !matches!(expr, Expr::Arrow(_) | Expr::Fn(_)) {
+        return false;
+    }
+    let mut c = MutationPresence { found: false };
+    expr.visit_with(&mut c);
+    c.found
+}
+
+struct MutationPresence {
+    found: bool,
+}
+
+impl Visit for MutationPresence {
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
+        self.found = true;
+        n.visit_children_with(self);
+    }
+    fn visit_update_expr(&mut self, n: &UpdateExpr) {
+        self.found = true;
+        n.visit_children_with(self);
+    }
+    fn visit_unary_expr(&mut self, n: &swc_ecma_ast::UnaryExpr) {
+        if matches!(n.op, swc_ecma_ast::UnaryOp::Delete) {
+            self.found = true;
+        }
+        n.visit_children_with(self);
+    }
+    fn visit_call_expr(&mut self, n: &CallExpr) {
+        if let Callee::Expr(callee) = &n.callee {
+            if let Expr::Member(m) = &**callee {
+                if let MemberProp::Ident(method) = &m.prop {
+                    if is_mutating_method(&method.sym) {
+                        self.found = true;
                     }
                 }
             }

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -1011,20 +1011,36 @@ fn is_object_mutator(m: &swc_ecma_ast::MemberExpr) -> bool {
 /// (destructured/absent) or the callback is passed by reference, returns false
 /// (no injection — a rare aliased element mutation is a documented limitation).
 fn callback_mutates(expr: &Expr) -> bool {
-    let param = match expr {
-        Expr::Arrow(a) => a.params.first().and_then(pat_ident_name),
-        Expr::Fn(f) => f
-            .function
-            .params
-            .first()
-            .and_then(|p| pat_ident_name(&p.pat)),
+    let mut c = MutationPresence {
+        elem: String::new(),
+        found: false,
+    };
+    match expr {
+        Expr::Arrow(a) => {
+            let Some(elem) = a.params.first().and_then(pat_ident_name) else {
+                return false;
+            };
+            c.elem = elem;
+            // Visit the BODY, not the arrow node itself, so the element parameter
+            // isn't mistaken for a shadowing nested binding by visit_arrow_expr.
+            a.body.visit_with(&mut c);
+        }
+        Expr::Fn(f) => {
+            let Some(elem) = f
+                .function
+                .params
+                .first()
+                .and_then(|p| pat_ident_name(&p.pat))
+            else {
+                return false;
+            };
+            c.elem = elem;
+            if let Some(body) = &f.function.body {
+                body.visit_with(&mut c);
+            }
+        }
         _ => return false,
-    };
-    let Some(elem) = param else {
-        return false;
-    };
-    let mut c = MutationPresence { elem, found: false };
-    expr.visit_with(&mut c);
+    }
     c.found
 }
 
@@ -1036,7 +1052,28 @@ fn pat_ident_name(pat: &Pat) -> Option<String> {
     }
 }
 
-/// Reports whether a callback body mutates the element binding `elem`.
+/// Whether a binding pattern binds `name` anywhere (incl. destructuring), so a
+/// nested function that rebinds the element name is recognized as shadowing.
+fn pat_binds(pat: &Pat, name: &str) -> bool {
+    match pat {
+        Pat::Ident(b) => *b.id.sym == *name,
+        Pat::Array(a) => a.elems.iter().flatten().any(|p| pat_binds(p, name)),
+        Pat::Object(o) => o.props.iter().any(|p| match p {
+            ObjectPatProp::KeyValue(kv) => pat_binds(&kv.value, name),
+            ObjectPatProp::Assign(a) => *a.key.sym == *name,
+            ObjectPatProp::Rest(r) => pat_binds(&r.arg, name),
+        }),
+        Pat::Rest(r) => pat_binds(&r.arg, name),
+        Pat::Assign(a) => pat_binds(&a.left, name),
+        _ => false,
+    }
+}
+
+/// Reports whether a callback body mutates the element binding `elem`. Scope-
+/// aware: it does not descend into a nested function that rebinds `elem` as a
+/// parameter, so an inner callback reusing the same name (`a.forEach(e =>
+/// b.forEach(e => e.k = 1))`) does not spuriously attribute the inner mutation
+/// to the outer element.
 struct MutationPresence {
     elem: String,
     found: bool,
@@ -1051,6 +1088,22 @@ impl MutationPresence {
 }
 
 impl Visit for MutationPresence {
+    fn visit_arrow_expr(&mut self, n: &swc_ecma_ast::ArrowExpr) {
+        if n.params.iter().any(|p| pat_binds(p, &self.elem)) {
+            return; // inner scope shadows the element name
+        }
+        n.visit_children_with(self);
+    }
+    fn visit_fn_expr(&mut self, n: &swc_ecma_ast::FnExpr) {
+        if n.function
+            .params
+            .iter()
+            .any(|p| pat_binds(&p.pat, &self.elem))
+        {
+            return;
+        }
+        n.visit_children_with(self);
+    }
     fn visit_assign_expr(&mut self, n: &AssignExpr) {
         if let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &n.left {
             if self.is_elem_rooted(&m.obj) {

--- a/crates/lunas_script/src/analysis.rs
+++ b/crates/lunas_script/src/analysis.rs
@@ -1001,45 +1001,97 @@ fn is_object_mutator(m: &swc_ecma_ast::MemberExpr) -> bool {
         )
 }
 
-/// True when a callback expression (arrow or function) contains any mutation in
-/// its body: an assignment, an update (`++`/`--`), a `delete`, or a mutating
-/// method call. Over-approximate on purpose — a stray local write only causes a
-/// benign extra re-render, never a wrong one. A callback passed by reference
-/// (`arr.forEach(fn)`) is not a literal function here, so it returns false.
+/// True when a callback (arrow or function) mutates its own ELEMENT parameter —
+/// `e.f = …`, `e.f++`, `delete e.k`, `e.items.push(…)`, `Object.assign(e, …)`.
+/// It is deliberately scoped to the element binding: a write to a callback-LOCAL
+/// variable (an accumulator/flag, as in `arr.forEach(x => { total += x.n })` or
+/// `arr.some(x => { bad = true })`) is NOT a mutation of the array, and treating
+/// it as one would inject a touch into an ordinary read-only computed and turn it
+/// into a self-invalidating loop. If the first parameter isn't a plain identifier
+/// (destructured/absent) or the callback is passed by reference, returns false
+/// (no injection — a rare aliased element mutation is a documented limitation).
 fn callback_mutates(expr: &Expr) -> bool {
-    if !matches!(expr, Expr::Arrow(_) | Expr::Fn(_)) {
+    let param = match expr {
+        Expr::Arrow(a) => a.params.first().and_then(pat_ident_name),
+        Expr::Fn(f) => f
+            .function
+            .params
+            .first()
+            .and_then(|p| pat_ident_name(&p.pat)),
+        _ => return false,
+    };
+    let Some(elem) = param else {
         return false;
-    }
-    let mut c = MutationPresence { found: false };
+    };
+    let mut c = MutationPresence { elem, found: false };
     expr.visit_with(&mut c);
     c.found
 }
 
+/// The identifier a pattern binds, if it is a plain (non-destructured) name.
+fn pat_ident_name(pat: &Pat) -> Option<String> {
+    match pat {
+        Pat::Ident(b) => Some(b.id.sym.to_string()),
+        _ => None,
+    }
+}
+
+/// Reports whether a callback body mutates the element binding `elem`.
 struct MutationPresence {
+    elem: String,
     found: bool,
+}
+
+impl MutationPresence {
+    fn is_elem_rooted(&self, obj: &Expr) -> bool {
+        root_ident(obj)
+            .map(|id| *id.sym == *self.elem)
+            .unwrap_or(false)
+    }
 }
 
 impl Visit for MutationPresence {
     fn visit_assign_expr(&mut self, n: &AssignExpr) {
-        self.found = true;
+        if let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &n.left {
+            if self.is_elem_rooted(&m.obj) {
+                self.found = true;
+            }
+        }
         n.visit_children_with(self);
     }
     fn visit_update_expr(&mut self, n: &UpdateExpr) {
-        self.found = true;
+        if let Expr::Member(m) = &*n.arg {
+            if self.is_elem_rooted(&m.obj) {
+                self.found = true;
+            }
+        }
         n.visit_children_with(self);
     }
     fn visit_unary_expr(&mut self, n: &swc_ecma_ast::UnaryExpr) {
         if matches!(n.op, swc_ecma_ast::UnaryOp::Delete) {
-            self.found = true;
+            if let Expr::Member(m) = &*n.arg {
+                if self.is_elem_rooted(&m.obj) {
+                    self.found = true;
+                }
+            }
         }
         n.visit_children_with(self);
     }
     fn visit_call_expr(&mut self, n: &CallExpr) {
         if let Callee::Expr(callee) = &n.callee {
             if let Expr::Member(m) = &**callee {
+                // `elem.push(…)` / `elem.child.set(…)` — mutating method on the element.
                 if let MemberProp::Ident(method) = &m.prop {
-                    if is_mutating_method(&method.sym) {
+                    if is_mutating_method(&method.sym) && self.is_elem_rooted(&m.obj) {
                         self.found = true;
+                    }
+                }
+                // `Object.assign(elem, …)` — writes the element by reference.
+                if is_object_mutator(m) {
+                    if let Some(arg) = n.args.first() {
+                        if self.is_elem_rooted(&arg.expr) {
+                            self.found = true;
+                        }
                     }
                 }
             }

--- a/crates/lunas_script/src/lib.rs
+++ b/crates/lunas_script/src/lib.rs
@@ -21,10 +21,10 @@ mod transform;
 
 pub use analysis::{
     analyze_script, assigned_identifiers, declared_bindings, declared_bindings_with_spans,
-    free_identifiers, free_identifiers_with_spans, free_identifiers_with_spans_program,
-    function_dependencies, function_mutations, module_binding_references, referenced_identifiers,
-    referenced_identifiers_with_spans, top_level_declarations, BindingRef, DeclKind,
-    ScriptAnalysis, TopLevelDecl,
+    deep_mutation_sites, free_identifiers, free_identifiers_with_spans,
+    free_identifiers_with_spans_program, function_dependencies, function_mutations,
+    module_binding_references, referenced_identifiers, referenced_identifiers_with_spans,
+    top_level_declarations, BindingRef, DeclKind, DeepMutationSite, ScriptAnalysis, TopLevelDecl,
 };
 pub use ast::{parse_to_ast_json, ScriptParseError};
 pub use for_header::{parse_for, ForKind, ParsedFor};

--- a/docs/api/reactivity.md
+++ b/docs/api/reactivity.md
@@ -80,14 +80,21 @@ function deepBox<T>(c: Context, i: number, v: T): Box<T>
 ### Description
 
 Creates a **deeply-mutated** reactive cell at reactive index `i`. Reads through
-`.v` return a `Proxy` that marks index `i` dirty on any nested `set` or `delete`
-— including array mutators (`push`, `splice`, …) which run with the proxy as
-`this`. Nested objects are wrapped lazily on property access; wrappers are cached
-per underlying object (via a `WeakMap`) so proxy identity is stable across reads.
-Replacing the whole value (`box.v = next`) also marks dirty and re-wraps.
+`.v` return the **raw** value — no `Proxy` — so reads are as cheap as a plain
+[`box`](#box). A deep mutation is made reactive by an explicit invalidation the
+compiler injects right after the mutating statement:
+
+- `box.touch()` — a structural mutation (`push`/`splice`/`arr[i] = x`/`obj.k = v`/
+  `delete`/`length =`/`Map`·`Set` `set`/`add`/`delete`/`clear`).
+- `box.touchElem(el)` — an element-field write on a direct array element
+  (`rows[i].label = x`); `el` is the mutated element, recorded so a `:for` can
+  patch just that item.
+
+Replacing the whole value (`box.v = next`) marks dirty through the setter, so no
+injected call is needed there. `markVar` defers the flush to a microtask.
 
 The compiler chooses `deepBox` for variables it observes being deeply mutated
-(`arr.push(...)`, `obj.k = …`).
+(`arr.push(...)`, `obj.k = …`) and emits the matching `touch()`/`touchElem()`.
 
 ### Parameters
 
@@ -99,20 +106,25 @@ The compiler chooses `deepBox` for variables it observes being deeply mutated
 
 ### Returns
 
-`Box<T>` — a cell whose `.v` getter yields the deep proxy.
+`Box<T>` — a cell whose `.v` getter yields the raw value, plus `touch()` and
+`touchElem(el)` invalidation methods.
 
 ### Example
 
 ```js
 const todos = deepBox(c, 1, []);
-todos.v.push({ text: "buy milk" }); // marks index 1 dirty
-todos.v[0].text = "buy oat milk";   // nested set — also marks dirty
+(todos.touch(), todos.v.push({ text: "buy milk" }));   // structural -> touch()
+(todos.touchElem(todos.v[0]), todos.v[0].text = "oat"); // element-field -> touchElem
 ```
+
+(The parenthesized `touch`/`touchElem` calls are what the compiler injects; you
+write the plain mutation in a `.lunas` component.)
 
 ### Notes
 
-- Only the reactive floor `Proxy` (ES2015) is used; no `BigInt`.
-- The Proxy handler is shared with module-level stores (see [store API](./store.md)).
+- No `Proxy` and no `BigInt`: the reactive core is plain ES2015.
+- Module-level stores use the same model — deep mutation via `store.touch(key)`
+  (see [store API](./store.md)).
 
 ---
 

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -34,12 +34,16 @@ type Unsubscribe = () => void
 
 Creates a module-level store from a plain object of named initial values. Each key
 becomes an independent **field** (its own subscriber list). Object/array field
-values get deep-mutation support (lazily `Proxy`-wrapped, the same handler as
-[`deepBox`](./reactivity.md#deepbox)). A value that is already field-shaped — e.g.
-the result of [`derivedStore`](#derivedstore) — is kept as-is instead of being
-wrapped, so derived values can be declared inline in the initial object.
+values get deep-mutation support with no `Proxy`, the same model as
+[`deepBox`](./reactivity.md#deepbox): `get(key)` returns the raw value and a deep
+mutation is made reactive by `store.touch(key)`, which the compiler injects after
+the mutating statement. A value that is already field-shaped — e.g. the result of
+[`derivedStore`](#derivedstore) — is kept as-is, so derived values can be declared
+inline in the initial object.
 
-- `get(key)` — current value (through the deep-mutation proxy for objects/arrays).
+- `get(key)` — current (raw) value.
+- `touch(key)` — signal a deep mutation of `key`'s value (`store.get(key).push(x)`,
+  `store.get(key).field = y`, …); notifies adopters and subscribers.
 - `set(key, v)` — write, notifying every component that adopted `key` (batched per
   the normal microtask flush) and every `subscribe` listener (synchronously).
   Same-value writes are no-ops. Throws if `key` holds a derived (read-only) value.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ the exact contract, see the design docs linked at the bottom.
 Lunas has two halves:
 
 - a **compiler** written in Rust (a Cargo workspace under `crates/`), and
-- a **tiny, dependency-free JavaScript runtime** (`packages/lunas`, ES2015 + `Proxy`,
+- a **tiny, dependency-free JavaScript runtime** (`packages/lunas`, ES2015,
   no build step, no `BigInt`).
 
 The compiler does all the analysis; the runtime does almost no thinking at
@@ -145,7 +145,9 @@ Adjacency is plain arrays, so it has **no width limit and no overflow case**. Th
 compiler may specialize small components (≤ 31 reactive vars) to a single `number`
 bitmask for the smallest constant factor. `BigInt` is rejected outright: it is
 slower than `number` **and** raises the compatibility floor above the competition.
-The floor is `Proxy` (ES2015 / Safari 10+) — the same as Vue 3 / Svelte 5 / Solid.
+The reactive core is plain ES2015 getters/setters — no `Proxy` anywhere — so the
+floor is *below* Vue 3 / Svelte 5 / Solid, which all require `Proxy` for their
+reactivity.
 
 ### 6. Per-variable box specialization
 
@@ -155,7 +157,7 @@ lightest reactive cell:
 | Classification | Box | Cost |
 | --- | --- | --- |
 | Reassigned only (`x = …`) | [`box`](./api/reactivity.md#box) — plain getter/setter | lightest, no Proxy |
-| Deeply mutated (`arr.push`, `obj.k = …`) | [`deepBox`](./api/reactivity.md#deepbox) — `Proxy` sets the bit on mutation | Proxy only where needed |
+| Deeply mutated (`arr.push`, `obj.k = …`) | [`deepBox`](./api/reactivity.md#deepbox) — raw value; the compiler injects a `touch()`/`touchElem()` call after the mutation to set the bit | no Proxy; a deep mutation costs one bit-set |
 | Shared across components (prop passed down + mutated) | [`shared`](./api/reactivity.md#shared) — marks every dependent component | cross-component, no signals |
 
 Module-level state generalizes `shared` into a [store](./api/store.md): created
@@ -195,7 +197,7 @@ highlights (design doc §2 and §4):
 | Anchors = runtime text nodes | Keeps the static HTML comment-free (fast path) while still marking dynamic insertion points. |
 | Element refs = positional navigation | ~2× faster than `getElementById`, works on a detached tree, no id bytes or cleanup. |
 | Whitespace-free static HTML | Stable `childNodes` positions for nav, plus smaller output. |
-| Adjacency dispatch, `number`/`Uint32Array`, never `BigInt` | O(affected) flush, no width limit; keeps the compatibility floor at `Proxy` (ES2015). |
+| Adjacency dispatch, `number`/`Uint32Array`, never `BigInt` | O(affected) flush, no width limit; the reactive core stays plain ES2015 — no `Proxy`. |
 
 > The fast-path-parser penalty is a Blink characteristic; Gecko/WebKit were not
 > measured, so re-verify the comment penalty there before relying on it.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -70,7 +70,7 @@ shares Vue 3's template ergonomics (`:attr`, `@event`, `:if`/`:for`, slots,
 | DOM construction | bulk `innerHTML` of a static skeleton | incremental DOM ops | virtual DOM |
 | Runtime tracking | none (deps known at compile time) | signal graph | proxy graph |
 | Reactive authoring | mutate a top-level `let` | `$state` / runes | `ref` / `reactive` |
-| Compatibility floor | ES2015 + `Proxy` | modern | modern |
+| Compatibility floor | ES2015 (no Proxy) | modern | modern |
 
 What makes a variable reactive in Lunas is simply **mutating a top-level `let`**
 in your script. You write ordinary JavaScript; the compiler wires the

--- a/packages/lunas/README.md
+++ b/packages/lunas/README.md
@@ -2,7 +2,7 @@
 
 Dependency-free ES2015 runtime for [Lunas](https://github.com/lunasrun/lunas)-compiled
 components. Plain ESM, no build step, no dependencies. Compatibility floor:
-ES2015 + `Proxy` (no `BigInt`).
+ES2015 (no `Proxy`, no `BigInt`).
 
 This package is the runtime target that the Lunas compiler emits calls into —
 `bind`/`markVar`/`flush` for the reactive core, `box`/`deepBox`/`shared` for
@@ -67,7 +67,7 @@ main repo for the calling contract.
 | `endScope(c)` | `lunas/core` | Close the currently-open scope. |
 | `dropScope(c, scope)` | `lunas/core` | Unregister every bind collected in `scope` (recursively) and tear it down. |
 | `box(c, i, v)` | `lunas/boxes` | Reassign-only reactive cell (plain getter/setter, no Proxy). |
-| `deepBox(c, i, v)` | `lunas/boxes` | Deeply-mutated reactive cell (Proxy-wrapped nested reads/writes). |
+| `deepBox(c, i, v)` | `lunas/boxes` | Deeply-mutated reactive cell (raw value; the compiler injects `touch()`/`touchElem()` after a deep mutation to invalidate it — no Proxy). |
 | `shared(v)` | `lunas/boxes` | A value shared/mutated across multiple components. |
 | `computed(c, i, deps, fn)` | `lunas/computed` | Lazily-evaluated, memoized derived value. |
 | `watch(c, deps, cb, opts?)` | `lunas/watch` | Run `cb` when any of `deps` changes (optionally `immediate`). |

--- a/packages/lunas/src/boxes.mjs
+++ b/packages/lunas/src/boxes.mjs
@@ -1,15 +1,13 @@
 // boxes.mjs — per-variable reactive boxes, specialized by the compiler.
 // See output-design.md §4 "Per-variable box specialization".
 //
-// ES2015 + Proxy (the runtime's compatibility floor). No BigInt.
+// ES2015+. No Proxy, no BigInt. Deep mutation is made reactive by explicit
+// compiler-injected invalidation (`box.touch()` / `box.touchElem(el)`) emitted
+// right after each mutating statement — the Svelte-family model — instead of a
+// runtime Proxy intercepting every nested get/set. Reads return the RAW value,
+// so the hot path pays nothing.
 
 import { markVar } from "./core.mjs";
-
-// Marker to unwrap a fine-grained `:for` element proxy back to its raw target:
-// reading `proxy[RAW]` returns the underlying object. Kept for callers that hold
-// an element proxy and need stable raw identity (the forBlock itself iterates
-// the box's raw array directly and does not need it on the hot path).
-export const RAW = Symbol("lunas.raw");
 
 // box(c, i, v) — reassign-only variable at reactive index i.
 // Lightest path: plain getter/setter, no Proxy. Same-value writes are no-ops.
@@ -27,44 +25,58 @@ export function box(c, i, v) {
   };
 }
 
-// deepBox(c, i, v) — deeply-mutated variable (arr.push, obj.k = …).
-// Reads through .v return a Proxy that marks the variable dirty on any
-// nested set/delete. Nested objects are wrapped lazily on property access;
-// wrappers are cached per underlying object so identity is stable.
-// Mutating array methods (push/splice/…) work through the set trap because
-// they run with the proxy as `this`.
-// Map/Set (and WeakMap/WeakSet) values are collection-aware: reads and methods
-// run against the real collection (native internal slots reject a foreign
-// receiver), and mutating ops (Map set/delete/clear, Set add/delete/clear)
-// mark the variable dirty. Values stored inside a collection are not deeply
-// wrapped — reassign an entry to make a change reactive.
+// deepBox(c, i, v) — deeply-mutated variable (arr.push, obj.k = …, nested
+// field writes, Map/Set mutations).
 //
-// Fine-grained `:for` tracking (opt-in): a deepBox used as a `:for` source can
-// have a `forBlock` attach itself via `box.observeElems()`. Once observed, the
-// box records — between flushes — whether the mutation was STRUCTURAL (a write
-// on the array itself: `arr[i] = x`, `arr.length = n`, `push`/`splice`/…, or a
-// whole-value reassign `box.v = x`) or a pure ELEMENT-FIELD write (a nested
-// mutation of an object that is a direct element of the array, e.g.
-// `arr[i].label = x`). Both still `markVar` so every dependent flushes; the
-// forBlock consults `box._struct` / `box._elems` to patch just the touched
-// items instead of running a full reconcile when nothing structural changed.
+// Proxy-free (Svelte-family model): `.v` returns the RAW value, so reads are as
+// cheap as a plain `box`. Deep mutation is made reactive by an explicit
+// invalidation call the compiler injects immediately after each mutating
+// statement:
+//   - `box.touch()`       — a STRUCTURAL deep mutation (`arr.push(x)`,
+//                           `arr[i] = y`, `arr.length = n`, `obj.k = v`,
+//                           `delete obj.k`, Map/Set `set/add/delete/clear`, or a
+//                           whole-value reassign — the setter marks that one).
+//   - `box.touchElem(el)` — an ELEMENT-FIELD mutation of a direct array element
+//                           (`arr[i].label = x`): `el` is the mutated element.
+// Both call `markVar`, so every dependent flushes. `markVar` defers the flush to
+// a microtask, so it does not matter that the touch runs before the mutation
+// completes within the same synchronous statement.
+//
+// Fine-grained `:for` tracking (opt-in): a deepBox used as a `:for` source has
+// a `forBlock` attach via `box.observeElems()`. Once observed, the box records —
+// between flushes — whether a STRUCTURAL change occurred (`touch()` / reassign)
+// or only ELEMENT-FIELD writes (`touchElem(el)`), so the forBlock can patch just
+// the touched items instead of a full reconcile. This is the same `_struct` /
+// `_elems` contract the Proxy version exposed; only the source of the signal
+// changed (explicit calls, not trap interception).
 export function deepBox(c, i, v) {
   const notify = () => markVar(c, i);
-  // Fine-grained state (null until a forBlock opts in via observeElems()).
   const self = {
     get v() {
-      return px;
+      return v;
     },
     set v(x) {
       if (x !== v) {
         v = x;
-        if (self._track) {
-          self._struct = true; // whole-value reassign is structural
-          wrap.markRoot(x);
-        }
-        px = wrap(x);
+        if (self._track) self._struct = true; // whole-value reassign is structural
         notify();
       }
+    },
+    // touch() — a structural deep mutation happened on the current value.
+    // Returns the raw value so a compiler-injected `(box.touch(), expr)` prefix
+    // never disturbs the surrounding expression's own value.
+    touch() {
+      if (self._track) self._struct = true;
+      notify();
+      return v;
+    },
+    // touchElem(el) — a field of the direct array element `el` was mutated.
+    // Records `el` for fine-grained patching (when observed) and marks dirty.
+    // Returns `el` so it composes in a comma-prefixed injection.
+    touchElem(el) {
+      if (self._elems) self._elems.add(el);
+      notify();
+      return el;
     },
     // --- fine-grained :for support (all no-cost until observeElems runs) ---
     _track: false, // observing element-field vs structural changes
@@ -73,12 +85,7 @@ export function deepBox(c, i, v) {
     observeElems() {
       if (!this._track) {
         this._track = true;
-        fineHooks.active = true;
         this._elems = new Set();
-        // Register the current root array so its own mutations are structural,
-        // then re-wrap so reads populate owner attribution.
-        wrap.markRoot(v);
-        px = wrap(v);
       }
       return this;
     },
@@ -86,183 +93,12 @@ export function deepBox(c, i, v) {
       this._struct = false;
       if (this._elems) this._elems.clear();
     },
-    // The underlying RAW current value (the unwrapped array). forBlock iterates
-    // this for keying/patching so the hot reconcile path never reads through the
-    // element proxies; field-write detection still runs when USER code mutates
-    // via `.v` (the proxy).
+    // The RAW current value. forBlock iterates this for keying/patching.
     _raw() {
       return v;
     },
   };
-  const fineHooks = {
-    active: false,
-    onStruct() {
-      self._struct = true;
-      notify();
-    },
-    onElem(rawEl) {
-      if (self._elems) self._elems.add(rawEl);
-      notify();
-    },
-  };
-  const wrap = makeWrap(notify, fineHooks);
-  let px = wrap(v);
   return self;
-}
-
-// makeWrap(notify) — build a lazy, cached deep-Proxy wrapper that calls
-// `notify` on any nested set/delete. Exported so other modules that need the
-// same "deeply-mutated value" semantics (e.g. store.mjs's per-field deep
-// mutation support) don't have to reimplement the Proxy handler.
-//
-// Collections (Map/Set) get a dedicated get-trap path: their accessors and
-// methods have internal slots ([[MapData]]/[[SetData]]) that reject a foreign
-// receiver, so we must run them against the REAL target rather than the proxy.
-// Mutating collection methods (Map set/delete/clear, Set add/delete/clear) are
-// wrapped to perform the op then `notify()`, so bindings that read the
-// collection (`.size`, `.get`, iteration, `.has`, …) re-run. Reads never mark.
-//
-// Values stored inside a Map/Set are NOT deeply wrapped: only collection-level
-// membership mutations are reactive. Mutating an object retrieved from a
-// collection (`map.get(k).field = …`) does not mark the box — reassign the
-// entry (`map.set(k, next)`) to trigger reactivity. Keeping values raw avoids
-// proxy-identity hazards with `has`/`get`/key lookups and keeps semantics
-// honest and simple.
-export function makeWrap(notify, fine) {
-  const cache = new WeakMap(); // raw object -> proxy
-  // Fine-grained :for tracking (optional, `fine` present). When active, the
-  // ROOT array proxy's own mutations route to fine.onStruct() (structural), and
-  // a nested field write attributes to the direct array element it lives under,
-  // via fine.onElem(rawElement). Owner attribution uses a single WeakMap
-  // (raw subtree object -> owning array element), populated on read, so the
-  // hot get/set traps stay MONOMORPHIC (one shared handler, no per-element
-  // handler allocation) — matching the non-fine cost as closely as possible.
-  // `fine` is a live hooks object with a mutable `active` flag (false until a
-  // forBlock calls observeElems). While inactive the traps behave exactly like
-  // the non-fine path — one boolean read of overhead — so deepBoxes not used as
-  // a fine `:for` source pay essentially nothing.
-  const owners = fine ? new WeakMap() : null; // raw obj -> raw owning element
-  const roots = fine ? new WeakSet() : null; // the diffed root array(s)
-
-  const handler = {
-    get(t, k, r) {
-      // `proxy[RAW]` unwraps to the raw target in every mode. This is also what
-      // keeps `wrap` idempotent: a value that is already one of our proxies is
-      // detected via its RAW marker and returned as-is instead of being wrapped
-      // again. Without this, code that reads elements out through the proxy and
-      // stores them back (e.g. a `:for` swap doing `r = arr.slice(); arr = r`)
-      // would grow a fresh proxy layer on every update — an O(depth) read cost
-      // that compounds into super-linear churn.
-      if (k === RAW) return t;
-      if (fine && fine.active) {
-        const val = Reflect.get(t, k, r);
-        if (val === null || typeof val !== "object") return val;
-        if (roots.has(t)) {
-          if (typeof k !== "symbol") owners.set(val, val); // direct element owns itself
-        } else {
-          const o = owners.get(t);
-          if (o !== undefined && !owners.has(val)) owners.set(val, o);
-        }
-        return wrap(val);
-      }
-      const val = Reflect.get(t, k, r);
-      return val !== null && typeof val === "object" ? wrap(val) : val;
-    },
-    set(t, k, x, r) {
-      const had = k in t;
-      const old = t[k];
-      const ok = Reflect.set(t, k, x, r);
-      if (ok && (!had || old !== x)) {
-        if (fine && fine.active) {
-          if (roots.has(t)) fine.onStruct();
-          else {
-            const o = owners.get(t);
-            if (o !== undefined) fine.onElem(o);
-            else notify();
-          }
-        } else notify();
-      }
-      return ok;
-    },
-    deleteProperty(t, k) {
-      const had = k in t;
-      const ok = Reflect.deleteProperty(t, k);
-      if (ok && had) {
-        if (fine && fine.active) {
-          if (roots.has(t)) fine.onStruct();
-          else {
-            const o = owners.get(t);
-            if (o !== undefined) fine.onElem(o);
-            else notify();
-          }
-        } else notify();
-      }
-      return ok;
-    },
-  };
-  // Collection handler: bind everything to the real target so native internal
-  // slots accept the receiver; wrap mutators to notify after the op.
-  const collectionHandler = {
-    get(t, k) {
-      if (k === RAW) return t; // keep wrap idempotent for collection proxies too
-      const val = Reflect.get(t, k, t);
-      if (typeof val !== "function") return val;
-      if (MUTATORS.has(k) && MUTATORS.get(k)(t)) {
-        return function (...args) {
-          const ret = val.apply(t, args);
-          notify();
-          return ret;
-        };
-      }
-      // Non-mutating method (get/has/forEach/keys/values/entries/…): bind so
-      // the native internal-slot check sees the real collection as receiver.
-      return val.bind(t);
-    },
-  };
-  const wrap = (val) => {
-    if (val === null || typeof val !== "object") return val;
-    // Idempotence: if `val` is already one of OUR proxies, `val[RAW]` returns
-    // its raw target (the get trap intercepts RAW). Re-wrapping would stack a
-    // new proxy layer every time, so wrap the underlying raw object instead —
-    // it's already cached under that key, so this collapses back to the
-    // canonical single-layer proxy for the object.
-    const raw = val[RAW];
-    if (raw !== undefined) val = raw;
-    let px = cache.get(val);
-    if (!px) {
-      px = new Proxy(val, isCollection(val) ? collectionHandler : handler);
-      cache.set(val, px);
-    }
-    return px;
-  };
-  // markRoot(rawArray) — register the diffed root array so its own mutations are
-  // structural. Called by the box for the current `.v` value (fine mode only).
-  wrap.markRoot = (val) => {
-    if (roots && val !== null && typeof val === "object") roots.add(val);
-  };
-  return wrap;
-}
-
-// Mutating collection method names -> predicate that reports whether the method
-// is truly mutating on THIS target. `delete` and `clear` are shared names
-// across Map/Set (both mutate); `set` mutates on Map but is a WeakSet non-op /
-// absent elsewhere, and `add` mutates on Set/WeakSet. The predicate guards
-// against, e.g., a `set` key on an unrelated wrapped object slipping through —
-// though collectionHandler only ever wraps real Map/Set/WeakMap/WeakSet.
-const MUTATORS = new Map([
-  ["set", (t) => t instanceof Map || t instanceof WeakMap],
-  ["add", (t) => t instanceof Set || t instanceof WeakSet],
-  ["delete", () => true],
-  ["clear", () => true],
-]);
-
-function isCollection(v) {
-  return (
-    v instanceof Map ||
-    v instanceof Set ||
-    v instanceof WeakMap ||
-    v instanceof WeakSet
-  );
 }
 
 // prop(c, i, raw, def) — adopt an `@input` prop as a reactive variable at

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -25,8 +25,17 @@ export function createContext(root) {
     post: null,
     parent: null,
     onUpdate: null,
+    depth: 0, // consecutive self-triggered flush passes (runaway-loop guard)
   };
 }
+
+// Cap on consecutive flush passes that re-trigger themselves. A reactive effect
+// that mutates a dependency it reads would otherwise schedule an unbounded chain
+// of microtask flushes and hang the page. With proxy-free deep reactivity a
+// convergent nested write no longer self-limits via an old===new guard (touch()
+// is unconditional), so this bound is what stops a runaway loop — the same
+// safeguard Vue applies (its "Maximum recursive updates" limit).
+const MAX_FLUSH_DEPTH = 100;
 
 // bind(c, deps, fn) — register an update function that reads the reactive
 // variable indices in `deps`. Runs fn once immediately (correct first paint,
@@ -78,6 +87,25 @@ export function flush(c) {
   if (post) {
     c.post = null;
     for (const cb of post) cb();
+  }
+  // Runaway-loop guard: if this pass re-triggered itself (an effect mutated a
+  // dependency it reads and scheduled another flush), bound the consecutive
+  // self-triggered passes. Resets the moment a pass settles without re-arming.
+  if (c.pending) {
+    if (++c.depth > MAX_FLUSH_DEPTH) {
+      c.pending = false;
+      c.queue = [];
+      c.depth = 0;
+      if (typeof console !== "undefined" && console.warn) {
+        console.warn(
+          "[lunas] update loop aborted after " +
+            MAX_FLUSH_DEPTH +
+            " self-triggered passes — a reactive effect keeps mutating a dependency it reads."
+        );
+      }
+    }
+  } else {
+    c.depth = 0;
   }
 }
 

--- a/packages/lunas/src/core.mjs
+++ b/packages/lunas/src/core.mjs
@@ -25,23 +25,26 @@ export function createContext(root) {
     post: null,
     parent: null,
     onUpdate: null,
-    depth: 0, // consecutive self-triggered flush passes (runaway-loop guard)
+    gen: 0, // current flush-burst id (runaway-loop guard; see flush)
   };
 }
 
-// Cap on consecutive flush passes that re-trigger themselves. A reactive effect
-// that mutates a dependency it reads would otherwise schedule an unbounded chain
-// of microtask flushes and hang the page. With proxy-free deep reactivity a
-// convergent nested write no longer self-limits via an old===new guard (touch()
-// is unconditional), so this bound is what stops a runaway loop — the same
-// safeguard Vue applies (its "Maximum recursive updates" limit).
+// Cap on how many times a SINGLE effect may re-run within one flush burst. A
+// reactive effect that mutates a dependency it reads would otherwise schedule an
+// unbounded chain of microtask flushes and hang the page. With proxy-free deep
+// reactivity a convergent nested write no longer self-limits via an old===new
+// guard (touch() is unconditional), so this per-effect bound is what stops a
+// runaway loop — the same safeguard Vue applies (its "Maximum recursive updates"
+// limit), counted per effect so a long chain of distinct effects is not aborted.
 const MAX_FLUSH_DEPTH = 100;
 
 // bind(c, deps, fn) — register an update function that reads the reactive
 // variable indices in `deps`. Runs fn once immediately (correct first paint,
 // no flush needed). Returns the bind record (needed for unbind).
 export function bind(c, deps, fn) {
-  const s = { fn, q: false, alive: true, deps };
+  // `runs`/`gen` power the runaway-loop guard (see flush): how many times this
+  // record has run within the current flush burst `c.gen`.
+  const s = { fn, q: false, alive: true, deps, runs: 0, gen: -1 };
   fn();
   for (const i of deps) (c.deps[i] || (c.deps[i] = [])).push(s);
   if (c.scope) c.scope.subs.push(s);
@@ -76,7 +79,23 @@ export function flush(c) {
   const ran = q.length > 0;
   for (const s of q) {
     s.q = false;
-    if (s.alive) s.fn();
+    if (s.alive) {
+      // Runaway-loop guard (per effect). A burst is one chain of self-triggered
+      // flushes, tagged by `c.gen`; within it we count how many times THIS record
+      // has run. A distinct-effect cascade runs each record ~once, so it never
+      // trips — only an effect that keeps re-marking a dependency it reads does.
+      // Counting per record (not per pass) is why a long legitimate chain is not
+      // falsely aborted.
+      if (s.gen !== c.gen) {
+        s.gen = c.gen;
+        s.runs = 0;
+      }
+      if (++s.runs > MAX_FLUSH_DEPTH) {
+        abortBurst(c, q);
+        return;
+      }
+      s.fn();
+    }
   }
   // onUpdate (lifecycle.mjs) — a lightweight per-context post-update hook that
   // fires only when an update pass actually ran, distinct from the one-shot
@@ -88,24 +107,30 @@ export function flush(c) {
     c.post = null;
     for (const cb of post) cb();
   }
-  // Runaway-loop guard: if this pass re-triggered itself (an effect mutated a
-  // dependency it reads and scheduled another flush), bound the consecutive
-  // self-triggered passes. Resets the moment a pass settles without re-arming.
-  if (c.pending) {
-    if (++c.depth > MAX_FLUSH_DEPTH) {
-      c.pending = false;
-      c.queue = [];
-      c.depth = 0;
-      if (typeof console !== "undefined" && console.warn) {
-        console.warn(
-          "[lunas] update loop aborted after " +
-            MAX_FLUSH_DEPTH +
-            " self-triggered passes — a reactive effect keeps mutating a dependency it reads."
-        );
-      }
-    }
-  } else {
-    c.depth = 0;
+  // Burst settled (nothing re-armed a flush): start a fresh generation so the
+  // next, unrelated burst counts run-depth from zero.
+  if (!c.pending) c.gen++;
+}
+
+// abortBurst(c, q) — tear down a runaway update loop cleanly. Clears every queued
+// record's `q` flag on BOTH the in-flight queue and any records re-enqueued
+// during this pass (so innocent effects sharing a dependency are not left
+// permanently un-queueable), drops pending post callbacks (afterFlush/nextTick,
+// which could otherwise perpetuate the loop), disarms the pending flush, and
+// bumps the generation. A dev warning names the cause.
+function abortBurst(c, q) {
+  for (const s of q) s.q = false;
+  for (const s of c.queue) s.q = false;
+  c.queue = [];
+  c.post = null;
+  c.pending = false;
+  c.gen++;
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn(
+      "[lunas] update loop aborted after " +
+        MAX_FLUSH_DEPTH +
+        " self-triggered passes — a reactive effect keeps mutating a dependency it reads."
+    );
   }
 }
 

--- a/packages/lunas/src/store.mjs
+++ b/packages/lunas/src/store.mjs
@@ -9,10 +9,11 @@
 // subscribable; a write to one field only marks dirty the components that
 // adopted *that* field.
 //
-// ES2015 + Proxy (the runtime's compatibility floor). No BigInt.
+// ES2015+. No Proxy, no BigInt: deep field mutation is made reactive by an
+// explicit compiler-injected `store.touch(key)` after each mutating statement,
+// the same model as boxes.mjs's deepBox.
 
 import { markVar } from "./core.mjs";
-import { makeWrap } from "./boxes.mjs";
 
 // isField(x) — true for anything shaped like a storeField/derivedStore
 // output (attach/detach/subscribe). Lets createStore accept a derivedStore
@@ -29,9 +30,10 @@ function isField(x) {
 
 // storeField(v) — one named slot of a store. Shaped like boxes.mjs's
 // `shared`: `.v` get/set, `attach(c, i)` / `detach(c)` for component adoption,
-// PLUS deep-mutation support (object/array values are lazily Proxy-wrapped,
-// same cached-wrapper strategy as deepBox) and a `subscribe(fn)` for plain-JS
-// consumers that are not component contexts at all (router, devtools, tests).
+// PLUS deep-mutation support (proxy-free: `.v` returns the raw value and a
+// mutation is made reactive by an explicit `touch()` the compiler injects) and
+// a `subscribe(fn)` for plain-JS consumers that are not component contexts at
+// all (router, devtools, tests).
 //
 // Returns [field, notify]: `notify(value?)` is kept internal to this module
 // (used directly by derivedStore to signal its own subscribers without a
@@ -47,19 +49,24 @@ function storeField(v) {
     for (const s of subs) markVar(s.c, s.i);
     for (const fn of listeners) fn(value.length ? value[0] : v);
   };
-  const wrap = makeWrap(notify);
-  let px = wrap(v);
 
   const field = {
     get v() {
-      return px;
+      return v;
     },
     set v(x) {
       if (x !== v) {
         v = x;
-        px = wrap(x);
         notify();
       }
+    },
+    // touch() — a deep mutation happened on this field's current value
+    // (`store.get(k).push(x)`, `store.get(k).f = y`, …). Marks every adopter
+    // and notifies plain-JS subscribers, same as a write. Returns the raw
+    // value so a compiler-injected `(field.touch(), expr)` prefix is transparent.
+    touch() {
+      notify();
+      return v;
     },
     // attach(c, i) — adopt this field at component context `c`'s reactive
     // index `i`: from now on, writes to this field mark index `i` dirty in
@@ -117,6 +124,14 @@ export function createStore(initial) {
     // holds a derived (read-only) value.
     set(key, v) {
       field(key).v = v;
+    },
+    // touch(key) — signal a deep mutation of `key`'s current value (the
+    // compiler injects this after `store.get(key)....` mutating statements,
+    // mirroring deepBox.touch()). Notifies adopters and subscribers. Returns
+    // the field's raw value so `(store.touch(key), expr)` stays transparent.
+    touch(key) {
+      const f = field(key);
+      return f.touch ? f.touch() : f.v;
     },
     // subscribe(key, fn) — outside-component subscription for plain-JS
     // consumers (router, devtools, tests). `fn(value)` runs synchronously on

--- a/packages/lunas/test/blocks-compiled.test.mjs
+++ b/packages/lunas/test/blocks-compiled.test.mjs
@@ -100,12 +100,14 @@ await test("forBlock html/wire: push appends, reorder moves same nodes, patch re
   const [n1, n2] = [parent.childNodes[0], parent.childNodes[1]];
 
   list.v.push({ id: 3, txt: "c" });
+  list.touch();
   await tick();
   assert.strictEqual(parent.childNodes.length, 4);
   assert.strictEqual(parent.childNodes[0], n1, "no rebuild on append");
   assert.strictEqual(parent.childNodes[2].outerHTML, "<li>c</li>");
 
   list.v.reverse();
+  list.touch();
   await tick();
   assert.strictEqual(parent.childNodes[0].outerHTML, "<li>c</li>");
   assert.strictEqual(parent.childNodes[1], n2, "same node object moved");
@@ -113,6 +115,7 @@ await test("forBlock html/wire: push appends, reorder moves same nodes, patch re
 
   // patch: same key, new data — node reused, text refreshed via runScope
   list.v[2] = { id: 1, txt: "A!" };
+  list.touch();
   await tick();
   assert.strictEqual(parent.childNodes[2], n1, "patched in place");
   assert.strictEqual(parent.childNodes[2].outerHTML, "<li>A!</li>");

--- a/packages/lunas/test/blocks.test.mjs
+++ b/packages/lunas/test/blocks.test.mjs
@@ -354,6 +354,7 @@ await test("forBlock initial render + reorder reuses nodes via reconciler", asyn
   const before = parent.childNodes.slice(0, 3);
 
   list.v.reverse();
+  list.touch();
   await tick();
   assert.strictEqual(shape(parent), "c b a |");
   assert.strictEqual(makes, 3, "reorder created no new nodes");

--- a/packages/lunas/test/boxes.collections.test.mjs
+++ b/packages/lunas/test/boxes.collections.test.mjs
@@ -1,7 +1,8 @@
 // boxes.collections.test.mjs — deepBox reactivity for native Map/Set (and
-// no-throw handling of WeakMap/WeakSet). Covers the MED-severity fix where the
-// generic deepBox Proxy handler threw "incompatible receiver" on Map/Set
-// accessors, and makes membership mutations (set/add/delete/clear) reactive.
+// no-throw handling of WeakMap/WeakSet). deepBox is proxy-free: `.v` returns the
+// raw collection, so accessors/methods run natively (no incompatible-receiver
+// hazard), and a membership mutation (set/add/delete/clear) is made reactive by
+// the compiler-injected `.touch()` that follows it — asserted here explicitly.
 // Run: node packages/lunas/test/boxes.collections.test.mjs
 
 import assert from "node:assert";
@@ -53,8 +54,9 @@ await test("Map: set() is reactive — a bind reading .size re-runs", async () =
   bind(c, [0], () => sizes.push(d.v.size));
   assert.deepStrictEqual(sizes, [0], "initial bind run");
   d.v.set("a", 1);
+  d.touch();
   await tick();
-  assert.deepStrictEqual(sizes, [0, 1], "set marks the var dirty");
+  assert.deepStrictEqual(sizes, [0, 1], "set + touch marks the var dirty");
 });
 
 await test("Map: set() to an existing key still notifies (value may have changed)", async () => {
@@ -63,6 +65,7 @@ await test("Map: set() to an existing key still notifies (value may have changed
   const values = [];
   bind(c, [0], () => values.push(d.v.get("a")));
   d.v.set("a", 2);
+  d.touch();
   await tick();
   assert.deepStrictEqual(values, [1, 2], "re-set of a key re-runs the bind");
 });
@@ -73,6 +76,7 @@ await test("Map: delete() is reactive", async () => {
   const sizes = [];
   bind(c, [0], () => sizes.push(d.v.size));
   const removed = d.v.delete("a");
+  d.touch();
   assert.strictEqual(removed, true, "delete returns the native boolean");
   await tick();
   assert.deepStrictEqual(sizes, [1, 0]);
@@ -84,6 +88,7 @@ await test("Map: clear() is reactive", async () => {
   const sizes = [];
   bind(c, [0], () => sizes.push(d.v.size));
   d.v.clear();
+  d.touch();
   await tick();
   assert.deepStrictEqual(sizes, [2, 0]);
 });
@@ -92,7 +97,7 @@ await test("Map: chained set() returns the Map (native contract preserved)", () 
   const c = createContext(null);
   const d = deepBox(c, 0, new Map());
   const ret = d.v.set("a", 1);
-  // Native Map.set returns the map itself; our wrapper returns the raw target.
+  // `.v` is the raw Map, so native Map.set returns the map itself.
   assert.strictEqual(ret.get("a"), 1);
   assert.strictEqual(ret.size, 1);
 });
@@ -121,6 +126,7 @@ await test("Set: add() is reactive", async () => {
   const sizes = [];
   bind(c, [0], () => sizes.push(d.v.size));
   d.v.add(1);
+  d.touch();
   await tick();
   assert.deepStrictEqual(sizes, [0, 1]);
 });
@@ -131,9 +137,11 @@ await test("Set: delete() and clear() are reactive", async () => {
   const sizes = [];
   bind(c, [0], () => sizes.push(d.v.size));
   d.v.delete(1);
+  d.touch();
   await tick();
   assert.deepStrictEqual(sizes, [2, 1]);
   d.v.clear();
+  d.touch();
   await tick();
   assert.deepStrictEqual(sizes, [2, 1, 0]);
 });
@@ -156,8 +164,9 @@ await test("Map nested in a deepBox'd object: reads work and mutations mark dirt
   bind(c, [0], () => sizes.push(d.v.tags.size));
   assert.deepStrictEqual(sizes, [1], "nested Map .size reads without throwing");
   d.v.tags.set("y", 2);
+  d.touch();
   await tick();
-  assert.deepStrictEqual(sizes, [1, 2], "nested Map mutation marks the outer var");
+  assert.deepStrictEqual(sizes, [1, 2], "nested Map mutation + touch marks the outer var");
 });
 
 await test("Set nested in a deepBox'd object: mutations mark dirty", async () => {
@@ -166,14 +175,17 @@ await test("Set nested in a deepBox'd object: mutations mark dirty", async () =>
   const sizes = [];
   bind(c, [0], () => sizes.push(d.v.ids.size));
   d.v.ids.add(2);
+  d.touch();
   await tick();
   assert.deepStrictEqual(sizes, [1, 2]);
 });
 
-await test("nested Map wrapper identity is stable across property reads", () => {
+await test("nested Map identity is stable across property reads (raw)", () => {
   const c = createContext(null);
-  const d = deepBox(c, 0, { m: new Map() });
-  assert.strictEqual(d.v.m, d.v.m, "same underlying Map -> same proxy");
+  const m = new Map();
+  const d = deepBox(c, 0, { m });
+  assert.strictEqual(d.v.m, d.v.m, "same underlying Map");
+  assert.strictEqual(d.v.m, m, "the raw Map itself, not a proxy");
 });
 
 // ---------------------------------------------------------------------------
@@ -216,6 +228,7 @@ await test("WeakMap mutation still notifies (collection-level, best-effort)", as
   const seen = [];
   bind(c, [0], () => seen.push(d.v.has(key)));
   d.v.set(key, 1);
+  d.touch();
   await tick();
   assert.deepStrictEqual(seen, [false, true]);
 });
@@ -230,6 +243,7 @@ await test("regression: object property set through deepBox still marks dirty", 
   const seen = [];
   bind(c, [0], () => seen.push(d.v.a));
   d.v.a = 2;
+  d.touch();
   await tick();
   assert.deepStrictEqual(seen, [1, 2]);
 });
@@ -240,14 +254,16 @@ await test("regression: array push/splice through deepBox still marks dirty", as
   const lens = [];
   bind(c, [0], () => lens.push(d.v.length));
   d.v.push(3);
+  d.touch();
   await tick();
   assert.deepStrictEqual(lens, [2, 3]);
   d.v.splice(0, 1);
+  d.touch();
   await tick();
   assert.deepStrictEqual(lens, [2, 3, 2]);
 });
 
-await test("regression: nested object wrapper identity stays stable", () => {
+await test("regression: nested object identity stays stable (raw)", () => {
   const c = createContext(null);
   const d = deepBox(c, 0, { user: { name: "a" } });
   assert.strictEqual(d.v.user, d.v.user);

--- a/packages/lunas/test/boxes.deep.test.mjs
+++ b/packages/lunas/test/boxes.deep.test.mjs
@@ -6,7 +6,7 @@
 
 import assert from "node:assert";
 import { createContext, bind } from "../src/core.mjs";
-import { box, deepBox, shared, RAW } from "../src/boxes.mjs";
+import { box, deepBox, shared } from "../src/boxes.mjs";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -144,11 +144,12 @@ await test("deepBox: deeply nested (3+ levels) mutation triggers", async () => {
   });
   assert.strictEqual(val, 1);
   d.v.a.b.c.d = 2;
+  d.touch(); // deep nested field write -> compiler-injected structural touch
   await tick();
   assert.strictEqual(val, 2);
 });
 
-await test("deepBox: array of objects, mutating an element's field triggers", async () => {
+await test("deepBox: array of objects, mutating an element's field triggers (touchElem)", async () => {
   const c = createContext(null);
   const d = deepBox(c, 0, [{ n: 1 }, { n: 2 }]);
   let total;
@@ -157,6 +158,7 @@ await test("deepBox: array of objects, mutating an element's field triggers", as
   });
   assert.strictEqual(total, 3);
   d.v[0].n = 10;
+  d.touchElem(d.v[0]); // element-field mutation of a direct array element
   await tick();
   assert.strictEqual(total, 12);
 });
@@ -169,9 +171,11 @@ await test("deepBox: sort() and reverse() both trigger and produce correct order
     snap = Array.from(d.v);
   });
   d.v.sort();
+  d.touch();
   await tick();
   assert.deepStrictEqual(snap, [1, 2, 3]);
   d.v.reverse();
+  d.touch();
   await tick();
   assert.deepStrictEqual(snap, [3, 2, 1]);
 });
@@ -184,9 +188,11 @@ await test("deepBox: shift() and unshift() both trigger", async () => {
     snap = Array.from(d.v);
   });
   d.v.unshift(0);
+  d.touch();
   await tick();
   assert.deepStrictEqual(snap, [0, 1, 2, 3]);
   d.v.shift();
+  d.touch();
   await tick();
   assert.deepStrictEqual(snap, [1, 2, 3]);
 });
@@ -199,6 +205,7 @@ await test("deepBox: pop() triggers and returns the removed element", async () =
     snap = Array.from(d.v);
   });
   const popped = d.v.pop();
+  d.touch();
   assert.strictEqual(popped, 3);
   await tick();
   assert.deepStrictEqual(snap, [1, 2]);
@@ -212,6 +219,7 @@ await test("deepBox: length truncation (arr.length = n) triggers", async () => {
     snap = Array.from(d.v);
   });
   d.v.length = 2;
+  d.touch();
   await tick();
   assert.deepStrictEqual(snap, [1, 2]);
 });
@@ -240,21 +248,23 @@ await test("deepBox: whole-value replace with the same reference is a no-op", as
   assert.strictEqual(runs, 1, "x === v guard applies to deepBox's raw value too");
 });
 
-await test("deepBox: proxy identity stable across repeated reads of the same nested path", () => {
+await test("deepBox: nested value identity is stable across repeated reads (raw, uncached)", () => {
   const c = createContext(null);
-  const d = deepBox(c, 0, { list: [1, 2, 3] });
-  assert.strictEqual(d.v.list, d.v.list, "nested array wrapper is cached, not rebuilt per read");
+  const list = [1, 2, 3];
+  const d = deepBox(c, 0, { list });
+  assert.strictEqual(d.v.list, d.v.list, "reads return the same raw nested value");
+  assert.strictEqual(d.v.list, list, "no proxy wrapper — the raw array itself");
 });
 
-await test("deepBox: proxy identity differs after whole-value replacement", () => {
+await test("deepBox: value identity differs after whole-value replacement", () => {
   const c = createContext(null);
   const d = deepBox(c, 0, { a: 1 });
   const first = d.v;
   d.v = { a: 1 }; // different underlying object, deep-equal but not ===
-  assert.notStrictEqual(d.v, first, "new raw object -> freshly wrapped proxy");
+  assert.notStrictEqual(d.v, first, "new raw object after reassign");
 });
 
-await test("deepBox: delete on a nested (not top-level) key triggers", async () => {
+await test("deepBox: delete on a nested (not top-level) key triggers via touch", async () => {
   const c = createContext(null);
   const d = deepBox(c, 0, { outer: { a: 1, b: 2 } });
   let keys;
@@ -263,41 +273,43 @@ await test("deepBox: delete on a nested (not top-level) key triggers", async () 
   });
   assert.strictEqual(keys, "a,b");
   delete d.v.outer.b;
+  d.touch();
   await tick();
   assert.strictEqual(keys, "a");
 });
 
-await test("deepBox: deleting a non-existent key does not trigger (had=false guard)", async () => {
+await test("deepBox: a deep mutation without an injected touch does NOT notify (proxy-free)", async () => {
+  // Documents the new contract: reactivity for a deep mutation comes from the
+  // compiler-injected touch(), not a runtime Proxy. A bare nested write that is
+  // never followed by touch() is invisible to dependents (the compiler always
+  // emits the touch in real components).
   const c = createContext(null);
   const d = deepBox(c, 0, { a: 1 });
   let runs = 0;
   bind(c, [0], () => runs++);
-  delete d.v.doesNotExist;
+  d.v.a = 2; // mutated the raw value, but no touch()
   await tick();
-  assert.strictEqual(runs, 1, "no spurious flush for deleting an absent key");
+  assert.strictEqual(runs, 1, "no flush without an explicit touch()");
+  d.touch(); // now signal it
+  await tick();
+  assert.strictEqual(runs, 2, "touch() delivers the pending mutation");
 });
 
-await test("deepBox: setting a nested field to NaN always triggers (NaN !== NaN check inside the proxy set trap)", async () => {
-  const c = createContext(null);
-  const d = deepBox(c, 0, { n: NaN });
-  let runs = 0;
-  bind(c, [0], () => runs++);
-  d.v.n = NaN;
-  await tick();
-  assert.strictEqual(runs, 2, "nested NaN write always reports as changed");
-});
-
-await test("deepBox: setting a nested field to the SAME primitive value is a no-op", async () => {
+await test("deepBox: touch() always notifies, even for a same-value nested write", async () => {
+  // Unlike the old Proxy set trap (which had an old===new guard), the injected
+  // touch() is unconditional — the compiler cannot cheaply prove a mutation was
+  // a no-op, so a deep write always flushes dependents (Svelte-family behavior).
   const c = createContext(null);
   const d = deepBox(c, 0, { n: 5 });
   let runs = 0;
   bind(c, [0], () => runs++);
   d.v.n = 5;
+  d.touch();
   await tick();
-  assert.strictEqual(runs, 1, "old === new for a primitive -> proxy set trap skips notify");
+  assert.strictEqual(runs, 2, "touch() notifies unconditionally");
 });
 
-await test("deepBox: primitive (non-object) values pass through the wrapper untouched", () => {
+await test("deepBox: primitive (non-object) values pass through untouched", () => {
   const c = createContext(null);
   const d = deepBox(c, 0, 42);
   assert.strictEqual(d.v, 42);
@@ -324,61 +336,51 @@ await test("deepBox: Map accessors/methods work through the collection-aware han
 });
 
 // ---------------------------------------------------------------------------
-// wrap idempotence: reading elements out through the proxy and storing them
-// back (the keyed `:for` swap: r = arr.slice(); reorder; arr = r) must NOT
-// stack a new proxy layer per update. Without idempotence this compounded into
-// super-linear read cost. Guard: RAW always unwraps one layer to the SAME raw
-// object no matter how many read/store cycles happened, and element proxy
-// identity stays stable across cycles.
+// Raw element identity: reads return the raw elements directly (no proxy
+// wrapping), so a keyed `:for` swap (r = arr.slice(); reorder; arr = r) never
+// accumulates proxy layers — there are no proxies at all. Element identity is
+// just object identity, stable by construction across read/store cycles.
 // ---------------------------------------------------------------------------
-await test("deepBox: proxy wrap is idempotent across read-and-store cycles (no proxy stacking)", async () => {
+await test("deepBox: reads return raw elements; identity is stable across read-and-store cycles", async () => {
   const c = createContext(null);
   const raw0 = { id: 1 };
   const d = deepBox(c, 0, [raw0, { id: 2 }, { id: 3 }]);
-  d.observeElems(); // fine mode — the path that used to stack proxies
+  d.observeElems(); // fine mode
 
-  // First read: element proxy over the raw object. RAW unwraps to the raw
-  // object (a plain object, which has no RAW of its own).
-  const e1 = d.v[0];
-  assert.strictEqual(e1[RAW], raw0, "element proxy unwraps to its raw object");
-  assert.strictEqual(e1[RAW][RAW], undefined, "the unwrapped raw object is not itself a proxy");
+  assert.strictEqual(d.v[0], raw0, "reads return the raw element, not a proxy");
 
-  // Simulate several swap cycles: slice (holds element proxies), reorder,
-  // reassign the whole value back through .v.
+  // Simulate several swap cycles: slice, reorder, reassign the whole value.
   for (let cycle = 0; cycle < 5; cycle++) {
     const r = d.v.slice();
     const t = r[0];
     r[0] = r[2];
     r[2] = t;
-    d.v = r; // store an array whose elements are proxies
+    d.v = r;
   }
 
-  // After 5 cycles the element for raw0 must still unwrap to raw0 in ONE step —
-  // no accumulated proxy layers.
-  const eAfter = d.v.slice().find((e) => e[RAW] === raw0);
+  // raw0's element is the SAME object no matter how many reorder cycles ran.
+  const eAfter = d.v.find((e) => e === raw0);
   assert.ok(eAfter, "raw0's element survives the reorder cycles");
-  assert.strictEqual(eAfter[RAW], raw0, "still unwraps to the same raw object in one step");
-  assert.strictEqual(eAfter[RAW][RAW], undefined, "unwrapped value is the raw object, not a stacked proxy");
-  // Element proxy identity is stable (cached), so reads are cheap and consistent.
-  assert.strictEqual(d.v.find((e) => e[RAW] === raw0), eAfter, "element proxy identity is stable");
+  assert.strictEqual(eAfter, raw0, "still the same raw object — no wrapper layers");
 });
 
-// A field write through a stored element proxy still marks the box (fine mode),
-// proving idempotent unwrapping did not break write attribution.
-await test("deepBox: field write through a re-stored element proxy still triggers reactivity", async () => {
+// A field write on a stored element, followed by touchElem, still marks the box
+// (fine mode): element attribution now comes from the explicit call, not a trap.
+await test("deepBox: element-field write + touchElem still triggers reactivity in fine mode", async () => {
   const c = createContext(null);
   const d = deepBox(c, 0, [{ id: 1, label: "a" }, { id: 2, label: "b" }]);
   d.observeElems();
   let runs = 0;
   bind(c, [0], () => { void d.v.length; runs++; });
-  // A read-store cycle (like a swap) then a nested field write on a stored elem.
   const r = d.v.slice();
-  d.v = r;
+  d.v = r; // a read-store cycle (like a swap)
   await tick();
   const before = runs;
-  d.v[0].label = "changed"; // nested write through the (re-stored) element proxy
+  d.v[0].label = "changed";
+  d.touchElem(d.v[0]); // element-field mutation of a direct element
   await tick();
-  assert.ok(runs > before, "nested field write on a re-stored element still flushes dependents");
+  assert.ok(runs > before, "element-field write + touchElem flushes dependents");
+  assert.ok(d._elems.has(d.v[0]), "the touched element is recorded for fine patching");
 });
 
 console.log("boxes.deep.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/boxes.test.mjs
+++ b/packages/lunas/test/boxes.test.mjs
@@ -47,6 +47,7 @@ await test("deepBox: push triggers", async () => {
   });
   assert.strictEqual(len, 2);
   d.v.push(3);
+  d.touch(); // compiler-injected invalidation after a structural mutation
   await tick();
   assert.strictEqual(len, 3);
   assert.deepStrictEqual(Array.from(d.v), [1, 2, 3]);
@@ -60,11 +61,12 @@ await test("deepBox: splice triggers", async () => {
     snapshot = Array.from(d.v);
   });
   d.v.splice(1, 2);
+  d.touch();
   await tick();
   assert.deepStrictEqual(snapshot, [1, 4]);
 });
 
-await test("deepBox: nested object set triggers", async () => {
+await test("deepBox: nested object set triggers (via injected touch)", async () => {
   const c = createContext(null);
   const d = deepBox(c, 0, { user: { name: "a" }, tags: ["x"] });
   let name = null;
@@ -72,7 +74,8 @@ await test("deepBox: nested object set triggers", async () => {
     name = d.v.user.name;
   });
   assert.strictEqual(name, "a");
-  d.v.user.name = "b"; // nested set through lazy proxy
+  d.v.user.name = "b"; // nested field write on the raw value
+  d.touch(); // compiler injects this after the mutation
   await tick();
   assert.strictEqual(name, "b");
   let tagCount = 0;
@@ -80,6 +83,7 @@ await test("deepBox: nested object set triggers", async () => {
     tagCount = d.v.tags.length;
   });
   d.v.tags.push("y"); // nested array mutation
+  d.touch();
   await tick();
   assert.strictEqual(tagCount, 2);
 });
@@ -92,17 +96,20 @@ await test("deepBox: delete triggers; whole-value replace triggers", async () =>
     keys = Object.keys(d.v).join(",");
   });
   delete d.v.b;
+  d.touch();
   await tick();
   assert.strictEqual(keys, "a");
-  d.v = { z: 9 };
+  d.v = { z: 9 }; // whole-value reassign: the setter marks, no touch needed
   await tick();
   assert.strictEqual(keys, "z");
 });
 
-await test("deepBox: proxy identity is stable across reads", () => {
+await test("deepBox: nested value identity is the raw object, stable across reads", () => {
   const c = createContext(null);
-  const d = deepBox(c, 0, { user: {} });
-  assert.strictEqual(d.v.user, d.v.user, "cached nested wrapper");
+  const inner = {};
+  const d = deepBox(c, 0, { user: inner });
+  assert.strictEqual(d.v.user, d.v.user, "raw value, no per-read wrapper");
+  assert.strictEqual(d.v.user, inner, "reads return the raw object, not a proxy");
 });
 
 await test("shared: two components both flushed", async () => {

--- a/packages/lunas/test/core.edge.test.mjs
+++ b/packages/lunas/test/core.edge.test.mjs
@@ -330,4 +330,48 @@ await test("dropScope on a scope whose child was already dropped independently",
   assert.strictEqual(parent.children.length, 0);
 });
 
+await test("runaway update loop is bounded, not hung (self-triggering effect)", async () => {
+  // An effect that reads a dep AND re-marks it every pass (e.g. a proxy-free
+  // deep mutation whose touch() is unconditional) would schedule microtask
+  // flushes forever. The flush depth guard must abort it after a bounded number
+  // of passes instead of hanging.
+  const c = createContext(null);
+  let runs = 0;
+  const warns = [];
+  const origWarn = console.warn;
+  console.warn = (m) => warns.push(m);
+  try {
+    bind(c, [0], () => {
+      runs++;
+      markVar(c, 0); // re-trigger self every pass (unconditional)
+    });
+    markVar(c, 0); // external trigger after deps are wired
+    // Drain microtasks; if unbounded this never settles.
+    let ticks = 0;
+    while (c.pending && ticks < 5000) {
+      ticks++;
+      await Promise.resolve();
+    }
+    assert.strictEqual(c.pending, false, "loop settled (guard fired), did not hang");
+    assert.ok(runs <= 205, "bounded number of passes, not unbounded: " + runs);
+    assert.ok(
+      warns.some((m) => /update loop aborted/.test(m)),
+      "a dev warning was emitted"
+    );
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+await test("depth guard resets between independent bursts (no false abort)", async () => {
+  const c = createContext(null);
+  let runs = 0;
+  bind(c, [0], () => runs++);
+  for (let i = 0; i < 150; i++) {
+    markVar(c, 0);
+    await new Promise((r) => setTimeout(r, 0)); // each burst settles on its own
+  }
+  assert.strictEqual(runs, 151, "each independent write flushes once; guard never trips");
+});
+
 console.log("core.edge.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/core.edge.test.mjs
+++ b/packages/lunas/test/core.edge.test.mjs
@@ -374,4 +374,60 @@ await test("depth guard resets between independent bursts (no false abort)", asy
   assert.strictEqual(runs, 151, "each independent write flushes once; guard never trips");
 });
 
+await test("aborting a runaway loop does NOT wedge an innocent sibling on another dep", async () => {
+  // The abort must reset queued records' q flags, or an effect that merely shares
+  // the flush with the loop would be skipped forever after the abort.
+  const c = createContext(null);
+  let sib = 0;
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    bind(c, [1], () => sib++); // innocent, its own dep
+    bind(c, [0], () => markVar(c, 0)); // self-looper on dep 0
+    markVar(c, 0); // start the loop
+    let t = 0;
+    while (c.pending && t < 5000) {
+      t++;
+      await Promise.resolve();
+    }
+    const sibBefore = sib; // 1 (the registration run)
+    markVar(c, 1); // change the innocent dep AFTER the abort
+    await new Promise((r) => setTimeout(r, 0));
+    assert.strictEqual(sib, sibBefore + 1, "innocent sibling still flushes after the abort");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+await test("guard counts per effect: a long chain of DISTINCT effects is not aborted", async () => {
+  // 150 distinct effects, each triggering the next once — a legitimate cascade
+  // that must fully propagate (per-effect counting, not per-pass).
+  const c = createContext(null);
+  const boxes = new Array(152).fill(0);
+  const origWarn = console.warn;
+  let warned = false;
+  console.warn = () => (warned = true);
+  try {
+    for (let k = 0; k < 151; k++) {
+      bind(c, [k], () => {
+        if (boxes[k] && !boxes[k + 1]) {
+          boxes[k + 1] = 1;
+          markVar(c, k + 1);
+        }
+      });
+    }
+    boxes[0] = 1;
+    markVar(c, 0);
+    let t = 0;
+    while (c.pending && t < 10000) {
+      t++;
+      await Promise.resolve();
+    }
+    assert.strictEqual(boxes.filter(Boolean).length, 152, "the whole 151-deep chain propagated");
+    assert.strictEqual(warned, false, "no false runaway-loop abort for a distinct-effect chain");
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
 console.log("core.edge.test.mjs: all " + passed + " tests passed");

--- a/packages/lunas/test/store.edge.test.mjs
+++ b/packages/lunas/test/store.edge.test.mjs
@@ -189,6 +189,7 @@ test("derivedStore field passed into createStore is not double-wrapped (isField 
   // plain field wrapping the derived object.
   assert.strictEqual(app.get("total"), 3);
   cart.get("items").push({ price: 7 });
+  cart.touch("items"); // deep mutation of the upstream field -> derived recomputes
   assert.strictEqual(app.get("total"), 10, "derived passthrough recomputes live");
 });
 
@@ -221,6 +222,7 @@ test("dropScope detaches a component from a derivedStore-backed field too", asyn
 
   dropScope(c, scope);
   cart.get("items").push(3);
+  cart.touch("items"); // deep mutation of the upstream field -> derived recomputes
   await tick();
   assert.strictEqual(seen, 2, "detached component does not observe the derived update");
   assert.strictEqual(app.get("count"), 3, "the derived value itself still updates");
@@ -228,19 +230,28 @@ test("dropScope detaches a component from a derivedStore-backed field too", asyn
 
 // -- deep mutation isolation between fields -----------------------------------
 
-test("deep mutation on one array field does not notify a sibling field's subscribers", () => {
+test("deep mutation + touch() on one array field does not notify a sibling field's subscribers", () => {
   const store = createStore({ list: [1], other: "x" });
+  const seenList = [];
   const seenOther = [];
+  store.subscribe("list", (v) => seenList.push(v));
   store.subscribe("other", (v) => seenOther.push(v));
+  // New contract: the deep mutation is inert on its own; touch(key) is what
+  // notifies, and it only notifies the field that was touched.
   store.get("list").push(2);
+  store.touch("list");
+  assert.deepStrictEqual(seenList, [[1, 2]], "the touched field's own subscribers fire");
   assert.deepStrictEqual(seenOther, [], "unrelated field's subscribers silent");
 });
 
-test("replacing a store field's whole value with a new object gets its own fresh proxy identity", () => {
+test("replacing a store field's whole value returns a new raw object (stable raw identity)", () => {
   const store = createStore({ obj: { a: 1 } });
   const first = store.get("obj");
+  // get() now returns the RAW value, so identity is stable across reads (no
+  // per-read proxy wrapping) rather than a fresh proxy each time.
+  assert.strictEqual(store.get("obj"), first, "repeated reads return the same raw object");
   store.set("obj", { a: 2 });
   const second = store.get("obj");
-  assert.notStrictEqual(first, second);
+  assert.notStrictEqual(first, second, "a whole-value write swaps in a different raw object");
   assert.strictEqual(second.a, 2);
 });

--- a/packages/lunas/test/store.test.mjs
+++ b/packages/lunas/test/store.test.mjs
@@ -114,7 +114,7 @@ await test("batching: multiple writes to the same field -> one flush", async () 
   assert.strictEqual(store.get("n"), 3);
 });
 
-await test("deep mutation on a store array triggers dependents", async () => {
+await test("deep mutation on a store array + touch() notifies dependents", async () => {
   const store = createStore({ items: [1, 2] });
   const c = createContext(null);
   useStore(c, 0, store, "items");
@@ -123,13 +123,16 @@ await test("deep mutation on a store array triggers dependents", async () => {
     len = store.get("items").length;
   });
   assert.strictEqual(len, 2);
+  // New contract: get() returns the raw array (no auto-notify proxy); the
+  // compiler injects store.touch(key) right after the mutating statement.
   store.get("items").push(3);
+  store.touch("items");
   await tick();
   assert.strictEqual(len, 3);
   assert.deepStrictEqual(Array.from(store.get("items")), [1, 2, 3]);
 });
 
-await test("deep mutation on a nested store object triggers dependents", async () => {
+await test("deep mutation on a nested store object + touch() notifies dependents", async () => {
   const store = createStore({ user: { name: "a", tags: ["x"] } });
   const c = createContext(null);
   useStore(c, 0, store, "user");
@@ -137,7 +140,9 @@ await test("deep mutation on a nested store object triggers dependents", async (
   bind(c, [0], () => {
     name = store.get("user").name;
   });
+  // New contract: a nested field write is followed by store.touch(key).
   store.get("user").name = "b";
+  store.touch("user");
   await tick();
   assert.strictEqual(name, "b");
 
@@ -146,6 +151,7 @@ await test("deep mutation on a nested store object triggers dependents", async (
     tagCount = store.get("user").tags.length;
   });
   store.get("user").tags.push("y");
+  store.touch("user");
   await tick();
   assert.strictEqual(tagCount, 2);
 });
@@ -243,6 +249,7 @@ await test("derivedStore: adopted by a component like a plain field", async () =
   assert.strictEqual(seen, 3);
 
   cart.get("items").push({ price: 5 });
+  cart.touch("items"); // deep mutation of the upstream field -> derived recomputes
   await tick();
   assert.strictEqual(seen, 8);
 });

--- a/packages/lunas/types/boxes.d.ts
+++ b/packages/lunas/types/boxes.d.ts
@@ -9,25 +9,37 @@ export interface Box<T> {
 }
 
 /**
+ * A deeply-mutated reactive cell. `.v` returns the RAW value (no Proxy); a deep
+ * mutation is made reactive by an explicit invalidation the compiler injects
+ * after the mutating statement.
+ */
+export interface DeepBox<T> {
+  v: T;
+  /** Signal a structural deep mutation (`arr.push`, `arr[i]=x`, `obj.k=v`, …). */
+  touch(): T;
+  /** Signal an element-field mutation of a direct array element `el`. */
+  touchElem<E>(el: E): E;
+}
+
+/**
  * box(c, i, v) — reassign-only variable at reactive index i.
  * Lightest path: plain getter/setter, no Proxy. Same-value writes are no-ops.
  */
 export function box<T>(c: Context, i: number, v: T): Box<T>;
 
 /**
- * deepBox(c, i, v) — deeply-mutated variable (arr.push, obj.k = …).
- * Reads through `.v` return a Proxy that marks the variable dirty on any
- * nested set/delete. Nested objects are wrapped lazily on property access;
- * wrappers are cached per underlying object so identity is stable.
+ * deepBox(c, i, v) — deeply-mutated variable (arr.push, obj.k = …, nested field
+ * writes, Map/Set mutations).
  *
- * Map/Set (and WeakMap/WeakSet) are collection-aware: accessors and methods
- * run against the real collection so native internal slots accept the
- * receiver, and mutating operations (Map `set`/`delete`/`clear`, Set
- * `add`/`delete`/`clear`) mark the variable dirty. Values stored inside a
- * collection are NOT deeply wrapped — reassign an entry to make a nested
- * change reactive. WeakMap/WeakSet do not throw but are not deeply reactive.
+ * Proxy-free (Svelte-family model): `.v` returns the RAW value, so reads are as
+ * cheap as a plain `box`. A deep mutation is made reactive by an explicit
+ * invalidation the compiler injects right after the mutating statement:
+ * `box.touch()` for a structural change (`push`/`splice`/`arr[i]=x`/`obj.k=v`/
+ * `delete`/`length=`/Map-Set `set`/`add`/`delete`/`clear`) and
+ * `box.touchElem(el)` for an element-field write (`arr[i].label = x`). Both mark
+ * the variable dirty; `markVar` defers the flush to a microtask.
  */
-export function deepBox<T>(c: Context, i: number, v: T): Box<T>;
+export function deepBox<T>(c: Context, i: number, v: T): DeepBox<T>;
 
 /**
  * prop(c, name, i, raw, def, deep) — adopt an `@input` prop as a reactive

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -33,7 +33,7 @@ tree:
         - { id: bench-construction, title: "innerHTML vs cloneNode (4 machines)", status: done }
         - { id: bench-anchors, title: "Comment fast-path; runtime text anchors", status: done }
         - { id: bench-refs, title: "Positional nav vs getElementById", status: done }
-        - { id: reactivity-design, title: "Adjacency dispatch; no BigInt; Proxy floor", status: done }
+        - { id: reactivity-design, title: "Adjacency dispatch; no BigInt; proxy-free deep mutation", status: done }
     - id: codegen
       title: Code generator (ResolvedComponent → JS)
       status: done
@@ -52,7 +52,7 @@ tree:
         - { id: cg-inputs, title: "@input props handling", status: done }
         - { id: cg-e2e, title: "End-to-end snapshot + browser smoke tests", status: done }
     - id: runtime
-      title: Runtime (ES2015 + Proxy floor)
+      title: Runtime (ES2015, proxy-free)
       status: done
       children:
         - { id: rt-core, title: "Adjacency dispatch core (bind, markVar, flush)", status: done }


### PR DESCRIPTION
## Hypothesis & verification

The suspicion was that v2 loses to Svelte on `js-framework-benchmark`-style workloads because of the **Proxy-based deep reactivity** (`deepBox`). I verified this before changing anything.

**Isolated microbenchmark** (real `deepBox`, process-isolated, `--expose-gc`, N=10k rows):

| operation | Proxy | proxy-free equivalent | slowdown |
|---|---|---|---|
| create (assign array) | 1.5ms | 0.2ms | — (one wrap) |
| readAll (reconciler path) | ~10ms | ~10ms | **≈ equal** |
| **update every 10th field** | **106ms** | **10.6ms** | **≈ 10×** |
| swap | 2.6ms | 0.5ms | ~5× |

The cost is entirely on the **deep-mutation write path** (`rows[i].label = x`, `arr.push`, …). Reads are unaffected because the reconciler hot path already reads the raw array via `_raw()`. Every trap dispatch + WeakMap owner-attribution is pure overhead that Svelte never pays — it compiles a mutation to a direct write + explicit invalidation. **Hypothesis confirmed.**

## The change — remove the Proxy, inject the invalidation

Adopt the Svelte-family model: `deepBox.v` returns the **raw** value, and the compiler injects an explicit invalidation right after each deep-mutation statement.

```
arr.push(x)        ->  (arr.touch(), arr.v.push(x))
obj.k = v          ->  (obj.touch(), obj.v.k = v)
rows[i].label = x  ->  (rows.touchElem(rows.v[i]), rows.v[i].label = x)
```

- **Runtime** (`packages/lunas/src/boxes.mjs`, `store.mjs`): `deepBox`/store fields are now proxy-free — `.v` is raw, plus `touch()` (structural) and `touchElem(el)` (element-field). No `Proxy`, no `makeWrap`, no `RAW`, no collection handler. The reactive core is now plain ES2015, floor **below** Vue 3 / Svelte 5 / Solid (which all rely on `Proxy`).
- **`forBlock` is unchanged** — it already drives the fine-grained `:for` item-field optimization off `observeElems/_raw/_struct/_elems/_clear`, which `touchElem` now feeds instead of a trap. Fine-grained item updates are preserved.
- **Compiler** (`crates/lunas_script`, `crates/lunas_compiler`): new `lunas_script::deep_mutation_sites` walks the swc AST to find each mutation site and classify it structural vs element-field (the latter only for the side-effect-free `X[idx].field` shape; structural `touch()` is the always-correct fallback). `emit.rs` wraps script-body, inline `@event`, and two-way-write mutations accordingly.

## Result — before/after through the real runtime

Same `forBlock` partial-update workload, old Proxy `deepBox` vs new proxy-free, both on the real reconciler (N=5000, 500 field-writes/round):

| operation | old (Proxy) | new (proxy-free) | speedup |
|---|---|---|---|
| partial update | 69–70ms | 35–38ms | **≈ 1.9×** |
| swap | 99–105ms | 89ms | ~1.15× |

The reactivity portion of the hot loop is roughly halved — the exact operations where a Proxy-based Lunas gave up its construction lead to Svelte. In a real browser the DOM-write share is smaller, so the proxy removal is an even larger fraction of the pure-reactivity rows.

## Semantics & compatibility

Identical observable behavior, with one honest change: a deep mutation now notifies **unconditionally** (the compiler can't cheaply prove a write was a no-op), matching Svelte — the old Proxy had an `old === new` guard on nested writes. Whole-value reassign (`box.v = x`) keeps its `===` no-op guard via the setter.

## Tests / quality gate

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`: clean
- `cargo test --workspace`: green (incl. all `codegen_exec` + 1067 runtime-sample cases that **compile and run** the emitted code — end-to-end proof the injected `touch`/`touchElem` drive reactivity)
- `node packages/lunas/test/run-all.mjs`: all 39 files green (box/store/blocks runtime tests migrated to the explicit-touch contract)
- codegen snapshots regenerated and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017aRZtnAYfMu2NCweAEqwL8)_